### PR TITLE
rake tasks do not show loaded files by default, Closes #72

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -110,6 +110,10 @@ This would generate following rake tasks:
     rake test:complex:fast            # Run tests for assertions:assert_block
     rake test:complex:slow            # Run tests for assertions:assert_empty
 
+By default, the rake tasks do not show which test files are being loaded.  If you want to see this output from the rake tasks, set a "show_loaded_files" environment variable at the rake command line:
+
+    $ rake test show_loaded_files=true  # run the tests showing which files were loaded
+
 === IRB with your environment loaded
 Assert provides a rake task for running irb with your test environment loaded.  Create an irb.rb file in your test file directory and have it require 'assert/setup'.  See https://github.com/teaminsight/assert/blob/master/test/irb.rb for an example.  Here's how you could use it:
 

--- a/lib/assert/rake_tasks.rb
+++ b/lib/assert/rake_tasks.rb
@@ -41,7 +41,7 @@ module Assert::RakeTasks
         # create a rake task to run it
         desc scope_tt.description
         task scope_tt.name do
-          RakeFileUtils.verbose(true) { ruby scope_tt.ruby_args }
+          RakeFileUtils.verbose(scope_tt.show_loaded_files?) { ruby scope_tt.ruby_args }
         end
       end
 
@@ -51,7 +51,7 @@ module Assert::RakeTasks
         scope.test_tasks.each do |test_file_tt|
           desc test_file_tt.description
           task test_file_tt.name do
-            RakeFileUtils.verbose(true) { ruby test_file_tt.ruby_args }
+            RakeFileUtils.verbose(test_file_tt.show_loaded_files?) { ruby test_file_tt.ruby_args }
           end
         end
 

--- a/lib/assert/rake_tasks/test_task.rb
+++ b/lib/assert/rake_tasks/test_task.rb
@@ -40,6 +40,10 @@ module Assert::RakeTasks
       ].compact.join(" ")
     end
 
+    def show_loaded_files?
+      ENV["show_loaded_files"] == 'true'
+    end
+
     protected
 
     def rake_loader

--- a/test/rake_tasks/test_task_test.rb
+++ b/test/rake_tasks/test_task_test.rb
@@ -14,7 +14,7 @@ module Assert::RakeTasks
 
     should have_accessors :path, :files
     should have_instance_methods :relative_path, :scope_description, :description, :name
-    should have_instance_methods :file_list, :ruby_args
+    should have_instance_methods :file_list, :ruby_args, :show_loaded_files?
 
     should "default with empty files collection" do
       assert_equal [], subject.files
@@ -50,6 +50,31 @@ module Assert::RakeTasks
       assert_equal "-rrubygems \"#{subject.send(:rake_loader)}\" #{subject.file_list}", subject.ruby_args
     end
 
+  end
+
+  class VerboseTests < TestTaskTests
+    setup do
+      @orig_env_setting = ENV["show_loaded_files"]
+      ENV["show_loaded_files"] = 'false'
+    end
+    teardown do
+      ENV["show_loaded_files"] = @orig_env_setting
+    end
+
+    should "not show loaded files by default" do
+      assert_equal false, subject.show_loaded_files?
+    end
+  end
+
+  class EnvVerboseTests < VerboseTests
+    desc "if the show_loaded_files env setting is true"
+    setup do
+      ENV["show_loaded_files"] = 'true'
+    end
+
+    should "show loaded files" do
+      assert_equal true, subject.show_loaded_files?
+    end
   end
 
 end


### PR DESCRIPTION
changed so that rake tasks do not show loaded files by default, Closes #72
- rake test tasks have a show_loaded_files? method, that is used when building the rake tasks
- set ENV["show_loaded_files"] to 'true' to override the default and show loaded files
- added a blurb to the README
