### PR TITLE
show exception class in result message, closes #64

### DIFF
--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -153,9 +153,19 @@ module Assert::Result
 
   # Error and Skip results are built from exceptions being raised
   class FromException < Base
-    def initialize(test_name, exception)
-      super(test_name, exception.message, exception.backtrace || [])
+
+    def self.exception_result_msg(exception)
+      if [ Assert::Result::TestSkipped ].include?(exception.class)
+        exception.message
+      else
+        "#{exception.message} (#{exception.class.name})"
+      end
     end
+
+    def initialize(test_name, exception)
+      super(test_name, self.class.exception_result_msg(exception), exception.backtrace || [])
+    end
+
   end
 
   # raised by the 'skip' context helper to break test execution

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -185,6 +185,14 @@ module Assert::Result
       assert_equal @exception.backtrace, subject.backtrace
     end
 
+    should "include the exceptiion message in the result message" do
+      assert_includes @exception.message, subject.message
+    end
+
+    should "include the exception class in the result message" do
+      assert_includes @exception.class.name, subject.message
+    end
+
   end
 
   class SkippedRuntimeErrorTest < Assert::Context


### PR DESCRIPTION
- will show for any result generated from an exception
- added on the end enclosed in parenths
- not adding class name for Assert::Result::TestSkipped exceptions to preserve behavior and not be redundant
