### PR TITLE
some cleanups and simplification and dryness added to the result model

### DIFF
--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -91,7 +91,10 @@ module Assert::Result
     def to_sym; nil; end
 
     def to_s
-      [self.test_name, self.message, self.trace].compact.join("\n")
+      [ "#{self.name.upcase}: #{self.test_name}",
+        self.message,
+        self.trace
+      ].compact.join("\n")
     end
 
     def name
@@ -114,40 +117,28 @@ module Assert::Result
 
   class Pass < Base
     def pass?; true; end
-    def to_sym; :passed; end
+    def to_sym; :pass; end
 
     def name
       "Pass"
-    end
-
-    def to_s
-      "PASS: #{super}"
     end
   end
 
   class Fail < Base
     def fail?; true; end
-    def to_sym; :failed; end
+    def to_sym; :fail; end
 
     def name
-      "Failure"
-    end
-
-    def to_s
-      "FAIL: #{super}"
+      "Fail"
     end
   end
 
   class Ignore < Base
     def ignore?; true; end
-    def to_sym; :ignored; end
+    def to_sym; :ignore; end
 
     def name
       "Ignore"
-    end
-
-    def to_s
-      "IGNORE: #{super}"
     end
   end
 
@@ -165,7 +156,6 @@ module Assert::Result
     def initialize(test_name, exception)
       super(test_name, self.class.exception_result_msg(exception), exception.backtrace || [])
     end
-
   end
 
   # raised by the 'skip' context helper to break test execution
@@ -173,28 +163,20 @@ module Assert::Result
 
   class Skip < FromException
     def skip?; true; end
-    def to_sym; :skipped; end
+    def to_sym; :skip; end
 
     def name
       "Skip"
-    end
-
-    def to_s
-      "SKIP: #{super}"
     end
   end
 
   class Error < FromException
 
     def error?; true; end
-    def to_sym; :errored; end
+    def to_sym; :error; end
 
     def name
       "Error"
-    end
-
-    def to_s
-      "ERROR: #{super}"
     end
 
     # override of the base, always show the full unfiltered backtrace for errors

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -98,7 +98,7 @@ module Assert::Result
     end
 
     should "know its to_sym" do
-      assert_equal :passed, subject.to_sym
+      assert_equal :pass, subject.to_sym
     end
 
     should "know its name" do
@@ -128,11 +128,11 @@ module Assert::Result
     end
 
     should "know its to_sym" do
-      assert_equal :failed, subject.to_sym
+      assert_equal :fail, subject.to_sym
     end
 
     should "know its name" do
-      assert_equal "Failure", subject.name
+      assert_equal "Fail", subject.name
     end
 
     should "include FAIL in its to_s" do
@@ -158,7 +158,7 @@ module Assert::Result
     end
 
     should "know its to_sym" do
-      assert_equal :ignored, subject.to_sym
+      assert_equal :ignore, subject.to_sym
     end
 
     should "know its name" do
@@ -221,7 +221,7 @@ module Assert::Result
     end
 
     should "know its to_sym" do
-      assert_equal :skipped, subject.to_sym
+      assert_equal :skip, subject.to_sym
     end
 
     should "know its name" do
@@ -251,7 +251,7 @@ module Assert::Result
     end
 
     should "know its to_sym" do
-      assert_equal :errored, subject.to_sym
+      assert_equal :error, subject.to_sym
     end
 
     should "know its name" do


### PR DESCRIPTION
just removing some duplicate code and making the result names and symbols a little more standard (removing past tense junk).  This will help with some stuff I'm doing in assert-view as well.
