### PR TITLE
Fix for assert failing when the HOME environment variable is not set

### DIFF
--- a/lib/assert/setup/helpers.rb
+++ b/lib/assert/setup/helpers.rb
@@ -34,7 +34,9 @@ module Assert
 
       def require_user_test_helper
         begin
-          require File.expand_path(USER_TEST_HELPER)
+          if ENV['HOME']
+            require File.expand_path(USER_TEST_HELPER)
+          end
         rescue LoadError => err
           # do nothing
         end


### PR DESCRIPTION
@kelredd @tpett This should keep assert from breaking when trying to expand that path. The exception thrown is an `ArgumentError`, which is not very specific, otherwise I would have rescued the exception instead. Because it's a very generic exception, I thought just checking that the ENV['HOME'] is not nil should keep it from failing.
