### PR TITLE
fixed an issue where fail traces were being set incorrectly

### DIFF
--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -165,7 +165,7 @@ module Assert::Result
 
     # override of the base, show the test's context info called_from
     def trace
-      self.test.context_info.called_from
+      self.test.context_info.called_from || super
     end
 
   end

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -5,13 +5,14 @@ module Assert
 
     class ContextInfo
 
-      attr_reader :klass, :called_from, :file
+      attr_reader :called_from, :first_caller, :klass, :file
 
-      def initialize(klass, called_from=nil)
-        @klass = klass
+      def initialize(klass, called_from=nil, first_caller=nil)
+        @first_caller = first_caller
         @called_from = called_from
-        @file = if called_from
-          called_from.gsub(/\:[0-9]+.*$/, '')
+        @klass = klass
+        @file = if (@called_from || @first_caller)
+          (@called_from || @first_caller).gsub(/\:[0-9]+.*$/, '')
         end
       end
 

--- a/test/suite/context_info_test.rb
+++ b/test/suite/context_info_test.rb
@@ -7,18 +7,18 @@ class Assert::Suite::ContextInfo
     setup do
       @caller = caller
       @klass = Assert::Context
-      @info = Assert::Suite::ContextInfo.new(@klass, @caller.first)
+      @info = Assert::Suite::ContextInfo.new(@klass, nil, @caller.first)
     end
     subject { @info }
 
-    should have_readers :klass, :called_from, :file
+    should have_readers :called_from, :first_caller, :klass, :file
 
     should "set its klass on init" do
       assert_equal @klass, subject.klass
     end
 
     should "set its called_from to the first caller on init" do
-      assert_equal @caller.first, subject.called_from
+      assert_equal @caller.first, subject.first_caller
     end
 
     should "set its file from caller info on init" do


### PR DESCRIPTION
- better capturing and tracking called_from overrides and the first caller context info
- fail traces prefer the called from override if it exists, if not, uses the std filtered result backtrace
