### PR TITLE
allow multiple test file suffixes

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -98,7 +98,7 @@ Assert, by default, will halt test execution when a test produces a Fail result.
 
 
 === Rake Tasks
-Assert provides some rake task helpers that will scan your test folder and recursively generate rake tasks for each one of your test folders or files ending in '_test'.  Use this as an alternative to running ruby on each one of your test files individually.
+Assert provides some rake task helpers that will scan your test folder and recursively generate rake tasks for each one of your test folders or files.  Test files must end in either `'_test.rb'` or `'_tests.rb'`.  Use this as an alternative to running ruby on each one of your test files individually.
 
 As an example, say your test folder has a file structure like so:
 

--- a/lib/assert/rake_tasks.rb
+++ b/lib/assert/rake_tasks.rb
@@ -9,8 +9,6 @@ require 'assert/rake_tasks/test_task'
 
 module Assert::RakeTasks
 
-  FILE_SUFFIX = "_test.rb"
-
   # Setup the rake tasks for testing
   # * add 'include Assert::RakeTasks' to your Rakefile
   def self.included(receiver)

--- a/lib/assert/rake_tasks/test_task.rb
+++ b/lib/assert/rake_tasks/test_task.rb
@@ -26,7 +26,10 @@ module Assert::RakeTasks
     end
 
     def name
-      File.basename(@path, Scope.test_file_suffix).to_sym
+      # File.basename(@path, Scope.test_file_suffix).to_sym
+      @name ||= File.basename(@path).tap do |bname|
+        Scope.test_file_suffixes.each { |suffix| bname.gsub(suffix, '') }
+      end.to_sym
     end
 
     def file_list # :nodoc:

--- a/test/rake_tasks/scope_test.rb
+++ b/test/rake_tasks/scope_test.rb
@@ -12,12 +12,12 @@ module Assert::RakeTasks
     end
     subject { @handler }
 
-    should have_class_methods :test_file_suffix
+    should have_class_methods :test_file_suffixes
     should have_instance_methods :namespace, :nested_files, :path_file_list, :to_test_task
     should have_instance_methods :test_tasks, :scopes
 
     should "know its the test file suffix" do
-      assert_equal "_test.rb", subject.class.test_file_suffix
+      assert_equal ['_test.rb', '_tests.rb'], subject.class.test_file_suffixes
     end
 
     should "know its namespace" do

--- a/test/test/running_tests.rb
+++ b/test/test/running_tests.rb
@@ -2,12 +2,12 @@ require 'assert'
 
 class Assert::Test
 
-  class RunningTest < Assert::Context
+  class RunningTests < Assert::Context
     desc "Assert tests that are run"
     subject{ @test }
   end
 
-  class NothingTest < RunningTest
+  class NothingTests < RunningTests
     desc "and does nothing"
     setup do
       @test = Factory.test
@@ -22,7 +22,7 @@ class Assert::Test
 
 
 
-  class PassTest < RunningTest
+  class PassTests < RunningTests
     desc "and passes a single assertion"
     setup do
       @test = Factory.test{ assert(1 == 1) }
@@ -40,7 +40,7 @@ class Assert::Test
 
 
 
-  class FailTest < RunningTest
+  class FailTests < RunningTests
     desc "and fails a single assertion"
     setup do
       @test = Factory.test{ assert(1 == 0) }
@@ -58,7 +58,7 @@ class Assert::Test
 
 
 
-  class SkipTest < RunningTest
+  class SkipTests < RunningTests
     desc "and skips"
     setup do
       @test = Factory.test{ skip }
@@ -76,7 +76,7 @@ class Assert::Test
 
 
 
-  class ErrorTest < RunningTest
+  class ErrorTests < RunningTests
     desc "and errors"
     setup do
       @test = Factory.test{ raise("WHAT") }
@@ -94,7 +94,7 @@ class Assert::Test
 
 
 
-  class MixedTest < RunningTest
+  class MixedTests < RunningTests
     desc "and has 1 pass and 1 fail assertion"
     setup do
       @test = Factory.test do
@@ -118,7 +118,7 @@ class Assert::Test
 
 
 
-  class MixedSkipTest < RunningTest
+  class MixedSkipTests < RunningTests
     desc "and has 1 pass and 1 fail assertion with a skip call in between"
     setup do
       @test = Factory.test do
@@ -149,7 +149,7 @@ class Assert::Test
 
 
 
-  class MixedErrorTest < RunningTest
+  class MixedErrorTests < RunningTests
     desc "and has 1 pass and 1 fail assertion with an exception raised in between"
     setup do
       @test = Factory.test do
@@ -180,7 +180,7 @@ class Assert::Test
 
 
 
-  class MixedPassTest < RunningTest
+  class MixedPassTests < RunningTests
     desc "and has 1 pass and 1 fail assertion with a pass call in between"
     setup do
       @test = Factory.test do
@@ -208,7 +208,7 @@ class Assert::Test
 
 
 
-  class MixedFailTest < RunningTest
+  class MixedFailTests < RunningTests
     desc "and has 1 pass and 1 fail assertion with a fail call in between"
     setup do
       @test = Factory.test do
@@ -236,7 +236,7 @@ class Assert::Test
 
 
 
-  class MixedFlunkTest < RunningTest
+  class MixedFlunkTests < RunningTests
     desc "and has 1 pass and 1 fail assertion with a flunk call in between"
     setup do
       @test = Factory.test do
@@ -264,7 +264,7 @@ class Assert::Test
 
 
 
-  class WithSetupTest < RunningTest
+  class WithSetupTests < RunningTests
     desc "a Test that runs and has assertions that depend on setups"
     setup do
       assert_style_msg = @asm = "set by assert style setup"
@@ -309,7 +309,7 @@ class Assert::Test
 
 
 
-  class WithTeardownTest < RunningTest
+  class WithTeardownTests < RunningTests
     desc "a Test that runs and has assertions with teardowns"
     setup do
       assert_style_msg = @asm = "set by assert style teardown"


### PR DESCRIPTION
This sets up the rake file generation and scoping tasks to recognize
test files with one of many suffixes.  I added the '_tests.rb' suffix
and renamed a test file for a proof of concept.

@jcredding, please look over this one and make sure there aren't
any other problems this introduces.  I think this change only affects
the rake file/tasks stuff.  Thanks man.
