### PR TITLE
default view from assert-view

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,17 +2,13 @@ PATH
   remote: .
   specs:
     assert (0.7.3)
-      assert-view (~> 0.5)
+      ansi (~> 1.3)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    ansi (1.4.1)
-    assert-view (0.5.0)
-      ansi (~> 1.3)
-      undies (~> 2.0)
+    ansi (1.4.2)
     rake (0.9.2)
-    undies (2.0.0)
 
 PLATFORMS
   ruby

--- a/README.rdoc
+++ b/README.rdoc
@@ -84,7 +84,7 @@ Assert uses a Runner object to run tests.  Any runner object should take the tes
 Assert provides a default Runner object for running test suites (https://github.com/teaminsight/assert/blob/master/lib/assert/runner.rb).  The default provides methods for running the tests, randomizing test order, and benchmarking test run time.  Feel free to extend this runner as you see fit.
 
 === Test Order
-The default Runner object runs tests in random order and the default Terminal view will display the seed value.  If you want to run tests in a consistant order, set a 'runner_seed' environment variable.  Here's an example running tests with rake:
+The default Runner object runs tests in random order and the `DefaultView` view will display the seed value.  If you want to run tests in a consistant order, set a 'runner_seed' environment variable.  Here's an example running tests with rake:
 
     $ rake test   # run tests in random order
     $ rake test runner_seed=1234  # run tests seeding with '1234'
@@ -139,13 +139,7 @@ Assert provides a rake task for running irb with your test environment loaded.  
 
 These are all tools that use and extend Assert.  If you write your own, share it with us and we will post it here.
 
-=== assert-view
-Assert::View (https://github.com/teaminsight/assert-view) is a collection of views that can be used with Assert.  Specify what view you want to use in your ~/.assert/options.rb settings file, ie:
-
-    # default is Assert::View::DefaultView on $stdout
-    Assert.options.view Assert::View::SuperCoolView.new($stdout)
-
-
+TODO: add in references to assert related tools.
 
 == Contributing
 
@@ -153,13 +147,13 @@ The source code is hosted on Github.  It's clean, modular, and easy to understan
 
 One note, however: please respect that Assert itself is intended to be the flexible, base-level type logic that should change little if at all.  Pull requests for niche functionality or personal testing philosphy stuff will likely not be accepted.
 
-If you wish to extend Assert for your niche purpose/desire/philosophy, please do so in it's own gem (named 'assert-<whatever>') that uses Assert as a dependency.  When you do, tell us about it and we'll add to the Family of tools.
+If you wish to extend Assert for your niche purpose/desire/philosophy, please do so in it's own gem (preferrably named 'assert-<whatever>') that uses Assert as a dependency.  When you do, tell us about it and we'll add to the Family of tools.
 
 
 
 == License
 
-Copyright (c) 2011 Kelly Redding, Collin Redding, and Team Insight
+Copyright (c) 2011-Present Kelly Redding, Collin Redding, and Team Insight
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/assert.gemspec
+++ b/assert.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency("bundler", ["~> 1.0"])
-  s.add_dependency("assert-view", ["~> 0.5"])
+  s.add_dependency("ansi", ["~> 1.3"])
+
 end

--- a/lib/assert/view/base.rb
+++ b/lib/assert/view/base.rb
@@ -1,0 +1,54 @@
+require 'assert/result'
+require 'assert/options'
+
+require 'assert/view/renderer'
+require 'assert/view/common'
+
+module Assert::View
+
+  class Base
+
+    include Assert::Options
+    options do
+      default_pass_abbrev   '.'
+      default_fail_abbrev   'F'
+      default_ignore_abbrev 'I'
+      default_skip_abbrev   'S'
+      default_error_abbrev  'E'
+    end
+
+    # the Renderer defines the hooks and callbacks needed for the runner to
+    # work with the view.  It provides:
+    # * 'render': called by the runner to render the view
+    # * 'self.helper': used to provide helper mixins to the renderer template
+    # * 'self.template': used to define the template proc
+    include Renderer
+
+    # include a bunch of common view utility methods
+    include Common
+
+    attr_accessor :suite, :output_io, :runtime_result_callback
+
+    def initialize(output_io, suite=Assert.suite)
+      self.output_io = output_io
+      self.suite     = suite
+    end
+
+    def view
+      self
+    end
+
+    # should be called by the view template to start running the tests
+    def run_tests(runner, &result_callback)
+      self.runtime_result_callback = result_callback
+      runner.call if runner
+    end
+
+    # callback used by the runner to notify the view of any new results
+    def handle_runtime_result(result)
+      self.runtime_result_callback.call(result) if self.runtime_result_callback
+    end
+
+  end
+
+end

--- a/lib/assert/view/common.rb
+++ b/lib/assert/view/common.rb
@@ -1,0 +1,139 @@
+module Assert::View
+
+  class ResultDetails
+
+    attr_reader :result, :test_index, :test, :output
+
+    def initialize(result, test, test_index)
+      @result = result
+      @test = test
+      @test_index = test_index
+      @output = test.output
+    end
+  end
+
+  module Common
+
+    # get the formatted suite run time
+    def run_time(format='%.6f')
+      format % self.suite.run_time
+    end
+
+    def runner_seed
+      self.suite.runner_seed
+    end
+
+    def count(type)
+      self.suite.count(type)
+    end
+
+    def tests?
+      self.count(:tests) > 0
+    end
+
+    def all_pass?
+      self.count(:pass) == self.count(:results)
+    end
+
+    # get a uniq list of contexts for the test suite
+    def suite_contexts
+      @suite_contexts ||= self.suite.tests.inject([]) do |contexts, test|
+        contexts << test.context_info.klass
+      end.uniq
+    end
+
+    def ordered_suite_contexts
+      self.suite_contexts.sort{|a,b| a.to_s <=> b.to_s}
+    end
+
+    # get a uniq list of files containing contexts for the test suite
+    def suite_files
+      @suite_files ||= self.suite.tests.inject([]) do |files, test|
+        files << test.context_info.file
+      end.uniq
+    end
+
+    def ordered_suite_files
+      self.suite_files.sort{|a,b| a.to_s <=> b.to_s}
+    end
+
+    # get all the result details for a set of tests
+    def result_details_for(tests, result_order=:normal)
+      test_index = 0
+      tests.collect do |test|
+        test_index += 1
+
+        details = test.results.
+          select { |result| self.show_result_details?(result) }.
+          collect { |result| ResultDetails.new(result, test, test_index) }
+
+        details.reverse! if result_order == :reversed
+
+        details
+      end.compact.flatten
+    end
+
+    # only show result details for failed or errored results
+    # show result details if a skip or passed result was issues w/ a message
+    def show_result_details?(result)
+      ([:fail, :error].include?(result.to_sym)) ||
+      ([:skip, :ignore].include?(result.to_sym) && result.message)
+    end
+
+    # return a list of result symbols that have actually occurred
+    def ocurring_result_types
+      @result_types ||= [
+        :pass, :fail, :ignore, :skip, :error
+      ].select { |result_sym| self.count(result_sym) > 0 }
+    end
+
+    # print a result summary message for a given result type
+    def result_summary_msg(result_type)
+      if result_type == :pass && self.all_pass?
+        self.all_pass_result_summary_msg
+      else
+        "#{self.count(result_type)} #{result_type.to_s}"
+      end
+    end
+
+    # generate an appropriate result summary msg for all tests passing
+    def all_pass_result_summary_msg
+      if self.count(:results) < 1
+        "uhh..."
+      elsif self.count(:results) == 1
+        "pass"
+      else
+        "all pass"
+      end
+    end
+
+    # generate a sentence fragment describing the breakdown of test results
+    # if a block is given, yield each msg in the breakdown for custom formatting
+    def results_summary_sentence
+      summaries = self.ocurring_result_types.collect do |result_sym|
+        summary_msg = self.result_summary_msg(result_sym)
+        block_given? ? yield(summary_msg, result_sym) : summary_msg
+      end
+      self.to_sentence(summaries)
+    end
+
+    def test_count_statement
+      "#{self.count(:tests)} test#{'s' if self.count(:tests) != 1}"
+    end
+
+    def result_count_statement
+      "#{self.count(:results)} result#{'s' if self.count(:results) != 1}"
+    end
+
+    # generate a comma-seperated sentence fragment given a list of things
+    def to_sentence(things)
+      if things.size <= 2
+        things.join(things.size == 2 ? ' and ' : '')
+      else
+        [things[0..-2].join(", "), things.last].join(", and ")
+      end
+    end
+
+  end
+
+end

--- a/lib/assert/view/default_view.rb
+++ b/lib/assert/view/default_view.rb
@@ -1,0 +1,65 @@
+require 'assert/view/base'
+require 'assert/view/helpers/ansi_styles'
+require 'assert/view/helpers/capture_output'
+
+module Assert::View
+
+  # This is the default view used by assert.  It renders ansi test output
+  # designed for terminal viewing.
+
+  class DefaultView < Base
+    helper Helpers::CaptureOutput
+    helper Helpers::AnsiStyles
+
+    options do
+      styled         true
+      pass_styles    :green
+      fail_styles    :red, :bold
+      error_styles   :yellow, :bold
+      skip_styles    :cyan
+      ignore_styles  :magenta
+    end
+
+    template do
+      _ "Loaded suite (#{view.test_count_statement})"
+
+      if view.tests?
+        _ "Running tests in random order, seeded with \"#{view.runner_seed}\""
+
+        view.run_tests(runner) do |result|
+          result_abbrev = view.options.send("#{result.to_sym}_abbrev")
+          styled_abbrev = ansi_styled_msg(result_abbrev, result_ansi_styles(result))
+
+          # list out an abbrev for each test result as it is run
+          _ styled_abbrev, false
+        end
+        _ "\n", false  # add a newline after list of test result abbrevs
+        _
+
+        # output detailed results for the tests in reverse test/result order
+        tests = view.suite.ordered_tests.reverse
+        view.result_details_for(tests, :reversed).each do |details|
+          # output the styled result details
+          result = details.result
+          _ ansi_styled_msg(result.to_s, result_ansi_styles(result))
+
+          # output any captured output
+          output = details.output
+          _ captured_output(output) if output && !output.empty?
+          _
+        end
+      end
+
+      styled_results_sentence = view.results_summary_sentence do |summary, sym|
+        # style the summaries of each result set
+        ansi_styled_msg(summary, result_ansi_styles(sym))
+      end
+
+      _ "#{view.result_count_statement}: #{styled_results_sentence}"
+      _
+      _ "(#{view.run_time} seconds)"
+    end
+
+  end
+
+end

--- a/lib/assert/view/helpers/ansi_styles.rb
+++ b/lib/assert/view/helpers/ansi_styles.rb
@@ -1,0 +1,25 @@
+require 'ansi/code'
+
+module Assert::View::Helpers
+
+  module AnsiStyles
+
+    def result_ansi_styles(result)
+      view.options.styled ? view.options.send("#{result.to_sym}_styles") : []
+    end
+
+    def ansi_styled_msg(msg, styles=[])
+      if !(style = ansi_style(*styles)).empty?
+        style + msg + ANSI.send(:reset)
+      else
+        msg
+      end
+    end
+
+    def ansi_style(*ansi_codes)
+      ansi_codes.collect{|code| ANSI.send(code) rescue nil}.compact.join('')
+    end
+
+  end
+
+end

--- a/lib/assert/view/helpers/capture_output.rb
+++ b/lib/assert/view/helpers/capture_output.rb
@@ -1,0 +1,23 @@
+module Assert::View::Helpers
+
+  module CaptureOutput
+
+    def captured_output(output)
+      if !output.empty?
+        # TODO: move to the base view
+        [ captured_output_start_msg,
+          output + captured_output_end_msg
+        ].join("\n")
+      end
+    end
+
+    def captured_output_start_msg
+      "--- stdout ---"
+    end
+    def captured_output_end_msg
+      "--------------"
+    end
+
+  end
+
+end

--- a/lib/assert/view/renderer.rb
+++ b/lib/assert/view/renderer.rb
@@ -1,0 +1,70 @@
+module Assert::View
+  module Renderer
+
+    # this module is mixed in to the Assert::View::Base class
+
+    def self.included(receiver)
+      receiver.send(:extend, ClassMethods)
+    end
+
+    module ClassMethods
+
+      # make any helper methods available to the template
+      def helper(helper_klass)
+        TemplatedView.send(:include, helper_klass)
+      end
+
+      # set the view's template by passing a block, get by calling w/ no args
+      def template(&block)
+        if block
+          @template = block
+        else
+          @template
+        end
+      end
+
+    end
+
+    class TemplatedView
+
+      # this class is used as the scope to instance_eval the view's template
+      # proc in which write the output
+
+      def initialize(*args)
+        # get the io to write to
+        @io = args.pop
+
+        # apply any given data to templated view scope
+        data = args.last.kind_of?(::Hash) ? args.pop : {}
+        if (data.keys.map(&:to_s) & self.public_methods.map(&:to_s)).size > 0
+          raise ArgumentError, "data conflicts with template public methods."
+        end
+        metaclass = class << self; self; end
+        data.each {|key, value| metaclass.class_eval { define_method(key){value} }}
+
+        # get the template source proc to instance_eval
+        @source = args.pop || Proc.new {}
+      end
+
+      def render!
+        instance_eval(&@source)
+      end
+
+      # method to output to the io stream
+      def _(data="", nl=true)
+        @io << "#{data.to_s}#{nl ? "\n" : ""}"
+      end
+
+    end
+
+    # this method is required by assert and is called by the test runner.
+    # this renders the templated view using the view's template
+    def render(*args, &runner)
+      TemplatedView.new(self.class.template, {
+        :view => self,
+        :runner => runner
+      }, self.output_io).render!
+    end
+
+  end
+end

--- a/test/view/base_tests.rb
+++ b/test/view/base_tests.rb
@@ -1,0 +1,62 @@
+require 'assert'
+require 'assert/suite'
+
+require 'assert/view/base'
+require 'stringio'
+
+module Assert::View
+
+  class BaseTests < Assert::Context
+    desc "the base view"
+    setup do
+      @view = Assert::View::Base.new(Assert::Suite.new, StringIO.new("", "w+"))
+    end
+    subject{ @view }
+
+    # options
+    should have_instance_method :options
+    should have_class_method :options
+
+    # accessors
+    should have_accessors :suite, :output_io, :runtime_result_callback
+
+    # renderer methods
+    should have_class_method :template, :helper
+    should have_instance_method :render
+
+    # base methods
+    should have_instance_methods :view, :run_tests, :handle_runtime_result
+
+    # common methods
+    should have_instance_methods :run_time, :runner_seed, :count, :tests?, :all_pass?
+    should have_instance_methods :suite_contexts, :ordered_suite_contexts
+    should have_instance_methods :suite_files, :ordered_suite_files
+    should have_instance_methods :result_details_for, :show_result_details?
+    should have_instance_methods :ocurring_result_types, :result_summary_msg
+    should have_instance_methods :all_pass_result_summary_msg, :results_summary_sentence
+    should have_instance_methods :test_count_statement, :result_count_statement
+    should have_instance_methods :to_sentence
+
+  end
+
+  class BaseOptionsTestx < Assert::Context
+    desc "options for the base view"
+    subject do
+      Assert::View::Base.options
+    end
+
+    should "be an Options::Base object" do
+      assert_kind_of Assert::Options::Base, subject
+    end
+
+    should "default its result abbreviations" do
+      assert_equal '.', subject.default_pass_abbrev
+      assert_equal 'F', subject.default_fail_abbrev
+      assert_equal 'I', subject.default_ignore_abbrev
+      assert_equal 'S', subject.default_skip_abbrev
+      assert_equal 'E', subject.default_error_abbrev
+    end
+
+  end
+
+end


### PR DESCRIPTION
Moving the default view and common view handlers and helpers
into the main assert repository.  Consolidating here and will be
deprecating assert-view.  Going to rethink custom view handling
and allow for third party view gems to be 'plugged in', most
likely via user ~/.assert/options.rb settings.
