### PR TITLE
base view sets output io to sync

### DIFF
--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -48,7 +48,9 @@ module Assert
 
     def run_suite
       # TODO: parallel running
-      tests_to_run.each {|test| test.run(@view)}
+      tests_to_run.each do |test|
+        test.run(@view)
+      end
     end
 
   end

--- a/lib/assert/view/base.rb
+++ b/lib/assert/view/base.rb
@@ -32,6 +32,10 @@ module Assert::View
     def initialize(output_io, suite=Assert.suite)
       self.output_io = output_io
       self.suite     = suite
+
+      if self.output_io.respond_to?(:sync=)
+        self.output_io.sync = true
+      end
     end
 
     def view


### PR DESCRIPTION
When setting up a view, the base should set the io to sync (if
applicable).  This allows for real-time result output as the tests
are being run.
