### PR TITLE
adding in "responds_to" plural assertion helpers

### DIFF
--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -74,6 +74,7 @@ module Assert
       ].join
       assert(object.respond_to?(method), fail_desc, what_failed_msg)
     end
+    alias_method :assert_responds_to, :assert_respond_to
 
     def assert_not_respond_to(method, object, fail_desc=nil)
       what_failed_msg = [
@@ -82,7 +83,9 @@ module Assert
       ].join
       assert(!object.respond_to?(method), fail_desc, what_failed_msg)
     end
+    alias_method :assert_not_responds_to, :assert_not_respond_to
     alias_method :refute_respond_to, :assert_not_respond_to
+    alias_method :refute_responds_to, :assert_not_respond_to
 
 
 

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -14,7 +14,9 @@ module Assert::Assertions
     should have_instance_methods :assert_raises, :assert_raise, :assert_nothing_raised, :assert_not_raises, :assert_not_raise
     should have_instance_methods :assert_kind_of, :assert_not_kind_of, :refute_kind_of
     should have_instance_methods :assert_instance_of, :assert_not_instance_of, :refute_instance_of
-    should have_instance_methods :assert_respond_to, :assert_not_respond_to, :refute_respond_to
+    should have_instance_methods :assert_respond_to, :assert_responds_to
+    should have_instance_methods :assert_not_respond_to, :assert_not_responds_to
+    should have_instance_methods :refute_respond_to, :refute_responds_to
     should have_instance_methods :assert_same, :assert_not_same, :refute_same
     should have_instance_methods :assert_equal, :assert_not_equal, :refute_equal
     should have_instance_methods :assert_match, :assert_not_match, :assert_no_match, :refute_match


### PR DESCRIPTION
This is the plural equivalent to `assert_respond_to` and its
inversion not_ helpers.  Only purpose is additional syntactical
sugar for developers in writing there tests.

Fixes #86.
