### PR TITLE
file_exists assertion helpers

### DIFF
--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -180,6 +180,19 @@ module Assert
 
 
 
+    def assert_file_exists(file_path, fail_desc=nil)
+      what_failed_msg = "Expected #{file_path.inspect} to exist."
+      assert(File.exists?(File.expand_path(file_path)), fail_desc, what_failed_msg)
+    end
+
+    def assert_not_file_exists(file_path, fail_desc=nil)
+      what_failed_msg = "Expected #{file_path.inspect} to not exist."
+      assert(!File.exists?(File.expand_path(file_path)), fail_desc, what_failed_msg)
+    end
+    alias_method :refute_file_exists, :assert_not_file_exists
+
+
+
     IGNORED_ASSERTION_HELPERS = [ :assert_throws, :assert_nothing_thrown, :assert_send,
       :assert_operator, :refute_operator, :assert_in_epsilon, :refute_in_epsilon,
       :assert_in_delta, :refute_in_delta

--- a/test/assertions/assert_file_exists_test.rb
+++ b/test/assertions/assert_file_exists_test.rb
@@ -1,0 +1,43 @@
+require 'assert'
+
+class Assert::Assertions::AssertFileExistsTests < Assert::Context
+  desc "the assert_file_exists helper run in a test"
+  setup do
+    fail_desc = @fail_desc = "assert file exists empty fail desc"
+    fail_args = @fail_args = [ '/a/path/to/some/file/that/no/exists', fail_desc ]
+    @test = Factory.test do
+      assert_file_exists(__FILE__) # pass
+      assert_file_exists(*fail_args) # fail
+    end
+    @test.run
+  end
+  subject{ @test }
+
+  should "have 2 total results" do
+    assert_equal 2, subject.result_count
+  end
+  should "have 1 pass result" do
+    assert_equal 1, subject.result_count(:pass)
+  end
+  should "have 1 fail result" do
+    assert_equal 1, subject.result_count(:fail)
+  end
+
+  class FailMessageTest < AssertFileExistsTests
+    desc "with a failed result"
+    setup do
+      @expected = [
+        @fail_args[1],
+        "Expected #{@fail_args[0].inspect} to exist."
+      ].join("\n")
+      @fail_message = @test.fail_results.first.message
+    end
+    subject{ @fail_message }
+
+    should "have a fail message with an explanation of what failed and my fail description" do
+      assert_equal @expected, subject
+    end
+
+  end
+
+end

--- a/test/assertions/assert_not_file_exists_test.rb
+++ b/test/assertions/assert_not_file_exists_test.rb
@@ -1,0 +1,43 @@
+require 'assert'
+
+class Assert::Assertions::AssertNotFileExistsTests < Assert::Context
+  desc "the assert_not_file_exists helper run in a test"
+  setup do
+    fail_desc = @fail_desc = "assert not file exists empty fail desc"
+    fail_args = @fail_args = [ __FILE__, fail_desc ]
+    @test = Factory.test do
+      assert_not_file_exists('/a/path/to/some/file/that/no/exists') # pass
+      assert_not_file_exists(*fail_args) # fail
+    end
+    @test.run
+  end
+  subject{ @test }
+
+  should "have 2 total results" do
+    assert_equal 2, subject.result_count
+  end
+  should "have 1 pass result" do
+    assert_equal 1, subject.result_count(:pass)
+  end
+  should "have 1 fail result" do
+    assert_equal 1, subject.result_count(:fail)
+  end
+
+  class FailMessageTest < AssertNotFileExistsTests
+    desc "with a failed result"
+    setup do
+      @expected = [
+        @fail_args[1],
+        "Expected #{@fail_args[0].inspect} to not exist."
+      ].join("\n")
+      @fail_message = @test.fail_results.first.message
+    end
+    subject{ @fail_message }
+
+    should "have a fail message with an explanation of what failed and my fail description" do
+      assert_equal @expected, subject
+    end
+
+  end
+
+end

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -22,6 +22,7 @@ module Assert::Assertions
     should have_instance_methods :assert_includes, :assert_included
     should have_instance_methods :assert_not_includes, :assert_not_included, :refute_includes, :refute_included
     should have_instance_methods :assert_nil, :assert_not_nil, :refute_nil
+    should have_instance_methods :assert_file_exists, :assert_not_file_exists, :refute_file_exists
   end
 
   class IgnoredTest < BasicTest


### PR DESCRIPTION
This addd `assert_file_exists`, `assert_not_file_exists`, and
`refute_file_exists` assertion helpers.  Pass a file path to the
helpers and they will test whether it exists or not.

Fixes #85.
