### PR TITLE
more succinct versions of the method macros

### DIFF
--- a/lib/assert/macros/methods.rb
+++ b/lib/assert/macros/methods.rb
@@ -21,6 +21,8 @@ module Assert::Macros
         end
       end
       alias_method :have_instance_methods, :have_instance_method
+      alias_method :have_imeth, :have_instance_method
+      alias_method :have_imeths, :have_instance_method
 
       def not_have_instance_method(*methods)
         called_from = (methods.last.kind_of?(Array) ? methods.pop : caller).first
@@ -34,6 +36,8 @@ module Assert::Macros
         end
       end
       alias_method :not_have_instance_methods, :not_have_instance_method
+      alias_method :not_have_imeth, :not_have_instance_method
+      alias_method :not_have_imeths, :not_have_instance_method
 
       def have_class_method(*methods)
         called_from = (methods.last.kind_of?(Array) ? methods.pop : caller).first
@@ -47,6 +51,8 @@ module Assert::Macros
         end
       end
       alias_method :have_class_methods, :have_class_method
+      alias_method :have_cmeth, :have_class_method
+      alias_method :have_cmeths, :have_class_method
 
       def not_have_class_method(*methods)
         called_from = (methods.last.kind_of?(Array) ? methods.pop : caller).first
@@ -60,6 +66,8 @@ module Assert::Macros
         end
       end
       alias_method :not_have_class_methods, :not_have_class_method
+      alias_method :not_have_cmeth, :not_have_class_method
+      alias_method :not_have_cmeths, :not_have_class_method
 
       def have_reader(*methods)
         methods << caller if !methods.last.kind_of?(Array)

--- a/test/macro_test.rb
+++ b/test/macro_test.rb
@@ -44,14 +44,14 @@ class Assert::Macro
     end
 
     should have_instance_method :method_1
-    should have_instance_method :method_2, :method_3
-    should have_instance_methods :method_4
-    should have_instance_methods :method_5, :method_6
+    should have_instance_methods :method_2, :method_3
+    should have_imeth :method_4
+    should have_imeths :method_5, :method_6
 
     should not_have_instance_method :method_7
-    should not_have_instance_method :method_8, :method_9
-    should not_have_instance_methods :method_10
-    should not_have_instance_methods :method_11, :method_12
+    should not_have_instance_methods :method_8, :method_9
+    should not_have_imeth :method_10
+    should not_have_imeths :method_11, :method_12
   end
 
   class ClassMethodsTest < Assert::Context
@@ -66,14 +66,14 @@ class Assert::Macro
     end
 
     should have_class_method :method_1
-    should have_class_method :method_2, :method_3
-    should have_class_methods :method_4
-    should have_class_methods :method_5, :method_6
+    should have_class_methods :method_2, :method_3
+    should have_cmeth :method_4
+    should have_cmeths :method_5, :method_6
 
     should not_have_class_method :method_7
-    should not_have_class_method :method_8, :method_9
-    should not_have_class_methods :method_10
-    should not_have_class_methods :method_11, :method_12
+    should not_have_class_methods :method_8, :method_9
+    should not_have_cmeth :method_10
+    should not_have_cmeths :method_11, :method_12
   end
 
   class ReadersTest < Assert::Context


### PR DESCRIPTION
It can be a pain to type our the full `have_instance_methods`, etc
macro methods repeatedly.  Plus they eat into your 80 char max width
stuff quite a bit.  This provides more succinct versions while not
sacrificing the meaning of each for brevity.
