### PR TITLE
have the CLI sort the test files before requiring them

### DIFF
--- a/lib/assert/cli.rb
+++ b/lib/assert/cli.rb
@@ -61,7 +61,7 @@ module Assert
         args
       ]
 
-      @test_files = file_paths(test_paths).select{ |f| test_file?(f) }
+      @test_files = file_paths(test_paths).select{ |f| test_file?(f) }.sort
     end
 
     def run


### PR DESCRIPTION
This ensures the tests will be added, run, and their results all
displayed in a consistant order.  The dir globbing introduced by the
cli was not returning paths in alpha-numeric order.  This ensures
test files are required in alpha-num order.

@jcredding heads up.
