### PR TITLE
updated Runner handling to configure runner instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Assert uses its [`Assert::Runner`](/lib/assert/runner.rb) to run tests.  You can
 require 'my_awesome_runner_class'
 
 Assert.configure do |config|
-  config.runner MyAwesomeRunnerClass
+  config.runner MyAwesomeRunnerClass.new
 end
 ```
 

--- a/lib/assert.rb
+++ b/lib/assert.rb
@@ -41,8 +41,8 @@ module Assert
 
     def initialize
       @view   = Assert::View::DefaultView.new($stdout)
-      @suite  = Suite.new
-      @runner = Assert::Runner
+      @suite  = Assert::Suite.new
+      @runner = Assert::Runner.new
 
       @runner_seed = begin # TODO: secure random??
         srand

--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -22,8 +22,7 @@ module Assert
 
     def run
       Assert.init(File.join(@test_dir_root_path, Assert.config.test_dir))
-      # TODO: have `run` take suite, view; config be instance
-      Assert.runner.new(Assert.suite, Assert.view).run
+      Assert.runner.run(Assert.suite, Assert.view)
     end
 
     protected

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -2,53 +2,34 @@ module Assert
 
   class Runner
 
-    # a Runner runs a suite of tests.
+    # Runner runs a suite of tests.
 
-    def initialize(suite, view)
+    def run(suite, view)
       raise ArgumentError if !suite.kind_of?(Suite)
-      @suite, @view = suite, view
-    end
 
-    def run
-      @view.fire(:on_start)
-      @suite.setup
+      view.fire(:on_start)
+      suite.setup
 
-      benchmark { run_suite }
+      suite.start_time = Time.now
+      # TODO: parallel running
+      tests_to_run(suite).each do |test|
+        view.fire(:before_test, test)
+        test.run{ |result| view.fire(:on_result, result) }
+        view.fire(:after_test, test)
+      end
+      suite.end_time = Time.now
 
-      @suite.teardown
-      @view.fire(:on_finish)
+      suite.teardown
+      view.fire(:on_finish)
 
-      count(:failed) + count(:errored)
-    end
-
-    def count(type)
-      @suite.count(type)
+      suite.count(:failed) + suite.count(:errored)
     end
 
     protected
 
-    def tests_to_run
-      # order tests randomly
-      tests = @suite.tests
+    def tests_to_run(suite)
       srand Assert.config.runner_seed # TODO: secure random??
-      tests.sort.sort_by { rand tests.size }
-    end
-
-    private
-
-    def benchmark
-      @suite.start_time = Time.now
-      yield if block_given?
-      @suite.end_time = Time.now
-    end
-
-    def run_suite
-      # TODO: parallel running
-      tests_to_run.each do |test|
-        @view.fire(:before_test, test)
-        test.run {|result| @view.fire(:on_result, result)}
-        @view.fire(:after_test, test)
-      end
+      suite.tests.sort.sort_by { rand suite.tests.size }
     end
 
   end

--- a/test/assert_test.rb
+++ b/test/assert_test.rb
@@ -38,7 +38,7 @@ module Assert
     should "default the view, suite, and runner" do
       assert_kind_of Assert::View::DefaultView, subject.view
       assert_kind_of Assert::Suite,  subject.suite
-      assert_equal   Assert::Runner, subject.runner
+      assert_kind_of Assert::Runner, subject.runner
     end
 
   end

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -11,13 +11,14 @@ class Assert::Runner
     setup do
       @suite  = Assert::Suite.new
       @view   = Assert::View::Base.new(@suite, StringIO.new("", "w+"))
+      @runner = Assert::Runner.new
     end
-    subject { Assert::Runner.new(@suite, @view) }
+    subject { @runner }
 
-    should have_instance_methods :run, :count
+    should have_instance_methods :run
 
     should "return an integer exit code" do
-      assert_equal 0, subject.run
+      assert_equal 0, subject.run(@suite, @view)
     end
 
   end


### PR DESCRIPTION
You now configure a Runner instance.  There are a couple reasons for
this.

One, the user may need to do custom Runner initialization and its
easier to let them do it and config Assert with an instance.  It's
never good to be creating instances of things on behalf of the users.

Two, this is more consistant with how you configure a View or a Suite -
you just pass an instance.

@jcredding ready for review
