### PR TITLE
added in requiring a local settings file on initialization

### DIFF
--- a/.assert.rb
+++ b/.assert.rb
@@ -1,0 +1,3 @@
+Assert.configure do |c|
+  # puts "Applying local settings..."
+end


### PR DESCRIPTION
This allows for settings that are specific to a project.  By default,
Assert will look for the file at `./.assert.rb`.  You can specify
a custom local settings file by setting the `ASSERT_LOCALFILE` env
var.
