### PR TITLE
handle and apply ENV settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Assert will look for and require the file `$HOME/.assert/initializer.rb`.  Use t
 
 Assert will look for and require the file `./.assert.rb`.  Use this file to specify project settings.  Local settings can be overridden by CLI, and ENV settings.
 
+To specify a custom local settings file path, use the `ASSERT_LOCALFILE` env var.
+
 ### CLI settings
 
 Assert accepts options from its CLI.  Use these options to specify runtime settings.  CLI settings can be overridden by ENV settings.
@@ -177,12 +179,6 @@ Using the CLI:
 $ assert [-o|--show-output|--no-show-output]
 ```
 
-Using an ENV var:
-
-```sh
-$ ASSERT_SHOW_OUTPUT=false assert
-```
-
 ### Failure Handling
 
 By default, Assert will halt test execution when a test produces a Fail result.  It provides a setting to override this default:
@@ -199,12 +195,6 @@ Using the CLI:
 
 ```sh
 $ assert [-t|--halt|--no-halt]
-```
-
-Using an ENV var:
-
-```sh
-$ ASSERT_HALT_ON_FAIL=false assert
 ```
 
 ## Viewing Test Results

--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -38,7 +38,9 @@ module Assert
     end
 
     def apply_env_settings
-      # TODO: drive assert config settings from env vars (don't nils)
+      Assert.configure do |c|
+        c.runner_seed ENV['ASSERT_RUNNER_SEED'].to_i if ENV['ASSERT_RUNNER_SEED']
+      end
     end
 
     def load_tests(paths)


### PR DESCRIPTION
This updates the initialization to honor env var settings.  Right
now, runner_seed is the only setting driven by an env var.

I chose to remove the boolean options from the env settings b/c
of difficulty in parsing and the ambiguity in handling the values
parsed.  Ultimately it's easier to just use the flags anyway.  We
can always handle them at a later time.

Closes #98.
Closes #99.

@jcredding ready for review.
