### PR TITLE
hooked up some `debug` behavior

### DIFF
--- a/lib/assert.rb
+++ b/lib/assert.rb
@@ -24,7 +24,7 @@ module Assert
     end
 
     # load the test files
-    Assert.view.fire(:before_load)
+    Assert.view.fire(:before_load, test_files)
     test_files.each{ |p| require p }
     Assert.view.fire(:after_load)
   end

--- a/lib/assert/view/default_view.rb
+++ b/lib/assert/view/default_view.rb
@@ -18,6 +18,13 @@ module Assert::View
       ignore_styles  :magenta
     end
 
+    def before_load(test_files)
+      if Assert.config.debug
+        puts "Loading test files:"
+        test_files.each{ |f| puts "  #{f}" }
+      end
+    end
+
     def after_load
       puts "Loaded suite (#{test_count_statement})"
     end


### PR DESCRIPTION
Now that you can run assert in "debug mode", this ties in some
behavior for that mode.  In debug mode, assert will show CLI error
backtraces and will show all of the test files that are loaded.

@jcredding this is just the latest commit here.  Will rebase it once #113 is merged.
