### PR TITLE
expand each given test path when determining which test files to load

### DIFF
--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -47,7 +47,8 @@ module Assert
 
     def test_files(test_paths)
       test_paths.inject(Set.new) do |paths, path|
-        paths += Dir.glob("#{path}*") + Dir.glob("#{path}*/**/*")
+        p = File.expand_path(path, Dir.pwd)
+        paths += Dir.glob("#{p}*") + Dir.glob("#{p}*/**/*")
       end.select{ |p| is_test_file?(p) }.sort
     end
 


### PR DESCRIPTION
This avoids bugs when given relative paths.  Specifically, duplicates
and unintended files would get loaded if given `"."` as a test path.
This normalizes all test file lookup by using expanded full paths.
