### PR TITLE
don't hide backtraces on exceptions raised while loading the tests

### DIFF
--- a/lib/assert/cli.rb
+++ b/lib/assert/cli.rb
@@ -44,7 +44,7 @@ module Assert
         exit(1)
       rescue Exception => exception
         puts "#{exception.class}: #{exception.message}"
-        puts exception.backtrace.join("\n") if debug_mode
+        puts exception.backtrace.join("\n")
         exit(1)
       end
       exit(0)


### PR DESCRIPTION
Short-sightedly put in a feature where test loading exceptions had
their backtraces hidden except in debug mode.  This proved to be
very annoying as you always want to see the backtrace in this
scenario.  Plus, without showing the backtrace, I found myself not
recognizing the output as an error and it confused me greatly.

Closes #123.

@jcredding yo!
