### PR TITLE
have AssertRunner ensure test files are looked up from a list of paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.gem
+*.log
 *.rbc
+.rbx/
 .bundle
 .config
 .yardoc

--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -13,7 +13,7 @@ module Assert
       apply_option_settings(test_options)
       apply_env_settings
 
-      files = test_files(test_paths.empty? ? Assert.config.test_dir : test_paths)
+      files = test_files(test_paths.empty? ? [*Assert.config.test_dir] : test_paths)
       Assert.init(files, {
         :test_dir_path => path_of(Assert.config.test_dir, files.first)
       })


### PR DESCRIPTION
Before if no test_paths were provided from the CLI, the files were
looked up from a single `Assert.config.test_dir` path.  Magically,
the `inject` that worked on that single entry in MRI, but fails in
jruby and probably other ruby versions.

This just ensures that we are always injecting over a collection
of test paths when looking for test files to run.

Closes #125.
