### PR TITLE
Inverting `show_output` option to be named `capture_output`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Assert uses a config pattern for specifying settings.  Using this pattern, you c
 
 ### User settings
 
-Assert will look for and require the file `$HOME/.assert/initializer.rb`.  Use this file to specify user settings.  User settings can be overridden by Local, CLI, and ENV settings.
+Assert will look for and require the file `$HOME/.assert/init.rb`.  Use this file to specify user settings.  User settings can be overridden by Local, CLI, and ENV settings.
 
 ### Local settings
 
@@ -161,22 +161,22 @@ Using an ENV var:
 $ ASSERT_RUNNER_SEED=1234 assert
 ```
 
-### Showing Output
+### Capture Output
 
-By default, Assert shows any output on `$stdout` produced while running a test.  It provides a setting to override whether to show this output or to 'capture' it and show it with the test result details:
+By default, Assert shows any output on `$stdout` produced while running a test.  It provides a setting to override whether to show this output or to 'capture' it and display it in the test result details:
 
 In user/local settings file:
 
 ```ruby
 Assert.configure do |config|
-  config.show_output false
+  config.capture_output true
 end
 ```
 
 Using the CLI:
 
 ```sh
-$ assert [-o|--show-output|--no-show-output]
+$ assert [-o|--capture-output|--no-capture-output]
 ```
 
 ### Failure Handling
@@ -309,10 +309,6 @@ A `View` object is responsible for rendering test result output.  Assert provide
 ### Macro
 
 Macros are procs that define sets of test code and make it available for easy reuse.  Macros work nicely with the 'should' and 'test' context methods.
-
-## The Assert family of testing tools
-
-TODO: add in references to assert related tools.
 
 ## Installation
 

--- a/lib/assert.rb
+++ b/lib/assert.rb
@@ -46,7 +46,7 @@ module Assert
     end
 
     settings :view, :suite, :runner, :test_dir, :test_helper
-    settings :runner_seed, :show_output, :halt_on_fail, :debug
+    settings :runner_seed, :capture_output, :halt_on_fail, :debug
 
     def initialize
       @view   = Assert::View::DefaultView.new($stdout)
@@ -55,11 +55,11 @@ module Assert
       @test_dir    = "test"
       @test_helper = "helper.rb"
 
-      # TODO: secure random??
-      @runner_seed  = begin; srand; srand % 0xFFFF; end.to_i
-      @show_output  = true
-      @halt_on_fail = true
-      @debug        = false
+      # default settings
+      @runner_seed    = begin; srand; srand % 0xFFFF; end.to_i
+      @capture_output = true
+      @halt_on_fail   = true
+      @debug          = false
     end
 
     def apply(settings)

--- a/lib/assert/cli.rb
+++ b/lib/assert/cli.rb
@@ -15,7 +15,7 @@ module Assert
         option 'runner_seed', 'Use a given seed to run tests', {
           :abbrev => 's', :value => Fixnum
         }
-        option 'show_output', 'show stdout output (do not capture)', {
+        option 'capture_output', 'capture stdout and display in result details', {
           :abbrev => 'o'
         }
         option 'halt_on_fail', 'halt a test when it fails', {

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -11,7 +11,6 @@ module Assert
       suite.setup
 
       suite.start_time = Time.now
-      # TODO: parallel running
       tests_to_run(suite).each do |test|
         view.fire(:before_test, test)
         test.run{ |result| view.fire(:on_result, result) }
@@ -28,7 +27,7 @@ module Assert
     protected
 
     def tests_to_run(suite)
-      srand Assert.config.runner_seed # TODO: secure random??
+      srand Assert.config.runner_seed
       suite.tests.sort.sort_by { rand suite.tests.size }
     end
 

--- a/lib/assert/test.rb
+++ b/lib/assert/test.rb
@@ -106,7 +106,7 @@ module Assert
     end
 
     def capture_output(&block)
-      if Assert.config.show_output == false
+      if Assert.config.capture_output == true
         orig_stdout = $stdout.clone
         $stdout = capture_io
         block.call

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -14,7 +14,7 @@ require 'pry'
 class Assert::Context
   def setup
     Assert.config.halt_on_fail false
-    # Note: don't mess with the `show_output` setting in this setup block. Doing
+    # Note: don't mess with the `capture_output` setting in this setup block. Doing
     # so will break the capture output tests.  If you really need to set it one
     # way or the other, do so in the `.assert.rb` local settings file.
   end

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -31,7 +31,7 @@ module Assert
     subject { Config }
 
     should have_imeths :suite, :view, :runner, :test_dir, :test_helper
-    should have_imeths :runner_seed, :show_output, :halt_on_fail, :debug
+    should have_imeths :runner_seed, :capture_output, :halt_on_fail, :debug
     should have_imeths :apply
 
     should "default the view, suite, and runner" do

--- a/test/unit/test_tests.rb
+++ b/test/unit/test_tests.rb
@@ -161,11 +161,11 @@ class Assert::Test
         puts "std out from the test"
         assert true
       }
-      @orig_show = Assert.config.show_output
-      Assert.config.show_output false
+      @orig_capture = Assert.config.capture_output
+      Assert.config.capture_output true
     end
     teardown do
-      Assert.config.show_output @orig_show
+      Assert.config.capture_output @orig_capture
     end
 
     should "capture any io from the test" do


### PR DESCRIPTION
This is more intuitive and better matches the defaults.  The default
(capture_output = false) is still to show output as the tests are
run, but now the "easy" option `-o` does the opposite of the default
which is more appropriate.

Overall, makes this a more intuitive option while maintaining the
same default behavior.

@jcredding ready for review.
