### PR TITLE
properly handle skip backtraces

### DIFF
--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -122,7 +122,7 @@ module Assert
           # create a test from the given code block
           Assert.suite.tests << Test.new(test_name, ci, &block)
         else
-          test_eventually(desc_or_macro, called_from, first_caller, &block)
+          test_eventually(desc_or_macro, called_from, first_caller || caller.first, &block)
         end
       end
 

--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -135,6 +135,11 @@ module Assert::Result
       "Skip"
     end
 
+    # override of the base, show the test's context info called_from
+    def trace
+      self.test.context_info.called_from || super
+    end
+
   end
 
   class Error < Base

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -4,18 +4,13 @@ module Assert
   class Suite
 
     class ContextInfo
-
-      attr_reader :called_from, :first_caller, :klass, :file
+      attr_reader :called_from, :klass, :file
 
       def initialize(klass, called_from=nil, first_caller=nil)
-        @first_caller = first_caller
-        @called_from = called_from
+        @called_from = called_from || first_caller
         @klass = klass
-        @file = if (@called_from || @first_caller)
-          (@called_from || @first_caller).gsub(/\:[0-9]+.*$/, '')
-        end
+        @file = @called_from.gsub(/\:[0-9]+.*$/, '') if @called_from
       end
-
     end
 
     TEST_METHOD_REGEX = /^test./

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -181,14 +181,18 @@ class Assert::Suite
     end
     subject{ @info }
 
-    should have_readers :called_from, :first_caller, :klass, :file
+    should have_readers :called_from, :klass, :file
 
     should "set its klass on init" do
       assert_equal @klass, subject.klass
     end
 
-    should "set its called_from to the first caller on init" do
-      assert_equal @caller.first, subject.first_caller
+    should "set its called_from to the called_from or first caller on init" do
+      info = Assert::Suite::ContextInfo.new(@klass, @caller.first, nil)
+      assert_equal @caller.first, info.called_from
+
+      info = Assert::Suite::ContextInfo.new(@klass, nil, @caller.first)
+      assert_equal @caller.first, info.called_from
     end
 
     should "set its file from caller info on init" do


### PR DESCRIPTION
There were a couple holes I discovered while debugging the backtrace
problems I saw in using the TODO skip in #130.

First, the skip result wasn't checking its context info `called_from`
when building its trace value.  Fail results do this so the macro
fails show the correct result.  Skips need to do this as well since
they can be generated from a context caller like fail results from
a macro.

Second, the context info wasn't properly building its `called_from`.
The first caller should be used as the called from if no called
from is explicitly provided.  What's funny is it seems the tests
were originally written with this intent, just not implmented
properly.

@jcredding ready for review.
