### PR TITLE
properly determine a result trace line

### DIFF
--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -98,7 +98,7 @@ class Assert::Context
 
     should "create a fail result and set its backtrace" do
       assert_kind_of Assert::Result::Fail, subject
-      assert_equal Factory.context_info_called_from, subject.trace
+      assert_equal subject.backtrace.filtered.first, subject.trace
       assert_kind_of Array, subject.backtrace
     end
 


### PR DESCRIPTION
This updates the logic to prefer the first filtered backtrace line
and then fallback to where the test was called from (in its context
info).  This properly sets the trace line for results not generated
in a test code block (like macros or tests with no block).

This fixes a regression in 2538fc2008511b54d9bb35db2aff16ccc0a8a8c5
that caused the called from to be shown over the backtrace for _all_
fail results.

The net effect of this new behavior is we expect filtered backtraces
to be empty at times and that triggers the called from fallback.  This
greatly simplifies the filtering logic on the backtrace.

Finally, this adds the assert bin path to the filter out logic.  Since
the bin was introduced in v2.0.0, assert hasn't been filtering out
assert lines in the backtrace.  This properly fixes that.

@jcredding ready for review.  nice that this ends up removing so much code.
