### PR TITLE
`with_backtrace` context helper method

### DIFF
--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -223,6 +223,20 @@ module Assert
       raise(Result::TestSkipped, skip_msg || "")
     end
 
+    # alter the backtraces of fail results generated in the given block
+    def with_backtrace(bt, &block)
+      bt ||= []
+      current_results.count.tap do |count|
+        begin
+          instance_eval(&block)
+        rescue Result::TestSkipped, Result::TestFailure => e
+          e.set_backtrace(bt); raise(e)
+        ensure
+          current_results[count..-1].each{ |r| r.set_backtrace(bt) }
+        end
+      end
+    end
+
     def subject
       if subj = self.class.subject
         instance_eval(&subj)
@@ -250,6 +264,10 @@ module Assert
         @__running_test__.results << result
         result
       end
+    end
+
+    def current_results
+      @__running_test__.results
     end
 
   end

--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -52,6 +52,12 @@ module Assert::Result
       (self.backtrace.filtered.first || self.test.context_info.called_from).to_s
     end
 
+    # chose to implement this way instead of using an `attr_writer` to be
+    # consistant with how you override exception backtraces.
+    def set_backtrace(bt)
+      @backtrace = Backtrace.new(bt || [])
+    end
+
     def ==(other)
       self.class == other.class && self.message == other.message
     end
@@ -110,7 +116,7 @@ module Assert::Result
   end
 
   # raised by the 'skip' context helper to break test execution
-  class TestSkipped < RuntimeError; end
+  TestSkipped = Class.new(RuntimeError)
 
   class Skip < Base
 

--- a/test/unit/result_tests.rb
+++ b/test/unit/result_tests.rb
@@ -40,6 +40,7 @@ module Assert::Result
 
     should have_readers :test, :message, :backtrace
     should have_imeths :test_name, :name, :to_sym, :to_s, :trace
+    should have_imeth :set_backtrace
 
     Assert::Result.types.keys.each do |type|
       should "respond to the instance method ##{type}?" do
@@ -62,6 +63,13 @@ module Assert::Result
     should "show only its class and message when inspected" do
       exp = "#<#{subject.class} @message=#{subject.message.inspect}>"
       assert_equal exp, subject.inspect
+    end
+
+    should "allow overriding the result backtrace with `set_backtrace`" do
+      subject.set_backtrace(['bt'])
+
+      assert_kind_of Assert::Result::Backtrace, subject.backtrace
+      assert_equal ['bt'], subject.backtrace
     end
 
   end


### PR DESCRIPTION
This method takes a backtrace and block.  It then runs the block and
takes any results generated by the block and replaces their backtrace
with the given backtrace.

This allows 3rd-party tools to write their own custom assertions
and have them abstract the 3rd-party backtraces that any results
would have.

An example usage would be:

``` ruby
def assert_some_custom_behavior(*args)
  with_backtrace(caller) do
    # asset some things (generate results)
  end
end
```

**Note**: this _does not_ affect error results.  These results need
to have "pure" backtraces to assist in debugging (error result
backtraces are never modified in Assert).  This _will_, however,
affect skip and halt-on-fail results: `with_backtrace` rescues the
exceptions raised in those scenarios and sets the exception's
backtrace to the given backtrace and then re-raises.  This way you
get both the halt behavior of the result and the backtrace abstraction
of `with_exception`.

@jcredding this should help with your MR custom assertions.  I'm going to head over there and test this in MR.  Ready for review.
