### PR TITLE
add option for running only matching test files with changes

### DIFF
--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -46,10 +46,25 @@ module Assert
     private
 
     def test_files(test_paths)
+      file_paths = if Assert.config.changed_only
+        changed_test_files(test_paths)
+      else
+        globbed_test_files(test_paths)
+      end
+
+      file_paths.select{ |p| is_test_file?(p) }.sort
+    end
+
+    def changed_test_files(test_paths)
+      puts "Loading only changed files:" if Assert.config.debug
+      globbed_test_files(Assert.config.changed_files.call(test_paths))
+    end
+
+    def globbed_test_files(test_paths)
       test_paths.inject(Set.new) do |paths, path|
         p = File.expand_path(path, Dir.pwd)
         paths += Dir.glob("#{p}*") + Dir.glob("#{p}*/**/*")
-      end.select{ |p| is_test_file?(p) }.sort
+      end
     end
 
     def is_test_file?(path)

--- a/lib/assert/cli.rb
+++ b/lib/assert/cli.rb
@@ -21,6 +21,9 @@ module Assert
         option 'halt_on_fail', 'halt a test when it fails', {
           :abbrev => 't'
         }
+        option 'changed_only', 'only run test files with changes', {
+          :abbrev => 'c'
+        }
         # show loaded test files, cli err backtraces, etc
         option 'debug', 'run in debug mode'
       end

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -30,9 +30,9 @@ module Assert
     desc "the Assert Config singleton"
     subject { Config }
 
-    should have_imeths :suite, :view, :runner, :test_dir, :test_helper
-    should have_imeths :runner_seed, :capture_output, :halt_on_fail, :debug
-    should have_imeths :apply
+    should have_imeths :suite, :view, :runner, :test_dir, :test_helper, :changed_files
+    should have_imeths :runner_seed, :capture_output, :halt_on_fail, :changed_only
+    should have_imeths :debug, :apply
 
     should "default the view, suite, and runner" do
       assert_kind_of Assert::View::DefaultView, subject.view


### PR DESCRIPTION
This is a new CLI option (`-c`) that tells assert to only load test
files in the given path(s) that have changes.  Use this to "scope
down" your test runs to just the tests you are actively working on.

This uses git (by default) to determine which files have changes.
Custom cmds can be configured in the user/local settings if git is
not available or a more specific set of cmds is needed.

Closes #134.

@jcredding this totally works and is totally awesome (I used it while testing it!).  Ready for review.  I need your thoughts especially on option naming, setting custom cmds and that whole workflow, and just "how does this feel".  Thanks man.
