### PR TITLE
make the "methods macros" more efficient

### DIFF
--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -180,8 +180,8 @@ module Assert::Result
   end
 
   class Backtrace < ::Array
-    def initialize(value=nil)
-      super(value || ["No backtrace"])
+    def initialize(value = nil)
+      super([*(value || "No backtrace")])
     end
 
     def to_s; self.join("\n"); end


### PR DESCRIPTION
Instead of creating a seperate test for each method, this creates
a _single_ test for methods and accumulates each type of method
to test.  Then the single test iterates over the method types and
makes the appropriate assertion for each.

I had to be sure and keep appropriate backtrace lines if the macro
failed.  To do this I had to "pass thru" a called from for each
method we would be asserting.  I then used `with_backtrace` to
apply the given called from.  However, this meant I had to update
the backtrace handling a bit and make it so that you could pass it
an array of lines _or_ an individual line (as we are in the method
macro case).

@jcredding ready for review.
