### PR TITLE
optimize fail msg handling

### DIFF
--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -1,154 +1,162 @@
 module Assert
   module Assertions
 
-    def assert_block(desc=nil)
-      msg ||= "Expected block to return a true value."
-      assert(yield, desc, msg)
+    def assert_block(desc = nil)
+      assert(yield, desc){ "Expected block to return a true value." }
     end
 
-    def assert_not_block(desc=nil)
-      msg ||= "Expected block to return a false value."
-      assert(!yield, desc, msg)
+    def assert_not_block(desc = nil)
+      assert(!yield, desc){ "Expected block to return a false value." }
     end
     alias_method :refute_block, :assert_not_block
 
-    def assert_empty(collection, desc=nil)
-      msg = "Expected #{collection.inspect} to be empty."
-      assert(collection.empty?, desc, msg)
+    def assert_empty(collection, desc = nil)
+      assert(collection.empty?, desc) do
+        "Expected #{collection.inspect} to be empty."
+      end
     end
 
-    def assert_not_empty(collection, desc=nil)
-      msg = "Expected #{collection.inspect} to not be empty."
-      assert(!collection.empty?, desc, msg)
+    def assert_not_empty(collection, desc = nil)
+      assert(!collection.empty?, desc) do
+        "Expected #{collection.inspect} to not be empty."
+      end
     end
     alias_method :refute_empty, :assert_not_empty
 
-    def assert_equal(expected, actual, desc=nil)
-      msg = "Expected #{expected.inspect}, not #{actual.inspect}."
-      assert(actual == expected, desc, msg)
+    def assert_equal(expected, actual, desc = nil)
+      assert(actual == expected, desc) do
+        "Expected #{expected.inspect}, not #{actual.inspect}."
+      end
     end
 
-    def assert_not_equal(expected, actual, desc=nil)
-      msg = "#{actual.inspect} not expected to equal #{expected.inspect}."
-      assert(actual != expected, desc, msg)
+    def assert_not_equal(expected, actual, desc = nil)
+      assert(actual != expected, desc) do
+        "#{actual.inspect} not expected to equal #{expected.inspect}."
+      end
     end
     alias_method :refute_equal, :assert_not_equal
 
-    def assert_file_exists(file_path, desc=nil)
-      msg = "Expected #{file_path.inspect} to exist."
-      assert(File.exists?(File.expand_path(file_path)), desc, msg)
+    def assert_file_exists(file_path, desc = nil)
+      assert(File.exists?(File.expand_path(file_path)), desc) do
+        "Expected #{file_path.inspect} to exist."
+      end
     end
 
-    def assert_not_file_exists(file_path, desc=nil)
-      msg = "Expected #{file_path.inspect} to not exist."
-      assert(!File.exists?(File.expand_path(file_path)), desc, msg)
+    def assert_not_file_exists(file_path, desc = nil)
+      assert(!File.exists?(File.expand_path(file_path)), desc) do
+        "Expected #{file_path.inspect} to not exist."
+      end
     end
     alias_method :refute_file_exists, :assert_not_file_exists
 
-    def assert_includes(object, collection, desc=nil)
-      msg = "Expected #{collection.inspect} to include #{object.inspect}."
-      assert(collection.include?(object), desc, msg)
+    def assert_includes(object, collection, desc = nil)
+      assert(collection.include?(object), desc) do
+        "Expected #{collection.inspect} to include #{object.inspect}."
+      end
     end
     alias_method :assert_included, :assert_includes
 
-    def assert_not_includes(object, collection, desc=nil)
-      msg = "Expected #{collection.inspect} to not include #{object.inspect}."
-      assert(!collection.include?(object), desc, msg)
+    def assert_not_includes(object, collection, desc = nil)
+      assert(!collection.include?(object), desc) do
+        "Expected #{collection.inspect} to not include #{object.inspect}."
+      end
     end
     alias_method :assert_not_included, :assert_not_includes
     alias_method :refute_includes, :assert_not_includes
     alias_method :refute_included, :assert_not_includes
 
-    def assert_instance_of(klass, instance, desc=nil)
-      msg = "Expected #{instance.inspect} (#{instance.class}) to"\
-            " be an instance of #{klass}."
-      assert(instance.instance_of?(klass), desc, msg)
+    def assert_instance_of(klass, instance, desc = nil)
+      assert(instance.instance_of?(klass), desc) do
+        "Expected #{instance.inspect} (#{instance.class}) to be an instance of #{klass}."
+      end
     end
 
-    def assert_not_instance_of(klass, instance, desc=nil)
-      msg = "#{instance.inspect} not expected to be an instance of #{klass}."
-      assert(!instance.instance_of?(klass), desc, msg)
+    def assert_not_instance_of(klass, instance, desc = nil)
+      assert(!instance.instance_of?(klass), desc) do
+        "#{instance.inspect} (#{instance.class}) not expected to be an instance of #{klass}."
+      end
     end
     alias_method :refute_instance_of, :assert_not_instance_of
 
     def assert_kind_of(klass, instance, desc=nil)
-      msg = "Expected #{instance.inspect} (#{instance.class}) to"\
-            " be a kind of #{klass}."
-      assert(instance.kind_of?(klass), desc, msg)
+      assert(instance.kind_of?(klass), desc) do
+        "Expected #{instance.inspect} (#{instance.class}) to be a kind of #{klass}."
+      end
     end
 
     def assert_not_kind_of(klass, instance, desc=nil)
-      msg = "#{instance.inspect} not expected to be a kind of #{klass}."
-      assert(!instance.kind_of?(klass), desc, msg)
+      assert(!instance.kind_of?(klass), desc) do
+        "#{instance.inspect} not expected to be a kind of #{klass}."
+      end
     end
     alias_method :refute_kind_of, :assert_not_kind_of
 
     def assert_match(expected, actual, desc=nil)
-      msg = "Expected #{actual.inspect} to match #{expected.inspect}."
-      expected = /#{Regexp.escape(expected)}/ if String === expected && String === actual
-      assert(actual =~ expected, desc, msg)
+      exp = String === expected && String === actual ? /#{Regexp.escape(expected)}/ : expected
+      assert(actual =~ exp, desc) do
+        "Expected #{actual.inspect} to match #{expected.inspect}."
+      end
     end
 
     def assert_not_match(expected, actual, desc=nil)
-      msg = "#{actual.inspect} not expected to match #{expected.inspect}."
-      expected = /#{Regexp.escape(expected)}/ if String === expected && String === actual
-      assert(actual !~ expected, desc, msg)
+      exp = String === expected && String === actual ? /#{Regexp.escape(expected)}/ : expected
+      assert(actual !~ exp, desc) do
+        "#{actual.inspect} not expected to match #{expected.inspect}."
+      end
     end
     alias_method :refute_match, :assert_not_match
     alias_method :assert_no_match, :assert_not_match
 
     def assert_nil(object, desc=nil)
-      msg = "Expected nil, not #{object.inspect}."
-      assert(object.nil?, desc, msg)
+      assert(object.nil?, desc){ "Expected nil, not #{object.inspect}." }
     end
 
     def assert_not_nil(object, desc=nil)
-      msg = "Expected #{object.inspect} to not be nil."
-      assert(!object.nil?, desc, msg)
+      assert(!object.nil?, desc){ "Expected #{object.inspect} to not be nil." }
     end
     alias_method :refute_nil, :assert_not_nil
 
     def assert_raises(*exceptions, &block)
       desc = exceptions.last.kind_of?(String) ? exceptions.pop : nil
       err = RaisedException.new(exceptions, &block)
-      assert(err.raised?, desc, err.msg)
+      assert(err.raised?, desc){ err.msg }
     end
     alias_method :assert_raise, :assert_raises
 
     def assert_nothing_raised(*exceptions, &block)
       desc = exceptions.last.kind_of?(String) ? exceptions.pop : nil
       err = NoRaisedException.new(exceptions, &block)
-      assert(!err.raised?, desc, err.msg)
+      assert(!err.raised?, desc){ err.msg }
     end
     alias_method :assert_not_raises, :assert_nothing_raised
     alias_method :assert_not_raise, :assert_nothing_raised
 
     def assert_respond_to(method, object, desc=nil)
-      msg = "Expected #{object.inspect} (#{object.class}) to"\
-            " respond to `#{method}`."
-      assert(object.respond_to?(method), desc, msg)
+      assert(object.respond_to?(method), desc) do
+        "Expected #{object.inspect} (#{object.class}) to respond to `#{method}`."
+      end
     end
     alias_method :assert_responds_to, :assert_respond_to
 
     def assert_not_respond_to(method, object, desc=nil)
-      msg = "#{object.inspect} (#{object.class}) not expected to"\
-            " respond to `#{method}`."
-      assert(!object.respond_to?(method), desc, msg)
+      assert(!object.respond_to?(method), desc) do
+        "#{object.inspect} (#{object.class}) not expected to respond to `#{method}`."
+      end
     end
     alias_method :assert_not_responds_to, :assert_not_respond_to
     alias_method :refute_respond_to, :assert_not_respond_to
     alias_method :refute_responds_to, :assert_not_respond_to
 
     def assert_same(expected, actual, desc=nil)
-      msg = "Expected #{actual} (#{actual.object_id}) to"\
-            " be the same as #{expected} (#{expected.object_id})."
-      assert(actual.equal?(expected), desc, msg)
+      assert(actual.equal?(expected), desc) do
+        "Expected #{actual} (#{actual.object_id}) to be the same as #{expected} (#{expected.object_id})."
+      end
     end
 
     def assert_not_same(expected, actual, desc=nil)
-      msg = "#{actual} (#{actual.object_id}) not expected to"\
-            " be the same as #{expected} (#{expected.object_id})."
-      assert(!actual.equal?(expected), desc, msg)
+      assert(!actual.equal?(expected), desc) do
+        "#{actual} (#{actual.object_id}) not expected to be the same as #{expected} (#{expected.object_id})."
+      end
     end
     alias_method :refute_same, :assert_not_same
 

--- a/test/unit/assertions/assert_instance_of_tests.rb
+++ b/test/unit/assertions/assert_instance_of_tests.rb
@@ -50,7 +50,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n#{@args[1].inspect} not expected to"\
+      exp = "#{@args[2]}\n#{@args[1].inspect} (#{@args[1].class}) not expected to"\
             " be an instance of #{@args[0]}."
       assert_equal exp, subject.fail_results.first.message
     end

--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -108,12 +108,6 @@ class Assert::Context
       assert_equal fail_msg, result.message
     end
 
-    should "set any given result message evaluated from a proc" do
-      fail_msg = ::Proc.new{ "Still didn't work" }
-      result = @context.fail(fail_msg)
-      assert_equal fail_msg.call, result.message
-    end
-
   end
 
   class HaltOnFailTests < FailTests
@@ -151,13 +145,13 @@ class Assert::Context
     end
 
     should "return a pass result given a `true` assertion" do
-      result = subject.assert(true, @fail_desc, @what_failed)
+      result = subject.assert(true, @fail_desc){ @what_failed }
       assert_kind_of Assert::Result::Pass, result
       assert_nil result.message
     end
 
     should "return a fail result given a `false` assertion" do
-      result = subject.assert(false, @fail_desc, @what_failed)
+      result = subject.assert(false, @fail_desc){ @what_failed }
       assert_kind_of Assert::Result::Fail, result
       assert_equal [@fail_desc, @what_failed].join("\n"), result.message
     end


### PR DESCRIPTION
No need to create all these fail msg strings if the assert passes.
This moves the custom "what failed" message definition to a block.
The block is only yielded to if the assertion fails.

This also reworks the processing of fail messages to not work in
Procs but instead just take arbitrary string args and join them with
new lines.

The added overhead of creating a block for every what failed message
should be negated by removing the overhead of creating a proc for
processing every fail message that we were already doing.

@jcredding ready for review.  Not this has a few "breaking" changes:
- can't pass a block to the `fail` method (not sure why you even  would?)
- can no longer pass a "what failed message" as a 3rd param (this was never part of the public API - just used internally)
