### PR TITLE
bugfix: capture skip results in teardown blocks

### DIFF
--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -220,7 +220,7 @@ module Assert
 
     # adds a Skip result to the end of the test's results and breaks test execution
     def skip(skip_msg=nil)
-      raise(Result::TestSkipped, skip_msg || "")
+      raise(Result::TestSkipped, skip_msg || '')
     end
 
     # alter the backtraces of fail results generated in the given block

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -77,7 +77,7 @@ module Assert
       if block_given?
         self.setups << block
       else
-        self.setups.each{|setup| setup.call}
+        self.setups.each{ |setup| setup.call }
       end
     end
     alias_method :startup, :setup
@@ -86,7 +86,7 @@ module Assert
       if block_given?
         self.teardowns << block
       else
-        self.teardowns.reverse.each{|teardown| teardown.call}
+        self.teardowns.reverse.each{ |teardown| teardown.call }
       end
     end
     alias_method :shutdown, :teardown

--- a/lib/assert/test.rb
+++ b/lib/assert/test.rb
@@ -40,6 +40,8 @@ module Assert
       ensure
         begin
           run_test_teardown(run_scope)
+        rescue Result::TestSkipped => err
+          @results << Result::Skip.new(self, err)
         rescue Exception => teardown_err
           @results << Result::Error.new(self, teardown_err)
         end


### PR DESCRIPTION
This fixes a bug where and `skip` calls in teardown blocks would
produce error results.  This tweaks the teardown block exception
handling to specifically look for and capture skip results.

Closes #137.

@jcredding ready for review.
