### PR TITLE
ensure consistent exception handling when running tests

### DIFF
--- a/lib/assert/test.rb
+++ b/lib/assert/test.rb
@@ -35,13 +35,19 @@ module Assert
         @results << Result::Fail.new(self, err)
       rescue Result::TestSkipped => err
         @results << Result::Skip.new(self, err)
+      rescue SignalException => err
+        raise(err)
       rescue Exception => err
         @results << Result::Error.new(self, err)
       ensure
         begin
           run_test_teardown(run_scope)
+        rescue Result::TestFailure => err
+          @results << Result::Fail.new(self, err)
         rescue Result::TestSkipped => err
           @results << Result::Skip.new(self, err)
+        rescue SignalException => err
+          raise(err)
         rescue Exception => teardown_err
           @results << Result::Error.new(self, teardown_err)
         end


### PR DESCRIPTION
This ensures exceptions raised when running test teardown are handled
the same as exceptions raised when running the setup/test itself.
Before any fails generated in the teardown wouldn't be captured.
Error results were being captured in teardowns but this behavior
was not tested explicitly.

This also adds `SignalException` handling when running tests.  This
allows a test suite run to be interrupted (previously this was inter
preted as an error result.

Closes #141.

@jcredding ready for review.
