### PR TITLE
updated debug output handling

### DIFF
--- a/bin/assert
+++ b/bin/assert
@@ -3,5 +3,10 @@
 # Copyright (c) 2011-Present Kelly Redding and Collin Redding
 #
 
+require 'assert'
 require 'assert/cli'
-Assert::CLI.run *ARGV
+
+Assert.config.debug ENV['ASSERT_DEBUG'] == 'true' || Assert::CLI.debug?(ARGV)
+
+Assert::CLI.bench('CLI init and parse'){ @cli = Assert::CLI.new(*ARGV) }
+@cli.run

--- a/lib/assert/view/default_view.rb
+++ b/lib/assert/view/default_view.rb
@@ -19,10 +19,6 @@ module Assert::View
     option 'ignore_styles', :magenta
 
     def before_load(test_files)
-      if Assert.config.debug
-        puts "Loading test files:"
-        test_files.each{ |f| puts "  #{f}" }
-      end
     end
 
     def after_load

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -9,7 +9,7 @@ module Assert
     desc "the Assert module"
     subject { Assert }
 
-    should have_imeths :view, :suite, :runner, :config, :configure, :init
+    should have_imeths :view, :suite, :runner, :config, :configure
 
     should "know its config singleton" do
       assert_same Config, subject.config


### PR DESCRIPTION
This adds enhanced debug output and handling.  This involves changes
to how the debug config is set, reorganization of debug-related code,
and show test suite setup steps w/ benchmarks in debug mode.

First off, this centalizes how "debug mode" is configured.  The main
bin now requires in the config and defaults the debug mode setting to
the ENV var setting.  Then everything related to debug output checks
against this flag.

Second, this reorganizes the debug handling code all into the assert
runner file.  All setup steps in the assert runner are benchmarked
and outputted if in debug mode.

Closes #136.

@jcredding ready for review.
