### PR TITLE
Pretty print output values in fail messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,18 @@ Assert.configure do |config|
 end
 ```
 
+## Pretty Printing values in fail messages
+
+By default, Assert uses `inspect` when outputting value details in failure messages.  This can be overridden to use a custom processor using the `pp_processor` config setting.  Any processor values should respond to `to_proc` and their proc form should take an input value.  For example:
+
+```ruby
+Assert.config.pp_processor :to_s
+
+# --or--
+
+Asser.config.pp_processor Proc.new{ |input| "herp, #{input.inspect}, derp" }
+```
+
 ## Viewing Test Results
 
 `Assert::View::DefaultView` is the default handler for viewing test results.  Its output goes something like this:

--- a/lib/assert.rb
+++ b/lib/assert.rb
@@ -1,6 +1,7 @@
 require 'singleton'
 require 'assert/version'
 
+require 'assert/utils'
 require 'assert/view'
 require 'assert/suite'
 require 'assert/runner'
@@ -33,8 +34,8 @@ module Assert
     end
 
     settings :view, :suite, :runner, :test_dir, :test_helper, :changed_files
-    settings :runner_seed, :capture_output, :halt_on_fail, :changed_only
-    settings :debug
+    settings :runner_seed, :pp_processor
+    settings :capture_output, :halt_on_fail, :changed_only, :debug
 
     def initialize
       @view   = Assert::View::DefaultView.new($stdout)
@@ -46,6 +47,7 @@ module Assert
 
       # default option values
       @runner_seed    = begin; srand; srand % 0xFFFF; end.to_i
+      @pp_processor   = :inspect
       @capture_output = false
       @halt_on_fail   = true
       @changed_only   = false

--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -1,4 +1,7 @@
+require 'assert/utils'
+
 module Assert
+
   module Assertions
 
     def assert_block(desc = nil)
@@ -12,53 +15,53 @@ module Assert
 
     def assert_empty(collection, desc = nil)
       assert(collection.empty?, desc) do
-        "Expected #{collection.inspect} to be empty."
+        "Expected #{Assert::U.pp(collection)} to be empty."
       end
     end
 
     def assert_not_empty(collection, desc = nil)
       assert(!collection.empty?, desc) do
-        "Expected #{collection.inspect} to not be empty."
+        "Expected #{Assert::U.pp(collection)} to not be empty."
       end
     end
     alias_method :refute_empty, :assert_not_empty
 
     def assert_equal(expected, actual, desc = nil)
       assert(actual == expected, desc) do
-        "Expected #{expected.inspect}, not #{actual.inspect}."
+        "Expected #{Assert::U.pp(expected)}, not #{Assert::U.pp(actual)}."
       end
     end
 
     def assert_not_equal(expected, actual, desc = nil)
       assert(actual != expected, desc) do
-        "#{actual.inspect} not expected to equal #{expected.inspect}."
+        "#{Assert::U.pp(actual)} not expected to equal #{Assert::U.pp(expected)}."
       end
     end
     alias_method :refute_equal, :assert_not_equal
 
     def assert_file_exists(file_path, desc = nil)
       assert(File.exists?(File.expand_path(file_path)), desc) do
-        "Expected #{file_path.inspect} to exist."
+        "Expected #{Assert::U.pp(file_path)} to exist."
       end
     end
 
     def assert_not_file_exists(file_path, desc = nil)
       assert(!File.exists?(File.expand_path(file_path)), desc) do
-        "Expected #{file_path.inspect} to not exist."
+        "Expected #{Assert::U.pp(file_path)} to not exist."
       end
     end
     alias_method :refute_file_exists, :assert_not_file_exists
 
     def assert_includes(object, collection, desc = nil)
       assert(collection.include?(object), desc) do
-        "Expected #{collection.inspect} to include #{object.inspect}."
+        "Expected #{Assert::U.pp(collection)} to include #{Assert::U.pp(object)}."
       end
     end
     alias_method :assert_included, :assert_includes
 
     def assert_not_includes(object, collection, desc = nil)
       assert(!collection.include?(object), desc) do
-        "Expected #{collection.inspect} to not include #{object.inspect}."
+        "Expected #{Assert::U.pp(collection)} to not include #{Assert::U.pp(object)}."
       end
     end
     alias_method :assert_not_included, :assert_not_includes
@@ -67,26 +70,26 @@ module Assert
 
     def assert_instance_of(klass, instance, desc = nil)
       assert(instance.instance_of?(klass), desc) do
-        "Expected #{instance.inspect} (#{instance.class}) to be an instance of #{klass}."
+        "Expected #{Assert::U.pp(instance)} (#{instance.class}) to be an instance of #{klass}."
       end
     end
 
     def assert_not_instance_of(klass, instance, desc = nil)
       assert(!instance.instance_of?(klass), desc) do
-        "#{instance.inspect} (#{instance.class}) not expected to be an instance of #{klass}."
+        "#{Assert::U.pp(instance)} (#{instance.class}) not expected to be an instance of #{klass}."
       end
     end
     alias_method :refute_instance_of, :assert_not_instance_of
 
     def assert_kind_of(klass, instance, desc=nil)
       assert(instance.kind_of?(klass), desc) do
-        "Expected #{instance.inspect} (#{instance.class}) to be a kind of #{klass}."
+        "Expected #{Assert::U.pp(instance)} (#{instance.class}) to be a kind of #{klass}."
       end
     end
 
     def assert_not_kind_of(klass, instance, desc=nil)
       assert(!instance.kind_of?(klass), desc) do
-        "#{instance.inspect} not expected to be a kind of #{klass}."
+        "#{Assert::U.pp(instance)} not expected to be a kind of #{klass}."
       end
     end
     alias_method :refute_kind_of, :assert_not_kind_of
@@ -94,25 +97,25 @@ module Assert
     def assert_match(expected, actual, desc=nil)
       exp = String === expected && String === actual ? /#{Regexp.escape(expected)}/ : expected
       assert(actual =~ exp, desc) do
-        "Expected #{actual.inspect} to match #{expected.inspect}."
+        "Expected #{Assert::U.pp(actual)} to match #{Assert::U.pp(expected)}."
       end
     end
 
     def assert_not_match(expected, actual, desc=nil)
       exp = String === expected && String === actual ? /#{Regexp.escape(expected)}/ : expected
       assert(actual !~ exp, desc) do
-        "#{actual.inspect} not expected to match #{expected.inspect}."
+        "#{Assert::U.pp(actual)} not expected to match #{Assert::U.pp(expected)}."
       end
     end
     alias_method :refute_match, :assert_not_match
     alias_method :assert_no_match, :assert_not_match
 
     def assert_nil(object, desc=nil)
-      assert(object.nil?, desc){ "Expected nil, not #{object.inspect}." }
+      assert(object.nil?, desc){ "Expected nil, not #{Assert::U.pp(object)}." }
     end
 
     def assert_not_nil(object, desc=nil)
-      assert(!object.nil?, desc){ "Expected #{object.inspect} to not be nil." }
+      assert(!object.nil?, desc){ "Expected #{Assert::U.pp(object)} to not be nil." }
     end
     alias_method :refute_nil, :assert_not_nil
 
@@ -133,14 +136,14 @@ module Assert
 
     def assert_respond_to(method, object, desc=nil)
       assert(object.respond_to?(method), desc) do
-        "Expected #{object.inspect} (#{object.class}) to respond to `#{method}`."
+        "Expected #{Assert::U.pp(object)} (#{object.class}) to respond to `#{method}`."
       end
     end
     alias_method :assert_responds_to, :assert_respond_to
 
     def assert_not_respond_to(method, object, desc=nil)
       assert(!object.respond_to?(method), desc) do
-        "#{object.inspect} (#{object.class}) not expected to respond to `#{method}`."
+        "#{Assert::U.pp(object)} (#{object.class}) not expected to respond to `#{method}`."
       end
     end
     alias_method :assert_not_responds_to, :assert_not_respond_to
@@ -149,13 +152,15 @@ module Assert
 
     def assert_same(expected, actual, desc=nil)
       assert(actual.equal?(expected), desc) do
-        "Expected #{actual} (#{actual.object_id}) to be the same as #{expected} (#{expected.object_id})."
+        "Expected #{Assert::U.pp(actual)} (#{actual.object_id})"\
+        " to be the same as #{Assert::U.pp(expected)} (#{expected.object_id})."
       end
     end
 
     def assert_not_same(expected, actual, desc=nil)
       assert(!actual.equal?(expected), desc) do
-        "#{actual} (#{actual.object_id}) not expected to be the same as #{expected} (#{expected.object_id})."
+        "#{Assert::U.pp(actual)} (#{actual.object_id})"\
+        " not expected to be the same as #{Assert::U.pp(expected)} (#{expected.object_id})."
       end
     end
     alias_method :refute_same, :assert_not_same
@@ -213,8 +218,8 @@ module Assert
         if @exception
           backtrace = Assert::Result::Backtrace.new(@exception.backtrace)
           [ raised_msg,
-            "Class: <#{@exception.class}>",
-            "Message: <#{@exception.message.inspect}>",
+            "Class: `#{@exception.class}`",
+            "Message: `#{@exception.message.inspect}`",
             "---Backtrace---",
             backtrace.filtered.to_s,
             "---------------"
@@ -238,4 +243,5 @@ module Assert
     end
 
   end
+
 end

--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -1,3 +1,4 @@
+require 'assert/utils'
 require 'assert/suite'
 require 'assert/assertions'
 require 'assert/result'
@@ -174,19 +175,19 @@ module Assert
     # check if the assertion is a truthy value, if so create a new pass result, otherwise
     # create a new fail result with the desc and what failed msg.
     # all other assertion helpers use this one in the end
-    def assert(assertion, fail_desc = nil)
+    def assert(assertion, desc = nil)
       if assertion
         pass
       else
-        what_failed_msg = block_given? ? yield : "Failed assert: assertion was <#{assertion.inspect}>."
-        fail(fail_message(fail_desc, what_failed_msg))
+        what = block_given? ? yield : "Failed assert: assertion was `#{Assert::U.pp(assertion)}`."
+        fail(fail_message(desc, what))
       end
     end
 
     # the opposite of assert, check if the assertion is a false value, if so create a new pass
     # result, otherwise create a new fail result with the desc and it's what failed msg
     def assert_not(assertion, fail_desc = nil)
-      assert(!assertion, fail_desc){ "Failed assert_not: assertion was <#{assertion.inspect}>." }
+      assert(!assertion, fail_desc){ "Failed assert_not: assertion was `#{Assert::U.pp(assertion)}`." }
     end
     alias_method :refute, :assert_not
 

--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -63,7 +63,7 @@ module Assert::Result
     end
 
     def inspect
-      "#<#{self.class} @message=#{self.message.inspect}>"
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)} @message=#{self.message.inspect}>"
     end
 
   end

--- a/lib/assert/test.rb
+++ b/lib/assert/test.rb
@@ -78,7 +78,7 @@ module Assert
       attributes_string = ([ :name, :context_info, :results ].collect do |attr|
         "@#{attr}=#{self.send(attr).inspect}"
       end).join(" ")
-      "#<#{self.class} #{attributes_string}>"
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)} #{attributes_string}>"
     end
 
     protected

--- a/lib/assert/utils.rb
+++ b/lib/assert/utils.rb
@@ -1,0 +1,18 @@
+require 'assert'
+
+module Assert
+
+  module Utils
+
+    def self.pp(input)
+      output = Assert.config.pp_processor.to_proc.call(input)
+      output = output.encode(Encoding.default_external) if defined?(Encoding)
+      output
+    end
+
+  end
+
+  # alias for brevity
+  U = Utils
+
+end

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -31,13 +31,19 @@ module Assert
     subject { Config }
 
     should have_imeths :suite, :view, :runner, :test_dir, :test_helper, :changed_files
-    should have_imeths :runner_seed, :capture_output, :halt_on_fail, :changed_only
-    should have_imeths :debug, :apply
+    should have_imeths :runner_seed, :pp_processor
+    should have_imeths :capture_output, :halt_on_fail, :changed_only, :debug
+    should have_imeths :apply
 
     should "default the view, suite, and runner" do
       assert_kind_of Assert::View::DefaultView, subject.view
       assert_kind_of Assert::Suite,  subject.suite
       assert_kind_of Assert::Runner, subject.runner
+    end
+
+    should "default the optional settings" do
+      assert_not_nil subject.runner_seed
+      assert_equal :inspect, subject.pp_processor
     end
 
   end

--- a/test/unit/assertions/assert_empty_tests.rb
+++ b/test/unit/assertions/assert_empty_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'assert/assertions'
 
+require 'assert/utils'
+
 module Assert::Assertions
 
   class AssertEmptyTests < Assert::Context
@@ -23,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{@args[0].inspect} to be empty."
+      exp = "#{@args[1]}\nExpected #{Assert::U.pp(@args[0])} to be empty."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -49,7 +51,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{@args[0].inspect} to not be empty."
+      exp = "#{@args[1]}\nExpected #{Assert::U.pp(@args[0])} to not be empty."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_equal_tests.rb
+++ b/test/unit/assertions/assert_equal_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'assert/assertions'
 
+require 'assert/utils'
+
 module Assert::Assertions
 
   class AssertEqualTests < Assert::Context
@@ -23,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{@args[0].inspect}, not #{@args[1].inspect}."
+      exp = "#{@args[2]}\nExpected #{Assert::U.pp(@args[0])}, not #{Assert::U.pp(@args[1])}."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -50,7 +52,7 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "#{@args[1].inspect} not expected to equal #{@args[0].inspect}."
+            "#{Assert::U.pp(@args[1])} not expected to equal #{Assert::U.pp(@args[0])}."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_file_exists_tests.rb
+++ b/test/unit/assertions/assert_file_exists_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'assert/assertions'
 
+require 'assert/utils'
+
 module Assert::Assertions
 
   class AssertFileExistsTests < Assert::Context
@@ -23,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{@args[0].inspect} to exist."
+      exp = "#{@args[1]}\nExpected #{Assert::U.pp(@args[0])} to exist."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -49,7 +51,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{@args[0].inspect} to not exist."
+      exp = "#{@args[1]}\nExpected #{Assert::U.pp(@args[0])} to not exist."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_includes_tests.rb
+++ b/test/unit/assertions/assert_includes_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'assert/assertions'
 
+require 'assert/utils'
+
 module Assert::Assertions
 
   class AssertIncludesTests < Assert::Context
@@ -24,7 +26,7 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "Expected #{@args[1].inspect} to include #{@args[0].inspect}."
+            "Expected #{Assert::U.pp(@args[1])} to include #{Assert::U.pp(@args[0])}."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -51,7 +53,7 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "Expected #{@args[1].inspect} to not include #{@args[0].inspect}."
+            "Expected #{Assert::U.pp(@args[1])} to not include #{Assert::U.pp(@args[0])}."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_instance_of_tests.rb
+++ b/test/unit/assertions/assert_instance_of_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'assert/assertions'
 
+require 'assert/utils'
+
 module Assert::Assertions
 
   class AssertInstanceOfTests < Assert::Context
@@ -23,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{@args[1].inspect} (#{@args[1].class}) to"\
+      exp = "#{@args[2]}\nExpected #{Assert::U.pp(@args[1])} (#{@args[1].class}) to"\
             " be an instance of #{@args[0]}."
       assert_equal exp, subject.fail_results.first.message
     end
@@ -50,7 +52,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n#{@args[1].inspect} (#{@args[1].class}) not expected to"\
+      exp = "#{@args[2]}\n#{Assert::U.pp(@args[1])} (#{@args[1].class}) not expected to"\
             " be an instance of #{@args[0]}."
       assert_equal exp, subject.fail_results.first.message
     end

--- a/test/unit/assertions/assert_kind_of_tests.rb
+++ b/test/unit/assertions/assert_kind_of_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'assert/assertions'
 
+require 'assert/utils'
+
 module Assert::Assertions
 
   class AssertKindOfTests < Assert::Context
@@ -23,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{@args[1].inspect} (#{@args[1].class}) to"\
+      exp = "#{@args[2]}\nExpected #{Assert::U.pp(@args[1])} (#{@args[1].class}) to"\
             " be a kind of #{@args[0]}."
       assert_equal exp, subject.fail_results.first.message
     end
@@ -50,7 +52,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n#{@args[1].inspect} not expected to be a kind of #{@args[0]}."
+      exp = "#{@args[2]}\n#{Assert::U.pp(@args[1])} not expected to be a kind of #{@args[0]}."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_match_tests.rb
+++ b/test/unit/assertions/assert_match_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'assert/assertions'
 
+require 'assert/utils'
+
 module Assert::Assertions
 
   class AssertMatchTests < Assert::Context
@@ -23,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{@args[1].inspect} to match #{@args[0].inspect}."
+      exp = "#{@args[2]}\nExpected #{Assert::U.pp(@args[1])} to match #{Assert::U.pp(@args[0])}."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -49,7 +51,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n#{@args[1].inspect} not expected to match #{@args[0].inspect}."
+      exp = "#{@args[2]}\n#{Assert::U.pp(@args[1])} not expected to match #{Assert::U.pp(@args[0])}."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_nil_tests.rb
+++ b/test/unit/assertions/assert_nil_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'assert/assertions'
 
+require 'assert/utils'
+
 module Assert::Assertions
 
   class AssertNilTests < Assert::Context
@@ -23,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected nil, not #{@args[0].inspect}."
+      exp = "#{@args[1]}\nExpected nil, not #{Assert::U.pp(@args[0])}."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -49,7 +51,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{@args[0].inspect} to not be nil."
+      exp = "#{@args[1]}\nExpected #{Assert::U.pp(@args[0])} to not be nil."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_respond_to_tests.rb
+++ b/test/unit/assertions/assert_respond_to_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'assert/assertions'
 
+require 'assert/utils'
+
 module Assert::Assertions
 
   class AssertRespondToTest < Assert::Context
@@ -24,7 +26,7 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "Expected #{@args[1].inspect} (#{@args[1].class})"\
+            "Expected #{Assert::U.pp(@args[1])} (#{@args[1].class})"\
             " to respond to `#{@args[0]}`."
       assert_equal exp, subject.fail_results.first.message
     end
@@ -52,7 +54,7 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "#{@args[1].inspect} (#{@args[1].class})"\
+            "#{Assert::U.pp(@args[1])} (#{@args[1].class})"\
             " not expected to respond to `#{@args[0]}`."
       assert_equal exp, subject.fail_results.first.message
     end

--- a/test/unit/assertions/assert_same_tests.rb
+++ b/test/unit/assertions/assert_same_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'assert/assertions'
 
+require 'assert/utils'
+
 module Assert::Assertions
 
   class AssertSameTest < Assert::Context
@@ -25,8 +27,8 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "Expected #{@args[1].inspect} (#{@args[1].object_id})"\
-            " to be the same as #{@args[0].inspect} (#{@args[0].object_id})."
+            "Expected #{Assert::U.pp(@args[1])} (#{@args[1].object_id})"\
+            " to be the same as #{Assert::U.pp(@args[0])} (#{@args[0].object_id})."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -54,8 +56,8 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "#{@args[1].inspect} (#{@args[1].object_id}) not expected"\
-            " to be the same as #{@args[0].inspect} (#{@args[0].object_id})."
+            "#{Assert::U.pp(@args[1])} (#{@args[1].object_id}) not expected"\
+            " to be the same as #{Assert::U.pp(@args[0])} (#{@args[0].object_id})."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -1,9 +1,11 @@
 require 'assert'
 require 'assert/context'
 
+require 'assert/utils'
+
 class Assert::Context
 
-  class BasicTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Assert context"
     setup do
       @test = Factory.test
@@ -27,7 +29,7 @@ class Assert::Context
 
   end
 
-  class SkipTests < BasicTests
+  class SkipTests < UnitTests
     desc "skip method"
     setup do
       @skip_msg = "I need to implement this in the future."
@@ -44,7 +46,7 @@ class Assert::Context
 
   end
 
-  class IgnoreTests < BasicTests
+  class IgnoreTests < UnitTests
     desc "ignore method"
     setup do
       @ignore_msg = "Ignore this for now, will do later."
@@ -59,7 +61,7 @@ class Assert::Context
 
   end
 
-  class PassTests < BasicTests
+  class PassTests < UnitTests
     desc "pass method"
     setup do
       @pass_msg = "That's right, it works."
@@ -74,7 +76,7 @@ class Assert::Context
 
   end
 
-  class FlunkTests < BasicTests
+  class FlunkTests < UnitTests
     desc "flunk method"
     setup do
       @flunk_msg = "It flunked."
@@ -89,7 +91,7 @@ class Assert::Context
 
   end
 
-  class FailTests < BasicTests
+  class FailTests < UnitTests
     desc "fail method"
     setup do
       @result = @context.fail
@@ -137,7 +139,7 @@ class Assert::Context
 
   end
 
-  class AssertTests < BasicTests
+  class AssertTests < UnitTests
     desc "assert method"
     setup do
       @fail_desc = "my fail desc"
@@ -153,6 +155,17 @@ class Assert::Context
     should "return a fail result given a `false` assertion" do
       result = subject.assert(false, @fail_desc){ @what_failed }
       assert_kind_of Assert::Result::Fail, result
+    end
+
+    should "pp the assertion value in the fail message by default" do
+      exp_default_what = "Failed assert: assertion was `#{Assert::U.pp(false)}`."
+      result = subject.assert(false, @fail_desc)
+
+      assert_equal [@fail_desc, exp_default_what].join("\n"), result.message
+    end
+
+    should "use a custom fail message if one is given" do
+      result = subject.assert(false, @fail_desc){ @what_failed }
       assert_equal [@fail_desc, @what_failed].join("\n"), result.message
     end
 
@@ -166,23 +179,28 @@ class Assert::Context
 
   end
 
-  class AssertNotTests < BasicTests
+  class AssertNotTests < UnitTests
     desc "assert_not method"
     setup do
       @fail_desc = "my fail desc"
-      @what_failed = "Failed assert_not: assertion was <true>."
-    end
-
-    should "return a fail result given a `true` assertion" do
-      result = subject.assert_not(true, @fail_desc)
-      assert_kind_of Assert::Result::Fail, result
-      assert_equal [@fail_desc, @what_failed].join("\n"), result.message
     end
 
     should "return a pass result given a `false` assertion" do
       result = subject.assert_not(false, @fail_desc)
       assert_kind_of Assert::Result::Pass, result
       assert_nil result.message
+    end
+
+    should "return a fail result given a `true` assertion" do
+      result = subject.assert_not(true, @fail_desc)
+      assert_kind_of Assert::Result::Fail, result
+    end
+
+    should "pp the assertion value in the fail message by default" do
+      exp_default_what = "Failed assert_not: assertion was `#{Assert::U.pp(true)}`."
+      result = subject.assert_not(true, @fail_desc)
+
+      assert_equal [@fail_desc, exp_default_what].join("\n"), result.message
     end
 
     should "return a fail result given a \"truthy\" assertion" do
@@ -195,7 +213,7 @@ class Assert::Context
 
   end
 
-  class SubjectTests < BasicTests
+  class SubjectTests < UnitTests
     desc "subject method"
     setup do
       expected = @expected = "amazing"
@@ -213,7 +231,7 @@ class Assert::Context
 
   end
 
-  class WithBacktraceTests < BasicTests
+  class WithBacktraceTests < UnitTests
     desc "with_backtrace method"
     setup do
       @from_bt = ['called_from_here']
@@ -240,7 +258,7 @@ class Assert::Context
 
   end
 
-  class InspectTests < BasicTests
+  class InspectTests < UnitTests
     desc "inspect method"
     setup do
       @expected = "#<#{@context.class}>"

--- a/test/unit/result_tests.rb
+++ b/test/unit/result_tests.rb
@@ -61,7 +61,8 @@ module Assert::Result
     end
 
     should "show only its class and message when inspected" do
-      exp = "#<#{subject.class} @message=#{subject.message.inspect}>"
+      exp = "#<#{subject.class}:#{'0x0%x' % (subject.object_id << 1)}"\
+            " @message=#{subject.message.inspect}>"
       assert_equal exp, subject.inspect
     end
 

--- a/test/unit/test_tests.rb
+++ b/test/unit/test_tests.rb
@@ -39,7 +39,7 @@ class Assert::Test
       attrs_string = [:name, :context_info, :results].collect do |method|
         "@#{method}=#{subject.send(method).inspect}"
       end.join(" ")
-      expected = "#<#{subject.class} #{attrs_string}>"
+      expected = "#<#{subject.class}:#{'0x0%x' % (subject.object_id << 1)} #{attrs_string}>"
       assert_equal expected, subject.inspect
     end
 

--- a/test/unit/utils_tests.rb
+++ b/test/unit/utils_tests.rb
@@ -1,0 +1,38 @@
+require 'assert'
+require 'assert/utils'
+
+module Assert::Utils
+
+  class UnitTests < Assert::Context
+    desc "Assert::Utils"
+    subject{ Assert::Utils }
+
+    should have_imeths :pp
+
+  end
+
+  class PrettyPrintTests < UnitTests
+    desc "`pp`"
+    setup do
+      @inputs = [ 1, 'hi there', Hash.new, [:a, :b]]
+      @default_processor = Assert.config.pp_processor
+      @new_processor = Proc.new{ |input| 'herp derp' }
+    end
+    teardown do
+      Assert.config.pp_processor(@default_processor)
+    end
+
+    should "process its given input and encode if available" do
+      @inputs.each do |input|
+        assert_equal @default_processor.to_proc.call(input), subject.pp(input)
+      end
+
+      Assert.config.pp_processor(@new_processor)
+      @inputs.each do |input|
+        assert_equal @new_processor.to_proc.call(input), subject.pp(input)
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds pretty-printing of object values in assertion fail messages.
Before, we were just doing a blanket `inspect`.  Now this is abstracted
by a `pp` util method.  The `pp` util also encodes the output if
Encoding is available.

The pp operation, by default, is still to `inspect` the object.  This
can be overridden using the `pp_processor` config setting.  I've included
a README section describing its use.

All assertion fail messages have been updated to pretty print instead
of just inspecting their object values.

This is added for two reasons:
1) neat feature to add, plus encoding support
2) this is in prep for showing diffs on `assert_equal` fails.  this
   abstraction needs to be in place.

@jcredding ready for review.  Please check and make sure I didn't miss any assertions.  Thanks.
