### PR TITLE
use stdlib `PP.pp` to show objects in fail messages

### DIFF
--- a/lib/assert.rb
+++ b/lib/assert.rb
@@ -34,8 +34,8 @@ module Assert
     end
 
     settings :view, :suite, :runner, :test_dir, :test_helper, :changed_files
-    settings :runner_seed, :pp_processor
-    settings :capture_output, :halt_on_fail, :changed_only, :debug
+    settings :runner_seed, :pp_proc
+    settings :capture_output, :halt_on_fail, :changed_only, :pp_objects, :debug
 
     def initialize
       @view   = Assert::View::DefaultView.new($stdout)
@@ -46,11 +46,14 @@ module Assert
       @changed_files = Assert::AssertRunner::DEFAULT_CHANGED_FILES_PROC
 
       # default option values
-      @runner_seed    = begin; srand; srand % 0xFFFF; end.to_i
-      @pp_processor   = :inspect
+      @runner_seed = begin; srand; srand % 0xFFFF; end.to_i
+      @pp_proc     = Assert::U.stdlib_pp_proc
+
+      # mode flags
       @capture_output = false
       @halt_on_fail   = true
       @changed_only   = false
+      @pp_objects     = false
       @debug          = false
     end
 

--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -15,53 +15,53 @@ module Assert
 
     def assert_empty(collection, desc = nil)
       assert(collection.empty?, desc) do
-        "Expected #{Assert::U.pp(collection)} to be empty."
+        "Expected #{Assert::U.show(collection)} to be empty."
       end
     end
 
     def assert_not_empty(collection, desc = nil)
       assert(!collection.empty?, desc) do
-        "Expected #{Assert::U.pp(collection)} to not be empty."
+        "Expected #{Assert::U.show(collection)} to not be empty."
       end
     end
     alias_method :refute_empty, :assert_not_empty
 
-    def assert_equal(expected, actual, desc = nil)
-      assert(actual == expected, desc) do
-        "Expected #{Assert::U.pp(expected)}, not #{Assert::U.pp(actual)}."
+    def assert_equal(exp, act, desc = nil)
+      assert(act == exp, desc) do
+        "Expected #{Assert::U.show(exp)}, not #{Assert::U.show(act)}."
       end
     end
 
-    def assert_not_equal(expected, actual, desc = nil)
-      assert(actual != expected, desc) do
-        "#{Assert::U.pp(actual)} not expected to equal #{Assert::U.pp(expected)}."
+    def assert_not_equal(exp, act, desc = nil)
+      assert(act != exp, desc) do
+        "#{Assert::U.show(act)} not expected to equal #{Assert::U.show(exp)}."
       end
     end
     alias_method :refute_equal, :assert_not_equal
 
     def assert_file_exists(file_path, desc = nil)
       assert(File.exists?(File.expand_path(file_path)), desc) do
-        "Expected #{Assert::U.pp(file_path)} to exist."
+        "Expected #{Assert::U.show(file_path)} to exist."
       end
     end
 
     def assert_not_file_exists(file_path, desc = nil)
       assert(!File.exists?(File.expand_path(file_path)), desc) do
-        "Expected #{Assert::U.pp(file_path)} to not exist."
+        "Expected #{Assert::U.show(file_path)} to not exist."
       end
     end
     alias_method :refute_file_exists, :assert_not_file_exists
 
     def assert_includes(object, collection, desc = nil)
       assert(collection.include?(object), desc) do
-        "Expected #{Assert::U.pp(collection)} to include #{Assert::U.pp(object)}."
+        "Expected #{Assert::U.show(collection)} to include #{Assert::U.show(object)}."
       end
     end
     alias_method :assert_included, :assert_includes
 
     def assert_not_includes(object, collection, desc = nil)
       assert(!collection.include?(object), desc) do
-        "Expected #{Assert::U.pp(collection)} to not include #{Assert::U.pp(object)}."
+        "Expected #{Assert::U.show(collection)} to not include #{Assert::U.show(object)}."
       end
     end
     alias_method :assert_not_included, :assert_not_includes
@@ -70,52 +70,52 @@ module Assert
 
     def assert_instance_of(klass, instance, desc = nil)
       assert(instance.instance_of?(klass), desc) do
-        "Expected #{Assert::U.pp(instance)} (#{instance.class}) to be an instance of #{klass}."
+        "Expected #{Assert::U.show(instance)} (#{instance.class}) to be an instance of #{klass}."
       end
     end
 
     def assert_not_instance_of(klass, instance, desc = nil)
       assert(!instance.instance_of?(klass), desc) do
-        "#{Assert::U.pp(instance)} (#{instance.class}) not expected to be an instance of #{klass}."
+        "#{Assert::U.show(instance)} (#{instance.class}) not expected to be an instance of #{klass}."
       end
     end
     alias_method :refute_instance_of, :assert_not_instance_of
 
     def assert_kind_of(klass, instance, desc=nil)
       assert(instance.kind_of?(klass), desc) do
-        "Expected #{Assert::U.pp(instance)} (#{instance.class}) to be a kind of #{klass}."
+        "Expected #{Assert::U.show(instance)} (#{instance.class}) to be a kind of #{klass}."
       end
     end
 
     def assert_not_kind_of(klass, instance, desc=nil)
       assert(!instance.kind_of?(klass), desc) do
-        "#{Assert::U.pp(instance)} not expected to be a kind of #{klass}."
+        "#{Assert::U.show(instance)} not expected to be a kind of #{klass}."
       end
     end
     alias_method :refute_kind_of, :assert_not_kind_of
 
-    def assert_match(expected, actual, desc=nil)
-      exp = String === expected && String === actual ? /#{Regexp.escape(expected)}/ : expected
-      assert(actual =~ exp, desc) do
-        "Expected #{Assert::U.pp(actual)} to match #{Assert::U.pp(expected)}."
+    def assert_match(exp, act, desc=nil)
+      exp_regex = String === exp && String === act ? /#{Regexp.escape(exp)}/ : exp
+      assert(act =~ exp_regex, desc) do
+        "Expected #{Assert::U.show(act)} to match #{Assert::U.show(exp)}."
       end
     end
 
-    def assert_not_match(expected, actual, desc=nil)
-      exp = String === expected && String === actual ? /#{Regexp.escape(expected)}/ : expected
-      assert(actual !~ exp, desc) do
-        "#{Assert::U.pp(actual)} not expected to match #{Assert::U.pp(expected)}."
+    def assert_not_match(exp, act, desc=nil)
+      exp = String === exp && String === act ? /#{Regexp.escape(exp)}/ : exp
+      assert(act !~ exp, desc) do
+        "#{Assert::U.show(act)} not expected to match #{Assert::U.show(exp)}."
       end
     end
     alias_method :refute_match, :assert_not_match
     alias_method :assert_no_match, :assert_not_match
 
     def assert_nil(object, desc=nil)
-      assert(object.nil?, desc){ "Expected nil, not #{Assert::U.pp(object)}." }
+      assert(object.nil?, desc){ "Expected nil, not #{Assert::U.show(object)}." }
     end
 
     def assert_not_nil(object, desc=nil)
-      assert(!object.nil?, desc){ "Expected #{Assert::U.pp(object)} to not be nil." }
+      assert(!object.nil?, desc){ "Expected #{Assert::U.show(object)} to not be nil." }
     end
     alias_method :refute_nil, :assert_not_nil
 
@@ -136,31 +136,31 @@ module Assert
 
     def assert_respond_to(method, object, desc=nil)
       assert(object.respond_to?(method), desc) do
-        "Expected #{Assert::U.pp(object)} (#{object.class}) to respond to `#{method}`."
+        "Expected #{Assert::U.show(object)} (#{object.class}) to respond to `#{method}`."
       end
     end
     alias_method :assert_responds_to, :assert_respond_to
 
     def assert_not_respond_to(method, object, desc=nil)
       assert(!object.respond_to?(method), desc) do
-        "#{Assert::U.pp(object)} (#{object.class}) not expected to respond to `#{method}`."
+        "#{Assert::U.show(object)} (#{object.class}) not expected to respond to `#{method}`."
       end
     end
     alias_method :assert_not_responds_to, :assert_not_respond_to
     alias_method :refute_respond_to, :assert_not_respond_to
     alias_method :refute_responds_to, :assert_not_respond_to
 
-    def assert_same(expected, actual, desc=nil)
-      assert(actual.equal?(expected), desc) do
-        "Expected #{Assert::U.pp(actual)} (#{actual.object_id})"\
-        " to be the same as #{Assert::U.pp(expected)} (#{expected.object_id})."
+    def assert_same(exp, act, desc=nil)
+      assert(act.equal?(exp), desc) do
+        "Expected #{Assert::U.show(act)} (#{act.object_id})"\
+        " to be the same as #{Assert::U.show(exp)} (#{exp.object_id})."
       end
     end
 
-    def assert_not_same(expected, actual, desc=nil)
-      assert(!actual.equal?(expected), desc) do
-        "#{Assert::U.pp(actual)} (#{actual.object_id})"\
-        " not expected to be the same as #{Assert::U.pp(expected)} (#{expected.object_id})."
+    def assert_not_same(exp, act, desc=nil)
+      assert(!act.equal?(exp), desc) do
+        "#{Assert::U.show(act)} (#{act.object_id})"\
+        " not expected to be the same as #{Assert::U.show(exp)} (#{exp.object_id})."
       end
     end
     alias_method :refute_same, :assert_not_same

--- a/lib/assert/cli.rb
+++ b/lib/assert/cli.rb
@@ -25,6 +25,7 @@ module Assert
     end
 
     def initialize(*args)
+      @args = args
       @cli = CLIRB.new do
         option 'runner_seed', 'Use a given seed to run tests', {
           :abbrev => 's', :value => Fixnum
@@ -38,14 +39,17 @@ module Assert
         option 'changed_only', 'only run test files with changes', {
           :abbrev => 'c'
         }
+        option 'pp_objects', 'pretty-print objects in fail messages', {
+          :abbrev => 'p'
+        }
         # show loaded test files, cli err backtraces, etc
         option 'debug', 'run in debug mode'
       end
-      @cli.parse!(args)
     end
 
     def run
       begin
+        @cli.parse!(@args)
         Assert::AssertRunner.new(@cli.args, @cli.opts).run
       rescue CLIRB::HelpExit
         puts help

--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -179,7 +179,7 @@ module Assert
       if assertion
         pass
       else
-        what = block_given? ? yield : "Failed assert: assertion was `#{Assert::U.pp(assertion)}`."
+        what = block_given? ? yield : "Failed assert: assertion was `#{Assert::U.show(assertion)}`."
         fail(fail_message(desc, what))
       end
     end
@@ -187,7 +187,7 @@ module Assert
     # the opposite of assert, check if the assertion is a false value, if so create a new pass
     # result, otherwise create a new fail result with the desc and it's what failed msg
     def assert_not(assertion, fail_desc = nil)
-      assert(!assertion, fail_desc){ "Failed assert_not: assertion was `#{Assert::U.pp(assertion)}`." }
+      assert(!assertion, fail_desc){ "Failed assert_not: assertion was `#{Assert::U.show(assertion)}`." }
     end
     alias_method :refute, :assert_not
 

--- a/lib/assert/utils.rb
+++ b/lib/assert/utils.rb
@@ -4,10 +4,20 @@ module Assert
 
   module Utils
 
-    def self.pp(input)
-      output = Assert.config.pp_processor.to_proc.call(input)
-      output = output.encode(Encoding.default_external) if defined?(Encoding)
-      output
+    # show objects in a human-readable manner.  Either inspects or pretty-prints
+    # them depending on settings.
+
+    def self.show(obj)
+      out = Assert.config.pp_objects ? Assert.config.pp_proc.call(obj) : obj.inspect
+      out = out.encode(Encoding.default_external) if defined?(Encoding)
+      out
+    end
+
+    # Get a proc that uses stdlib `PP.pp` to pretty print objects
+
+    def self.stdlib_pp_proc(width = nil)
+      require 'pp'
+      Proc.new{ |obj| "\n#{PP.pp(obj, '', width || 79).strip}\n" }
     end
 
   end

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -1,7 +1,9 @@
 require 'assert'
+
 require 'assert/view/default_view'
 require 'assert/runner'
 require 'assert/suite'
+require 'assert/utils'
 
 module Assert
 
@@ -31,9 +33,9 @@ module Assert
     subject { Config }
 
     should have_imeths :suite, :view, :runner, :test_dir, :test_helper, :changed_files
-    should have_imeths :runner_seed, :pp_processor
-    should have_imeths :capture_output, :halt_on_fail, :changed_only, :debug
-    should have_imeths :apply
+    should have_imeths :runner_seed, :pp_proc
+    should have_imeths :capture_output, :halt_on_fail, :changed_only, :pp_objects
+    should have_imeths :debug, :apply
 
     should "default the view, suite, and runner" do
       assert_kind_of Assert::View::DefaultView, subject.view
@@ -41,9 +43,9 @@ module Assert
       assert_kind_of Assert::Runner, subject.runner
     end
 
-    should "default the optional settings" do
+    should "default the optional values" do
       assert_not_nil subject.runner_seed
-      assert_equal :inspect, subject.pp_processor
+      assert_not_nil subject.pp_proc
     end
 
   end

--- a/test/unit/assertions/assert_empty_tests.rb
+++ b/test/unit/assertions/assert_empty_tests.rb
@@ -25,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.pp(@args[0])} to be empty."
+      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0])} to be empty."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -51,7 +51,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.pp(@args[0])} to not be empty."
+      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0])} to not be empty."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_equal_tests.rb
+++ b/test/unit/assertions/assert_equal_tests.rb
@@ -25,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{Assert::U.pp(@args[0])}, not #{Assert::U.pp(@args[1])}."
+      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[0])}, not #{Assert::U.show(@args[1])}."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -52,7 +52,7 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "#{Assert::U.pp(@args[1])} not expected to equal #{Assert::U.pp(@args[0])}."
+            "#{Assert::U.show(@args[1])} not expected to equal #{Assert::U.show(@args[0])}."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_file_exists_tests.rb
+++ b/test/unit/assertions/assert_file_exists_tests.rb
@@ -25,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.pp(@args[0])} to exist."
+      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0])} to exist."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -51,7 +51,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.pp(@args[0])} to not exist."
+      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0])} to not exist."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_includes_tests.rb
+++ b/test/unit/assertions/assert_includes_tests.rb
@@ -26,7 +26,7 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "Expected #{Assert::U.pp(@args[1])} to include #{Assert::U.pp(@args[0])}."
+            "Expected #{Assert::U.show(@args[1])} to include #{Assert::U.show(@args[0])}."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -53,7 +53,7 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "Expected #{Assert::U.pp(@args[1])} to not include #{Assert::U.pp(@args[0])}."
+            "Expected #{Assert::U.show(@args[1])} to not include #{Assert::U.show(@args[0])}."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_instance_of_tests.rb
+++ b/test/unit/assertions/assert_instance_of_tests.rb
@@ -25,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{Assert::U.pp(@args[1])} (#{@args[1].class}) to"\
+      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1])} (#{@args[1].class}) to"\
             " be an instance of #{@args[0]}."
       assert_equal exp, subject.fail_results.first.message
     end
@@ -52,7 +52,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n#{Assert::U.pp(@args[1])} (#{@args[1].class}) not expected to"\
+      exp = "#{@args[2]}\n#{Assert::U.show(@args[1])} (#{@args[1].class}) not expected to"\
             " be an instance of #{@args[0]}."
       assert_equal exp, subject.fail_results.first.message
     end

--- a/test/unit/assertions/assert_kind_of_tests.rb
+++ b/test/unit/assertions/assert_kind_of_tests.rb
@@ -25,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{Assert::U.pp(@args[1])} (#{@args[1].class}) to"\
+      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1])} (#{@args[1].class}) to"\
             " be a kind of #{@args[0]}."
       assert_equal exp, subject.fail_results.first.message
     end
@@ -52,7 +52,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n#{Assert::U.pp(@args[1])} not expected to be a kind of #{@args[0]}."
+      exp = "#{@args[2]}\n#{Assert::U.show(@args[1])} not expected to be a kind of #{@args[0]}."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_match_tests.rb
+++ b/test/unit/assertions/assert_match_tests.rb
@@ -25,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{Assert::U.pp(@args[1])} to match #{Assert::U.pp(@args[0])}."
+      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1])} to match #{Assert::U.show(@args[0])}."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -51,7 +51,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n#{Assert::U.pp(@args[1])} not expected to match #{Assert::U.pp(@args[0])}."
+      exp = "#{@args[2]}\n#{Assert::U.show(@args[1])} not expected to match #{Assert::U.show(@args[0])}."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_nil_tests.rb
+++ b/test/unit/assertions/assert_nil_tests.rb
@@ -25,7 +25,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected nil, not #{Assert::U.pp(@args[0])}."
+      exp = "#{@args[1]}\nExpected nil, not #{Assert::U.show(@args[0])}."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -51,7 +51,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.pp(@args[0])} to not be nil."
+      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0])} to not be nil."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_respond_to_tests.rb
+++ b/test/unit/assertions/assert_respond_to_tests.rb
@@ -26,7 +26,7 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "Expected #{Assert::U.pp(@args[1])} (#{@args[1].class})"\
+            "Expected #{Assert::U.show(@args[1])} (#{@args[1].class})"\
             " to respond to `#{@args[0]}`."
       assert_equal exp, subject.fail_results.first.message
     end
@@ -54,7 +54,7 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "#{Assert::U.pp(@args[1])} (#{@args[1].class})"\
+            "#{Assert::U.show(@args[1])} (#{@args[1].class})"\
             " not expected to respond to `#{@args[0]}`."
       assert_equal exp, subject.fail_results.first.message
     end

--- a/test/unit/assertions/assert_same_tests.rb
+++ b/test/unit/assertions/assert_same_tests.rb
@@ -27,8 +27,8 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "Expected #{Assert::U.pp(@args[1])} (#{@args[1].object_id})"\
-            " to be the same as #{Assert::U.pp(@args[0])} (#{@args[0].object_id})."
+            "Expected #{Assert::U.show(@args[1])} (#{@args[1].object_id})"\
+            " to be the same as #{Assert::U.show(@args[0])} (#{@args[0].object_id})."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -56,8 +56,8 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "#{Assert::U.pp(@args[1])} (#{@args[1].object_id}) not expected"\
-            " to be the same as #{Assert::U.pp(@args[0])} (#{@args[0].object_id})."
+            "#{Assert::U.show(@args[1])} (#{@args[1].object_id}) not expected"\
+            " to be the same as #{Assert::U.show(@args[0])} (#{@args[0].object_id})."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -158,7 +158,7 @@ class Assert::Context
     end
 
     should "pp the assertion value in the fail message by default" do
-      exp_default_what = "Failed assert: assertion was `#{Assert::U.pp(false)}`."
+      exp_default_what = "Failed assert: assertion was `#{Assert::U.show(false)}`."
       result = subject.assert(false, @fail_desc)
 
       assert_equal [@fail_desc, exp_default_what].join("\n"), result.message
@@ -197,7 +197,7 @@ class Assert::Context
     end
 
     should "pp the assertion value in the fail message by default" do
-      exp_default_what = "Failed assert_not: assertion was `#{Assert::U.pp(true)}`."
+      exp_default_what = "Failed assert_not: assertion was `#{Assert::U.show(true)}`."
       result = subject.assert_not(true, @fail_desc)
 
       assert_equal [@fail_desc, exp_default_what].join("\n"), result.message

--- a/test/unit/utils_tests.rb
+++ b/test/unit/utils_tests.rb
@@ -5,31 +5,52 @@ module Assert::Utils
 
   class UnitTests < Assert::Context
     desc "Assert::Utils"
+    setup do
+      @objs = [ 1, 'hi there', Hash.new, [:a, :b]]
+    end
     subject{ Assert::Utils }
 
-    should have_imeths :pp
+    should have_imeths :show, :stdlib_pp_proc
+
+    should "build a pp proc that uses stdlib `PP.pp` to pretty print objects" do
+      exp_obj_pps = @objs.map{ |o| "\n#{PP.pp(o, '', 79).strip}\n" }
+      act_obj_pps = @objs.map{ |o| subject.stdlib_pp_proc.call(o) }
+      assert_equal exp_obj_pps, act_obj_pps
+
+      cust_width = 1
+      exp_obj_pps = @objs.map{ |o| "\n#{PP.pp(o, '', cust_width).strip}\n" }
+      act_obj_pps = @objs.map{ |o| subject.stdlib_pp_proc(cust_width).call(o) }
+      assert_equal exp_obj_pps, act_obj_pps
+    end
 
   end
 
-  class PrettyPrintTests < UnitTests
-    desc "`pp`"
+  class ShowTests < UnitTests
+    desc "`show`"
     setup do
-      @inputs = [ 1, 'hi there', Hash.new, [:a, :b]]
-      @default_processor = Assert.config.pp_processor
-      @new_processor = Proc.new{ |input| 'herp derp' }
+      @orig_pp_objs = Assert.config.pp_objects
+      @orig_pp_proc = Assert.config.pp_proc
+      @new_pp_proc  = Proc.new{ |input| 'herp derp' }
     end
     teardown do
-      Assert.config.pp_processor(@default_processor)
+      Assert.config.pp_proc(@orig_pp_proc)
+      Assert.config.pp_objects(@orig_pp_objs)
     end
 
-    should "process its given input and encode if available" do
-      @inputs.each do |input|
-        assert_equal @default_processor.to_proc.call(input), subject.pp(input)
-      end
+    should "use `inspect` to show objs when `pp_objects` setting is false" do
+      Assert.config.pp_objects(false)
 
-      Assert.config.pp_processor(@new_processor)
-      @inputs.each do |input|
-        assert_equal @new_processor.to_proc.call(input), subject.pp(input)
+      @objs.each do |obj|
+        assert_equal obj.inspect, subject.show(obj)
+      end
+    end
+
+    should "use `pp_proc` to show objs when `pp_objects` setting is true" do
+      Assert.config.pp_objects(true)
+      Assert.config.pp_proc(@new_pp_proc)
+
+      @objs.each do |obj|
+        assert_equal @new_pp_proc.call(obj), subject.show(obj)
       end
     end
 


### PR DESCRIPTION
As opposed to default way of using `inspect` to show them.  Control
this mode using a config setting (`pp_objects`) or a CLI flag (`-p`).
Uses the stdlib's `PP.pp` to do the pretty-printing by default.  Pass
a custom proc to `Assert.config.pp_proc` to get custom pretty printing
(ie awesome_print, etc).

This is to help with analyzing fails on objects that are very complex
(large text chunks, objects with unfriendly inspects, hashes, arrays,
etc).  This also preps for using `diff` output in `assert_equal` fail
messages.

Related to #144.

@jcredding ready for review.
