### PR TITLE
include diffs in `assert_equal` fail message output

### DIFF
--- a/lib/assert.rb
+++ b/lib/assert.rb
@@ -34,7 +34,7 @@ module Assert
     end
 
     settings :view, :suite, :runner, :test_dir, :test_helper, :changed_files
-    settings :runner_seed, :pp_proc
+    settings :runner_seed, :pp_proc, :use_diff_proc, :run_diff_proc
     settings :capture_output, :halt_on_fail, :changed_only, :pp_objects, :debug
 
     def initialize
@@ -46,8 +46,10 @@ module Assert
       @changed_files = Assert::AssertRunner::DEFAULT_CHANGED_FILES_PROC
 
       # default option values
-      @runner_seed = begin; srand; srand % 0xFFFF; end.to_i
-      @pp_proc     = Assert::U.stdlib_pp_proc
+      @runner_seed   = begin; srand; srand % 0xFFFF; end.to_i
+      @pp_proc       = Assert::U.stdlib_pp_proc
+      @use_diff_proc = Assert::U.default_use_diff_proc
+      @run_diff_proc = Assert::U.syscmd_diff_proc
 
       # mode flags
       @capture_output = false

--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -28,13 +28,29 @@ module Assert
 
     def assert_equal(exp, act, desc = nil)
       assert(act == exp, desc) do
-        "Expected #{Assert::U.show(exp)}, not #{Assert::U.show(act)}."
+        exp_show = Assert::U.show_for_diff(exp)
+        act_show = Assert::U.show_for_diff(act)
+
+        if Assert.config.use_diff_proc.call(exp_show, act_show)
+          "Expected does not equal actual, diff:\n"\
+          "#{Assert.config.run_diff_proc.call(exp_show, act_show)}"
+        else
+          "Expected #{Assert::U.show(exp)}, not #{Assert::U.show(act)}."
+        end
       end
     end
 
     def assert_not_equal(exp, act, desc = nil)
       assert(act != exp, desc) do
-        "#{Assert::U.show(act)} not expected to equal #{Assert::U.show(exp)}."
+        exp_show = Assert::U.show_for_diff(exp)
+        act_show = Assert::U.show_for_diff(act)
+
+        if Assert.config.use_diff_proc.call(exp_show, act_show)
+          "Expected equals actual, diff:\n"\
+          "#{Assert.config.run_diff_proc.call(exp_show, act_show)}"
+        else
+          "#{Assert::U.show(act)} not expected to equal #{Assert::U.show(exp)}."
+        end
       end
     end
     alias_method :refute_equal, :assert_not_equal

--- a/lib/assert/utils.rb
+++ b/lib/assert/utils.rb
@@ -13,11 +13,53 @@ module Assert
       out
     end
 
+    # show objects in a human-readable manner and make the output diff-able. This
+    # expands on the basic `show` util by escaping newlines and making object id
+    # hex-values generic.
+
+    def self.show_for_diff(obj)
+      show(obj).gsub(/\\n/, "\n").gsub(/:0x[a-fA-F0-9]{4,}/m, ':0xXXXXXX')
+    end
+
+    # open a tempfile and yield it
+
+    def self.tempfile(name, content)
+      require "tempfile"
+      Tempfile.open(name) do |tmpfile|
+        tmpfile.puts(content); tmpfile.flush
+        yield tmpfile if block_given?
+      end
+    end
+
     # Get a proc that uses stdlib `PP.pp` to pretty print objects
 
     def self.stdlib_pp_proc(width = nil)
       require 'pp'
       Proc.new{ |obj| "\n#{PP.pp(obj, '', width || 79).strip}\n" }
+    end
+
+    # Return true if if either show output has newlines or is bigger than 29 chars
+
+    def self.default_use_diff_proc
+      Proc.new do |exp_show_output, act_show_output|
+        exp_show_output.include?("\n") || exp_show_output.size > 29 ||
+        act_show_output.include?("\n") || act_show_output.size > 29
+      end
+    end
+
+    def self.syscmd_diff_proc(syscmd = "diff --unified=-1")
+      Proc.new do |exp_show_output, act_show_output|
+        result = ""
+        tempfile('exp_show_output', exp_show_output) do |a|
+          tempfile('act_show_output', act_show_output) do |b|
+            result = `#{syscmd} #{a.path} #{b.path}`
+            result.sub!(/^\-\-\- .+/, "--- expected")
+            result.sub!(/^\+\+\+ .+/, "+++ actual")
+            result = "--- expected\n+++ actual" if result.empty?
+          end
+        end
+        result
+      end
     end
 
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,7 +2,8 @@
 # put any test helpers here
 
 # add the root dir to the load path
-$LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
+ROOT_PATH = File.expand_path("../..", __FILE__)
+$LOAD_PATH.unshift(ROOT_PATH)
 
 # require pry for debugging (`binding.pry`)
 require 'pry'

--- a/test/support/diff_a.txt
+++ b/test/support/diff_a.txt
@@ -1,0 +1,3 @@
+This is a file
+  that is being
+diff'd.

--- a/test/support/diff_b.txt
+++ b/test/support/diff_b.txt
@@ -1,0 +1,3 @@
+This is a file
+  that will be
+diff'd.

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -33,7 +33,7 @@ module Assert
     subject { Config }
 
     should have_imeths :suite, :view, :runner, :test_dir, :test_helper, :changed_files
-    should have_imeths :runner_seed, :pp_proc
+    should have_imeths :runner_seed, :pp_proc, :use_diff_proc, :run_diff_proc
     should have_imeths :capture_output, :halt_on_fail, :changed_only, :pp_objects
     should have_imeths :debug, :apply
 
@@ -46,6 +46,8 @@ module Assert
     should "default the optional values" do
       assert_not_nil subject.runner_seed
       assert_not_nil subject.pp_proc
+      assert_not_nil subject.use_diff_proc
+      assert_not_nil subject.run_diff_proc
     end
 
   end

--- a/test/unit/assertions/assert_equal_tests.rb
+++ b/test/unit/assertions/assert_equal_tests.rb
@@ -6,7 +6,7 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertEqualTests < Assert::Context
-    desc "the assert_equal helper"
+    desc "`assert_equal`"
     setup do
       desc = @desc = "assert equal fail desc"
       args = @args = [ '1', '2', desc ]
@@ -32,7 +32,7 @@ module Assert::Assertions
   end
 
   class AssertNotEqualTests < Assert::Context
-    desc "the assert_not_equal helper"
+    desc "`assert_not_equal`"
     setup do
       desc = @desc = "assert not equal fail desc"
       args = @args = [ '1', '1', desc ]
@@ -53,6 +53,66 @@ module Assert::Assertions
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
             "#{Assert::U.show(@args[1])} not expected to equal #{Assert::U.show(@args[0])}."
+      assert_equal exp, subject.fail_results.first.message
+    end
+
+  end
+
+  class DiffTests < Assert::Context
+    desc "with objects that should use diff when showing"
+    setup do
+      @exp_obj = "I'm a\nstring"
+      @act_obj = "I am a \nstring"
+
+      @exp_obj_show = Assert::U.show_for_diff(@exp_obj)
+      @act_obj_show = Assert::U.show_for_diff(@act_obj)
+
+      @orig_use_diff_proc = Assert.config.use_diff_proc
+      @orig_run_diff_proc = Assert.config.run_diff_proc
+
+      Assert.config.use_diff_proc(Assert::U.default_use_diff_proc)
+      Assert.config.run_diff_proc(Assert::U.syscmd_diff_proc)
+    end
+    teardown do
+      Assert.config.use_diff_proc(@orig_use_diff_proc)
+      Assert.config.run_diff_proc(@orig_run_diff_proc)
+    end
+
+  end
+
+  class AssertEqualDiffTests < DiffTests
+    desc "`assert_equal`"
+    setup do
+      exp_obj, act_obj = @exp_obj, @act_obj
+      @test = Factory.test do
+        assert_equal(exp_obj, act_obj)
+      end
+      @test.run
+    end
+    subject{ @test }
+
+    should "include diff output in the fail messages" do
+      exp = "Expected does not equal actual, diff:\n"\
+            "#{Assert::U.syscmd_diff_proc.call(@exp_obj_show, @act_obj_show)}"
+      assert_equal exp, subject.fail_results.first.message
+    end
+
+  end
+
+  class AssertNotEqualDiffTests < DiffTests
+    desc "`assert_not_equal`"
+    setup do
+      exp_obj, act_obj = @exp_obj, @act_obj
+      @test = Factory.test do
+        assert_not_equal(exp_obj, exp_obj)
+      end
+      @test.run
+    end
+    subject{ @test }
+
+    should "include diff output in the fail messages" do
+      exp = "Expected equals actual, diff:\n"\
+            "#{Assert::U.syscmd_diff_proc.call(@exp_obj_show, @exp_obj_show)}"
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/utils_tests.rb
+++ b/test/unit/utils_tests.rb
@@ -1,27 +1,20 @@
 require 'assert'
 require 'assert/utils'
 
+require 'tempfile'
+
 module Assert::Utils
 
   class UnitTests < Assert::Context
     desc "Assert::Utils"
+    subject{ Assert::Utils }
     setup do
       @objs = [ 1, 'hi there', Hash.new, [:a, :b]]
     end
-    subject{ Assert::Utils }
 
-    should have_imeths :show, :stdlib_pp_proc
-
-    should "build a pp proc that uses stdlib `PP.pp` to pretty print objects" do
-      exp_obj_pps = @objs.map{ |o| "\n#{PP.pp(o, '', 79).strip}\n" }
-      act_obj_pps = @objs.map{ |o| subject.stdlib_pp_proc.call(o) }
-      assert_equal exp_obj_pps, act_obj_pps
-
-      cust_width = 1
-      exp_obj_pps = @objs.map{ |o| "\n#{PP.pp(o, '', cust_width).strip}\n" }
-      act_obj_pps = @objs.map{ |o| subject.stdlib_pp_proc(cust_width).call(o) }
-      assert_equal exp_obj_pps, act_obj_pps
-    end
+    should have_imeths :show, :show_for_diff
+    should have_imeths :tempfile
+    should have_imeths :stdlib_pp_proc, :default_use_diff_proc, :syscmd_diff_proc
 
   end
 
@@ -52,6 +45,108 @@ module Assert::Utils
       @objs.each do |obj|
         assert_equal @new_pp_proc.call(obj), subject.show(obj)
       end
+    end
+
+  end
+
+  class ShowForDiffTests < UnitTests
+    desc "`show_for_diff`"
+    setup do
+      @w_newlines = { :string => "herp derp, derp herp\nherpderpedia" }
+      @w_obj_id = Struct.new(:a, :b).new('aye', 'bee')
+    end
+
+    should "call show, escaping newlines" do
+      exp_out = "{:string=>\"herp derp, derp herp\nherpderpedia\"}"
+      assert_equal exp_out, subject.show_for_diff(@w_newlines)
+    end
+
+    should "make any obj ids generic" do
+      exp_out = "#<struct #<Class:0xXXXXXX> a=\"aye\", b=\"bee\">"
+      assert_equal exp_out, subject.show_for_diff(@w_obj_id)
+    end
+
+  end
+
+  class TempfileTests < UnitTests
+    desc "`tempfile`"
+
+    should "require tempfile, open a tempfile, write the given content, and yield it" do
+      subject.tempfile('a-name', 'some-content') do |tmpfile|
+        assert_equal false, (require 'tempfile')
+        assert tmpfile
+        assert_kind_of Tempfile, tmpfile
+
+        tmpfile.pos = 0
+        assert_equal "some-content\n", tmpfile.read
+      end
+    end
+
+  end
+
+  class StdlibPpProcTests < UnitTests
+    desc "`stdlib_pp_proc`"
+
+    should "build a pp proc that uses stdlib `PP.pp` to pretty print objects" do
+      exp_obj_pps = @objs.map{ |o| "\n#{PP.pp(o, '', 79).strip}\n" }
+      act_obj_pps = @objs.map{ |o| subject.stdlib_pp_proc.call(o) }
+      assert_equal exp_obj_pps, act_obj_pps
+
+      cust_width = 1
+      exp_obj_pps = @objs.map{ |o| "\n#{PP.pp(o, '', cust_width).strip}\n" }
+      act_obj_pps = @objs.map{ |o| subject.stdlib_pp_proc(cust_width).call(o) }
+      assert_equal exp_obj_pps, act_obj_pps
+    end
+
+  end
+
+  class DefaultUseDiffProcTests < UnitTests
+    desc "`default_use_diff_proc`"
+    setup do
+      @longer = "i am a really long string output; use diff when working with me"
+      @newlines = "i have\n newlines"
+    end
+
+    should "be true if either output has newlines or is bigger than 29 chars" do
+      proc = subject.default_use_diff_proc
+
+      assert_not proc.call('', '')
+      assert proc.call(@longer, '')
+      assert proc.call(@newlines, '')
+      assert proc.call('', @longer)
+      assert proc.call('', @newlines)
+      assert proc.call(@longer, @newlines)
+    end
+
+  end
+
+  class SyscmdDiffProc < UnitTests
+    desc "`syscmd_diff_proc`"
+    setup do
+      @diff_a_file = File.join(ROOT_PATH, 'test/support/diff_a.txt')
+      @diff_b_file = File.join(ROOT_PATH, 'test/support/diff_b.txt')
+
+      @diff_a = File.read(@diff_a_file)
+      @diff_b = File.read(@diff_b_file)
+    end
+
+    should "use the diff syscmd to output the diff between the exp/act show output" do
+      exp_diff_out = `diff --unified=-1 #{@diff_a_file} #{@diff_b_file}`.tap do |out|
+        out.sub!(/^\-\-\- .+/, "--- expected")
+        out.sub!(/^\+\+\+ .+/, "+++ actual")
+      end
+
+      assert_equal exp_diff_out, subject.syscmd_diff_proc.call(@diff_a, @diff_b)
+    end
+
+    should "allow you to specify a custom syscmd" do
+      cust_syscmd = 'diff'
+      exp_diff_out = `#{cust_syscmd} #{@diff_a_file} #{@diff_b_file}`.tap do |out|
+        out.sub!(/^\-\-\- .+/, "--- expected")
+        out.sub!(/^\+\+\+ .+/, "+++ actual")
+      end
+
+      assert_equal exp_diff_out, subject.syscmd_diff_proc(cust_syscmd).call(@diff_a, @diff_b)
     end
 
   end


### PR DESCRIPTION
This adds utilities/behavior to use diff output (when appropriate)
in `assert_equal` fail messages.

All of the behavior is customizable.  Set a custom `use_diff_proc`
config value to control the conditions when diff output is used.
By default, `use_diff_proc` is set to the `default_use_diff_proc`
util which is true when either show output has newlines or is larger
than 29 chars. Set a custom `run_diff_proc` config value to customize
how the diff is generated.  By default `run_diff_proc` uses the
`syscmd_diff_proc` util which used the `diff --unified=-1` syscmd
to generate the diff output.

Diff output works with both standard and pretty print output.

Closes #144.

@jcredding ready for review
