### PR TITLE
remove superfulous newlines from diff/pp output

### DIFF
--- a/lib/assert/utils.rb
+++ b/lib/assert/utils.rb
@@ -35,7 +35,7 @@ module Assert
 
     def self.stdlib_pp_proc(width = nil)
       require 'pp'
-      Proc.new{ |obj| "\n#{PP.pp(obj, '', width || 79).strip}\n" }
+      Proc.new{ |obj| PP.pp(obj, '', width || 79).strip }
     end
 
     # Return true if if either show output has newlines or is bigger than 29 chars
@@ -52,7 +52,7 @@ module Assert
         result = ""
         tempfile('exp_show_output', exp_show_output) do |a|
           tempfile('act_show_output', act_show_output) do |b|
-            result = `#{syscmd} #{a.path} #{b.path}`
+            result = `#{syscmd} #{a.path} #{b.path}`.strip
             result.sub!(/^\-\-\- .+/, "--- expected")
             result.sub!(/^\+\+\+ .+/, "+++ actual")
             result = "--- expected\n+++ actual" if result.empty?

--- a/test/unit/utils_tests.rb
+++ b/test/unit/utils_tests.rb
@@ -24,6 +24,7 @@ module Assert::Utils
       @orig_pp_objs = Assert.config.pp_objects
       @orig_pp_proc = Assert.config.pp_proc
       @new_pp_proc  = Proc.new{ |input| 'herp derp' }
+      Assert.config.pp_objects(false)
     end
     teardown do
       Assert.config.pp_proc(@orig_pp_proc)
@@ -31,8 +32,6 @@ module Assert::Utils
     end
 
     should "use `inspect` to show objs when `pp_objects` setting is false" do
-      Assert.config.pp_objects(false)
-
       @objs.each do |obj|
         assert_equal obj.inspect, subject.show(obj)
       end
@@ -49,7 +48,7 @@ module Assert::Utils
 
   end
 
-  class ShowForDiffTests < UnitTests
+  class ShowForDiffTests < ShowTests
     desc "`show_for_diff`"
     setup do
       @w_newlines = { :string => "herp derp, derp herp\nherpderpedia" }
@@ -88,12 +87,12 @@ module Assert::Utils
     desc "`stdlib_pp_proc`"
 
     should "build a pp proc that uses stdlib `PP.pp` to pretty print objects" do
-      exp_obj_pps = @objs.map{ |o| "\n#{PP.pp(o, '', 79).strip}\n" }
+      exp_obj_pps = @objs.map{ |o| PP.pp(o, '', 79).strip }
       act_obj_pps = @objs.map{ |o| subject.stdlib_pp_proc.call(o) }
       assert_equal exp_obj_pps, act_obj_pps
 
       cust_width = 1
-      exp_obj_pps = @objs.map{ |o| "\n#{PP.pp(o, '', cust_width).strip}\n" }
+      exp_obj_pps = @objs.map{ |o| PP.pp(o, '', cust_width).strip }
       act_obj_pps = @objs.map{ |o| subject.stdlib_pp_proc(cust_width).call(o) }
       assert_equal exp_obj_pps, act_obj_pps
     end
@@ -131,7 +130,7 @@ module Assert::Utils
     end
 
     should "use the diff syscmd to output the diff between the exp/act show output" do
-      exp_diff_out = `diff --unified=-1 #{@diff_a_file} #{@diff_b_file}`.tap do |out|
+      exp_diff_out = `diff --unified=-1 #{@diff_a_file} #{@diff_b_file}`.strip.tap do |out|
         out.sub!(/^\-\-\- .+/, "--- expected")
         out.sub!(/^\+\+\+ .+/, "+++ actual")
       end
@@ -141,7 +140,7 @@ module Assert::Utils
 
     should "allow you to specify a custom syscmd" do
       cust_syscmd = 'diff'
-      exp_diff_out = `#{cust_syscmd} #{@diff_a_file} #{@diff_b_file}`.tap do |out|
+      exp_diff_out = `#{cust_syscmd} #{@diff_a_file} #{@diff_b_file}`.strip.tap do |out|
         out.sub!(/^\-\-\- .+/, "--- expected")
         out.sub!(/^\+\+\+ .+/, "+++ actual")
       end


### PR DESCRIPTION
This preserves the default view having no newlines in the output of
each fail result.  Newlines can be viewed as "separating" fail result
output in the default view.

This is just a cleanup from the previous diff and pretty-print output
work based on real usage.

@jcredding ready for review.
