### PR TITLE
`Factory.test` now takes "flexible" args

### DIFF
--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -29,7 +29,7 @@ module Assert
         end
 
         ci = Suite::ContextInfo.new(self, nil, caller.first)
-        Assert.suite.tests << Test.new(method_name.to_s, ci, method_name)
+        Assert.suite.tests << Test.new(method_name.to_s, ci, :code => method_name)
       end
     end
 

--- a/lib/assert/test.rb
+++ b/lib/assert/test.rb
@@ -10,10 +10,12 @@ module Assert
     attr_reader :name, :code, :context_info
     attr_accessor :results, :output
 
-    def initialize(name, suite_context_info, code = nil, &block)
+    def initialize(name, suite_context_info, opts = nil, &block)
       @context_info = suite_context_info
       @name = name_from_context(name)
-      @code = (code || block)
+
+      o = opts || {}
+      @code = (o[:code] || block || Proc.new{})
       @results = Result::Set.new
       @output = ""
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,6 +7,7 @@ $LOAD_PATH.unshift(ROOT_PATH)
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
+require 'test/support/factory'
 
 # Force tests to run without halting on failures (needed so all tests will run
 # properly).  For halt on fail behavior testing, the context of those tests
@@ -54,50 +55,7 @@ class TestContext < Assert::Context
   def self.method_added(meth)
     if meth.to_s =~ Assert::Suite::TEST_METHOD_REGEX
       ci = Assert::Suite::ContextInfo.new(self, Factory.context_info_called_from)
-      TEST_ASSERT_SUITE.tests << Assert::Test.new(meth.to_s, ci, meth)
+      TEST_ASSERT_SUITE.tests << Assert::Test.new(meth.to_s, ci, :code => meth)
     end
   end
-end
-
-module Factory
-
-  def self.context_info_called_from
-    "/path/to_file.rb:1234"
-  end
-
-  def self.context_info(context_class)
-    Assert::Suite::ContextInfo.new(context_class, context_info_called_from)
-  end
-
-  # Generate an anonymous `Context` inherited from `TestContext` by default.
-  # This provides a common interface for all contexts used in testing.
-
-  def self.context_class(inherit_from=nil, &block)
-    inherit_from ||= TestContext
-    klass = Class.new(inherit_from, &block)
-    default = (const_name = "FactoryAssertContext").dup
-
-    while(Object.const_defined?(const_name)) do
-      const_name = "FactoryAssertContext#{rand(Time.now.to_i)}"
-    end
-    Object.const_set(const_name, klass)
-    klass
-  end
-
-  # Generate a no-op test for use in testing.
-
-  def self.test(*args, &block)
-    name = (args[0] || "a test").to_s
-    context_info = args[1] || self.context_info(self.context_class)
-    test_block = (block || args[2] || ::Proc.new{})
-
-    Assert::Test.new(name, context_info, &test_block)
-  end
-
-  # Generate a skip result for use in testing.
-
-  def self.skip_result(name, exception)
-    Assert::Result::Skip.new(Factory.test(name), exception)
-  end
-
 end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,0 +1,44 @@
+module Factory
+
+  def self.context_info_called_from
+    "/path/to_file.rb:1234"
+  end
+
+  def self.context_info(context_klass = nil)
+    Assert::Suite::ContextInfo.new(context_klass || self.context_class, context_info_called_from)
+  end
+
+  # Generate an anonymous `Context` inherited from `TestContext` by default.
+  # This provides a common interface for all contexts used in testing.
+
+  def self.context_class(inherit_from=nil, &block)
+    inherit_from ||= TestContext
+    klass = Class.new(inherit_from, &block)
+    default = (const_name = "FactoryAssertContext").dup
+
+    while(Object.const_defined?(const_name)) do
+      const_name = "FactoryAssertContext#{rand(Time.now.to_i)}"
+    end
+    Object.const_set(const_name, klass)
+    klass
+  end
+
+  # Generate a no-op test for use in testing.
+
+  def self.test(*args, &block)
+    opts, context_info, name = [
+      args.last.kind_of?(::Hash) ? args.pop : {},
+      args.last.kind_of?(Assert::Suite::ContextInfo) ? args.pop : self.context_info,
+      args.last.kind_of?(::String) ? args.pop : 'a test'
+    ]
+
+    Assert::Test.new(name, context_info, opts, &block)
+  end
+
+  # Generate a skip result for use in testing.
+
+  def self.skip_result(name, exception)
+    Assert::Result::Skip.new(Factory.test(name), exception)
+  end
+
+end

--- a/test/unit/assertions/assert_equal_tests.rb
+++ b/test/unit/assertions/assert_equal_tests.rb
@@ -5,7 +5,18 @@ require 'assert/utils'
 
 module Assert::Assertions
 
-  class AssertEqualTests < Assert::Context
+  class AssertEqualUnitTests < Assert::Context
+    setup do
+      @orig_pp_objects = Assert.config.pp_objects
+      Assert.config.pp_objects(false)
+    end
+    teardown do
+      Assert.config.pp_objects(@orig_pp_objects)
+    end
+
+  end
+
+  class AssertEqualTests < AssertEqualUnitTests
     desc "`assert_equal`"
     setup do
       desc = @desc = "assert equal fail desc"
@@ -31,7 +42,7 @@ module Assert::Assertions
 
   end
 
-  class AssertNotEqualTests < Assert::Context
+  class AssertNotEqualTests < AssertEqualUnitTests
     desc "`assert_not_equal`"
     setup do
       desc = @desc = "assert not equal fail desc"
@@ -58,7 +69,7 @@ module Assert::Assertions
 
   end
 
-  class DiffTests < Assert::Context
+  class DiffTests < AssertEqualUnitTests
     desc "with objects that should use diff when showing"
     setup do
       @exp_obj = "I'm a\nstring"

--- a/test/unit/test_tests.rb
+++ b/test/unit/test_tests.rb
@@ -9,7 +9,7 @@ class Assert::Test
       @test_code = lambda{ assert(true) }
       @context_class = Factory.context_class{ desc "context class" }
       @context_info  = Factory.context_info(@context_class)
-      @test = Factory.test("should do something amazing", @context_info, @test_code)
+      @test = Factory.test("should do something amazing", @context_info, :code => @test_code)
     end
     teardown do
       TEST_ASSERT_SUITE.tests.clear

--- a/test/unit/utils_tests.rb
+++ b/test/unit/utils_tests.rb
@@ -51,8 +51,14 @@ module Assert::Utils
   class ShowForDiffTests < ShowTests
     desc "`show_for_diff`"
     setup do
+      @orig_pp_objects = Assert.config.pp_objects
+      Assert.config.pp_objects(false)
+
       @w_newlines = { :string => "herp derp, derp herp\nherpderpedia" }
       @w_obj_id = Struct.new(:a, :b).new('aye', 'bee')
+    end
+    teardown do
+      Assert.config.pp_objects(@orig_pp_objects)
     end
 
     should "call show, escaping newlines" do


### PR DESCRIPTION
Before the test factory expected rigid args to be passed.  It used
intelligent defaults but if one arg was needed to passed, they all
had to be.

This changes the factory to take whatever args it is given and
interpet them based on the value.  This allows you to pass only a
name or only a context info if you like.

To make this happen, I had to update the test `.new` signature to
take its optional values as a hash of options.  This gave me an
easy way to keep the factory and test signatures the same but have
a distinct value type to interpret on.  This also scales nicely
as I'll need to optionally inject a config object in to tests when
I change the config to no longer be a singleton.

Related to #154.

@jcredding ready for review.
