### PR TITLE
rename `changed_files` config setting to `changed_proc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ This, of course, assumes you are working in a git repository.  If you are not or
 
 ```ruby
 Assert.configure do |config|
-  config.changed_files do |test_paths|
+  config.changed_proc Proc.new do |test_paths|
     `git diff --name-only master -- #{test_paths.join(' ')}`.split("\n")  # or whatever
   end
 end
@@ -242,10 +242,10 @@ If you just want to disable this feature completely:
 Assert.configure do |config|
 
   # run nothing if the `-c` flag is given
-  config.changed_files{ |test_paths| [] }
+  config.changed_proc Proc.new{ |test_paths| [] }
 
   # run all test paths if the `-c` flag is given
-  config.changed_files{ |test_paths| test_paths }
+  config.changed_proc Proc.new{ |test_paths| test_paths }
 
 end
 ```

--- a/lib/assert.rb
+++ b/lib/assert.rb
@@ -1,6 +1,7 @@
 require 'singleton'
 require 'assert/version'
 
+require 'assert/config'
 require 'assert/utils'
 require 'assert/view'
 require 'assert/suite'
@@ -15,58 +16,5 @@ module Assert
 
   def self.config; Config; end
   def self.configure; yield Config if block_given?; end
-
-  class Config
-    include Singleton
-    # map any class methods to the singleton
-    def self.method_missing(m, *a, &b); self.instance.send(m, *a, &b); end
-    def self.respond_to?(m); super || self.instance.respond_to?(m); end
-
-    def self.settings(*items)
-      items.each do |item|
-        define_method(item) do |*args|
-          if !(value = args.size > 1 ? args : args.first).nil?
-            instance_variable_set("@#{item}", value)
-          end
-          instance_variable_get("@#{item}")
-        end
-      end
-    end
-
-    settings :view, :suite, :runner, :test_dir, :test_helper, :changed_files
-    settings :runner_seed, :pp_proc, :use_diff_proc, :run_diff_proc
-    settings :capture_output, :halt_on_fail, :changed_only, :pp_objects, :debug
-
-    def initialize
-      @view   = Assert::View::DefaultView.new($stdout)
-      @suite  = Assert::Suite.new
-      @runner = Assert::Runner.new
-      @test_dir    = "test"
-      @test_helper = "helper.rb"
-      @changed_files = Assert::AssertRunner::DEFAULT_CHANGED_FILES_PROC
-
-      # default option values
-      @runner_seed   = begin; srand; srand % 0xFFFF; end.to_i
-      @pp_proc       = Assert::U.stdlib_pp_proc
-      @use_diff_proc = Assert::U.default_use_diff_proc
-      @run_diff_proc = Assert::U.syscmd_diff_proc
-
-      # mode flags
-      @capture_output = false
-      @halt_on_fail   = true
-      @changed_only   = false
-      @pp_objects     = false
-      @debug          = false
-    end
-
-    def apply(settings)
-      settings.keys.each do |name|
-        if !settings[name].nil? && self.respond_to?(name.to_s)
-          self.send(name.to_s, settings[name])
-        end
-      end
-    end
-
-  end
 
 end

--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -89,7 +89,7 @@ module Assert
     end
 
     def changed_test_files(test_paths)
-      globbed_test_files(Assert.config.changed_files.call(test_paths))
+      globbed_test_files(Assert.config.changed_proc.call(test_paths))
     end
 
     def globbed_test_files(test_paths)

--- a/lib/assert/config.rb
+++ b/lib/assert/config.rb
@@ -1,0 +1,56 @@
+module Assert
+
+  class Config
+    include Singleton
+    # map any class methods to the singleton
+    def self.method_missing(m, *a, &b); self.instance.send(m, *a, &b); end
+    def self.respond_to?(m); super || self.instance.respond_to?(m); end
+
+    def self.settings(*items)
+      items.each do |item|
+        define_method(item) do |*args|
+          if !(value = args.size > 1 ? args : args.first).nil?
+            instance_variable_set("@#{item}", value)
+          end
+          instance_variable_get("@#{item}")
+        end
+      end
+    end
+
+    settings :view, :suite, :runner, :test_dir, :test_helper, :changed_proc
+    settings :runner_seed, :pp_proc, :use_diff_proc, :run_diff_proc
+    settings :capture_output, :halt_on_fail, :changed_only, :pp_objects, :debug
+
+    def initialize
+      @view   = Assert::View::DefaultView.new($stdout)
+      @suite  = Assert::Suite.new
+      @runner = Assert::Runner.new
+      @test_dir    = "test"
+      @test_helper = "helper.rb"
+      @changed_proc = Assert::AssertRunner::DEFAULT_CHANGED_FILES_PROC
+
+      # default option values
+      @runner_seed   = begin; srand; srand % 0xFFFF; end.to_i
+      @pp_proc       = Assert::U.stdlib_pp_proc
+      @use_diff_proc = Assert::U.default_use_diff_proc
+      @run_diff_proc = Assert::U.syscmd_diff_proc
+
+      # mode flags
+      @capture_output = false
+      @halt_on_fail   = true
+      @changed_only   = false
+      @pp_objects     = false
+      @debug          = false
+    end
+
+    def apply(settings)
+      settings.keys.each do |name|
+        if !settings[name].nil? && self.respond_to?(name.to_s)
+          self.send(name.to_s, settings[name])
+        end
+      end
+    end
+
+  end
+
+end

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -32,7 +32,7 @@ module Assert
     desc "the Assert Config singleton"
     subject { Config }
 
-    should have_imeths :suite, :view, :runner, :test_dir, :test_helper, :changed_files
+    should have_imeths :suite, :view, :runner, :test_dir, :test_helper, :changed_proc
     should have_imeths :runner_seed, :pp_proc, :use_diff_proc, :run_diff_proc
     should have_imeths :capture_output, :halt_on_fail, :changed_only, :pp_objects
     should have_imeths :debug, :apply


### PR DESCRIPTION
This is prep for having a non-singleton config handler.  This renames
the `changed_files` setting to make it be named more consistent with
the other proc settings.

This also moves the config class to its own file, again, in prep for
a non-singleton config.

Related to #154.

@jcredding ready for review.
