### PR TITLE
cleanup the old `class << self` method of adding context DSL methods

### DIFF
--- a/lib/assert/context/setup_dsl.rb
+++ b/lib/assert/context/setup_dsl.rb
@@ -1,0 +1,70 @@
+module Assert; end
+class Assert::Context
+
+  module SetupDSL
+
+    def setup_once(&block)
+      Assert.suite.setup(&block)
+    end
+    alias_method :before_once, :setup_once
+    alias_method :startup, :setup_once
+
+    def teardown_once(&block)
+      Assert.suite.teardown(&block)
+    end
+    alias_method :after_once, :teardown_once
+    alias_method :shutdown, :teardown_once
+
+    # Add a setup block to run before each test or run the list of teardown blocks in given scope
+    def setup(scope_or_method_name = nil, &block)
+      is_method = scope_or_method_name.kind_of?(String) || scope_or_method_name.kind_of?(Symbol)
+      if block_given? || is_method
+        # arg is a block or method that needs to be stored as a setup
+        self.setups << (block || scope_or_method_name)
+      elsif !is_method
+        # arg is an instance of this class (the scope for a test),
+        # run the setups for this context in the scope
+        scope = scope_or_method_name
+        # setup parent...
+        self.superclass.setup(scope) if self.superclass.respond_to?(:setup)
+        # ... before child
+        self.setups.each do |setup|
+          setup.kind_of?(::Proc) ? scope.instance_eval(&setup) : scope.send(setup)
+        end
+      end
+    end
+    alias_method :before, :setup
+
+    # Add a teardown block to run after each test or run the list of teardown blocks in given scope
+    def teardown(scope_or_method_name = nil, &block)
+      is_method = scope_or_method_name.kind_of?(String) || scope_or_method_name.kind_of?(Symbol)
+      if block_given? || is_method
+        # arg is a block or method that needs to be stored as a teardown
+        self.teardowns << (block || scope_or_method_name)
+      elsif !is_method
+        # arg is an instance of this class (the scope for a test),
+        # run the setups for this context in the scope
+        scope = scope_or_method_name
+        # teardown child...
+        self.teardowns.each do |teardown|
+          teardown.kind_of?(::Proc) ? scope.instance_eval(&teardown) : scope.send(teardown)
+        end
+        # ... before parent
+        self.superclass.teardown(scope) if self.superclass.respond_to?(:teardown)
+      end
+    end
+    alias_method :after, :teardown
+
+    protected
+
+    def setups
+      @setups ||= []
+    end
+
+    def teardowns
+      @teardowns ||= []
+    end
+
+  end
+
+end

--- a/lib/assert/context/subject_dsl.rb
+++ b/lib/assert/context/subject_dsl.rb
@@ -1,0 +1,39 @@
+module Assert; end
+class Assert::Context
+
+  module SubjectDSL
+
+    # Add a piece of description text or return the full description for the context
+    def description(text = nil)
+      if text
+        self.descriptions << text.to_s
+      else
+        parent = self.superclass.desc if self.superclass.respond_to?(:desc)
+        own = self.descriptions
+        [parent, *own].compact.reject do |p|
+          p.to_s.empty?
+        end.join(" ")
+      end
+    end
+    alias_method :desc, :description
+    alias_method :describe, :description
+
+    def subject(&block)
+      if block_given?
+        @subject = block
+      else
+        @subject || if superclass.respond_to?(:subject)
+          superclass.subject
+        end
+      end
+    end
+
+    protected
+
+    def descriptions
+      @descriptions ||= []
+    end
+
+  end
+
+end

--- a/lib/assert/context/test_dsl.rb
+++ b/lib/assert/context/test_dsl.rb
@@ -1,0 +1,51 @@
+require 'assert/macro'
+require 'assert/suite'
+require 'assert/test'
+
+module Assert; end
+class Assert::Context
+
+  module TestDSL
+
+    def test(desc_or_macro, called_from=nil, first_caller=nil, &block)
+      if desc_or_macro.kind_of?(Assert::Macro)
+        instance_eval(&desc_or_macro)
+      elsif block_given?
+        ci = Assert::Suite::ContextInfo.new(self, called_from, first_caller || caller.first)
+        test_name = desc_or_macro
+
+        # create a test from the given code block
+        Assert.suite.tests << Assert::Test.new(test_name, ci, Assert.config, &block)
+      else
+        test_eventually(desc_or_macro, called_from, first_caller || caller.first, &block)
+      end
+    end
+
+    def test_eventually(desc_or_macro, called_from=nil, first_caller=nil, &block)
+      ci = Assert::Suite::ContextInfo.new(self, called_from, first_caller || caller.first)
+      test_name = desc_or_macro.kind_of?(Assert::Macro) ? desc_or_macro.name : desc_or_macro
+      skip_block = block.nil? ? Proc.new { skip 'TODO' } : Proc.new { skip }
+
+      # create a test from a proc that just skips
+      Assert.suite.tests << Assert::Test.new(test_name, ci, Assert.config, &skip_block)
+    end
+    alias_method :test_skip, :test_eventually
+
+    def should(desc_or_macro, called_from=nil, first_caller=nil, &block)
+      if !desc_or_macro.kind_of?(Assert::Macro)
+        desc_or_macro = "should #{desc_or_macro}"
+      end
+      test(desc_or_macro, called_from, first_caller || caller.first, &block)
+    end
+
+    def should_eventually(desc_or_macro, called_from=nil, first_caller=nil, &block)
+      if !desc_or_macro.kind_of?(Assert::Macro)
+        desc_or_macro = "should #{desc_or_macro}"
+      end
+      test_eventually(desc_or_macro, called_from, first_caller || caller.first, &block)
+    end
+    alias_method :should_skip, :should_eventually
+
+  end
+
+end

--- a/test/unit/context/setup_dsl_tests.rb
+++ b/test/unit/context/setup_dsl_tests.rb
@@ -1,18 +1,15 @@
 require 'assert'
-require 'assert/context'
+require 'assert/context/setup_dsl'
 
-class Assert::Context
+module Assert::Context::SetupDSL
 
-  class SetupTeardownSingletonUnitTests < Assert::Context
-    desc "setup and teardown"
-    setup do
-      @context_class = Factory.context_class
-    end
+  class UnitTests < Assert::Context
+    desc "Assert::Context::SetupDSL"
     subject{ @context_class }
 
   end
 
-  class SetupTeardownOnceMethodsTests < SetupTeardownSingletonUnitTests
+  class SetupTeardownOnceMethodsTests < UnitTests
     desc "once methods"
     setup do
       block = @block = ::Proc.new{ something_once = true }
@@ -32,7 +29,7 @@ class Assert::Context
 
   end
 
-  class SetupTeardownMethodsTests < SetupTeardownSingletonUnitTests
+  class SetupTeardownMethodsTests < UnitTests
     desc "methods"
     setup do
       block = @block = ::Proc.new{ something = true }
@@ -49,7 +46,7 @@ class Assert::Context
 
   end
 
-  class SetupTeardownWithMethodNameTests < SetupTeardownSingletonUnitTests
+  class SetupTeardownWithMethodNameTests < UnitTests
     desc "methods given a method name"
     setup do
       method_name = @method_name = :something_amazing
@@ -66,7 +63,7 @@ class Assert::Context
 
   end
 
-  class SetupTeardownMultipleTests < SetupTeardownSingletonUnitTests
+  class SetupTeardownMultipleTests < UnitTests
     desc "with multiple calls"
     setup do
       parent_setup_block    = ::Proc.new{ self.setup_status    =  "the setup"    }

--- a/test/unit/context/subject_dsl_tests.rb
+++ b/test/unit/context/subject_dsl_tests.rb
@@ -1,25 +1,15 @@
 require 'assert'
-require 'assert/context'
+require 'assert/context/subject_dsl'
 
-class Assert::Context
+module Assert::Context::SubjectDSL
 
-  class BasicSingletonUnitTests < Assert::Context
-    setup do
-      @context_class = Factory.context_class
-    end
+  class UnitTests < Assert::Context
+    desc "Assert::Context::SubjectDSL"
     subject{ @context_class }
-
-    should have_instance_methods :setup_once, :before_once, :startup
-    should have_instance_methods :teardown_once, :after_once, :shutdown
-    should have_instance_methods :setup, :before, :setups
-    should have_instance_methods :teardown, :after, :teardowns
-    should have_instance_methods :description, :desc, :describe, :subject
-    should have_instance_methods :test, :test_eventually, :test_skip
-    should have_instance_methods :should, :should_eventually, :should_skip
 
   end
 
-  class DescriptionsTests < BasicSingletonUnitTests
+  class DescriptionsTests < UnitTests
     desc "`descriptions` method"
     setup do
       descs = @descs = [ "something amazing", "it really is" ]
@@ -34,7 +24,7 @@ class Assert::Context
 
   end
 
-  class DescriptionTests < BasicSingletonUnitTests
+  class DescriptionTests < UnitTests
     desc "`description` method"
     setup do
       parent_text = @parent_desc = "parent description"
@@ -54,7 +44,7 @@ class Assert::Context
 
   end
 
-  class SubjectFromLocalTests < BasicSingletonUnitTests
+  class SubjectFromLocalTests < UnitTests
     desc "subject method using local context"
     setup do
       subject_block = @subject_block = ::Proc.new{ @something }
@@ -70,7 +60,7 @@ class Assert::Context
 
   end
 
-  class SubjectFromParentTests < BasicSingletonUnitTests
+  class SubjectFromParentTests < UnitTests
     desc "subject method using parent context"
     setup do
       parent_block = @parent_block = ::Proc.new{ @something }

--- a/test/unit/context/test_dsl_tests.rb
+++ b/test/unit/context/test_dsl_tests.rb
@@ -1,10 +1,10 @@
 require 'assert'
-require 'assert/context'
+require 'assert/context/test_dsl'
 
-class Assert::Context
+module Assert::Context::TestDSL
 
-  class TestShouldSingletonUnitTests < Assert::Context
-    desc "test and should methods"
+  class UnitTests < Assert::Context
+    desc "Assert::Context::TestDSL"
     setup do
       @test_count_before = Assert.suite.tests.size
       @test_desc = "be true"

--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -15,6 +15,15 @@ class Assert::Context
     end
     subject{ @context }
 
+    # DSL methods
+    should have_cmeths :description, :desc, :describe, :subject
+    should have_cmeths :setup_once, :before_once, :startup
+    should have_cmeths :teardown_once, :after_once, :shutdown
+    should have_cmeths :setup, :before, :setups
+    should have_cmeths :teardown, :after, :teardowns
+    should have_cmeths :test, :test_eventually, :test_skip
+    should have_cmeths :should, :should_eventually, :should_skip
+
     should have_imeths :assert, :assert_not, :refute
     should have_imeths :skip, :pass, :fail, :flunk, :ignore
     should have_imeths :with_backtrace, :subject


### PR DESCRIPTION
This is a legacy way of adding class methods.  Updated to define
"dsl modules" and extend them onto the class.  This also breaks up
the dsl methods from the main context definition and organizes the
context source files more like the tests were organized.

Overall, this is just a cleanup/reorg - no behavior changes.

Closes #162.

@jcredding ready for review.
