### PR TITLE
move the git changed proc from a const to a defined util

### DIFF
--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -7,21 +7,6 @@ module Assert
     USER_SETTINGS_FILE  = ".assert/init.rb"
     LOCAL_SETTINGS_FILE = ".assert.rb"
 
-    DEFAULT_CHANGED_FILES_PROC = Proc.new do |config, test_paths|
-      # use git to determine which files have changes
-      files = []
-      cmd = [
-        "git diff --no-ext-diff --name-only",       # changed files
-        "git ls-files --others --exclude-standard"  # added files
-      ].map{ |c| "#{c} -- #{test_paths.join(' ')}" }.join(' && ')
-
-      Assert::CLI.bench('Load only changed files') do
-        files = `#{cmd}`.split("\n")
-      end
-      puts Assert::CLI.debug_msg("  `#{cmd}`") if config.debug
-      files
-    end
-
     attr_reader :config
 
     def initialize(config, test_paths, test_options)

--- a/lib/assert/config.rb
+++ b/lib/assert/config.rb
@@ -27,7 +27,7 @@ module Assert
       @test_helper = "helper.rb"
       @runner_seed   = begin; srand; srand % 0xFFFF; end.to_i
 
-      @changed_proc  = Assert::AssertRunner::DEFAULT_CHANGED_FILES_PROC
+      @changed_proc  = Assert::U.git_changed_proc
       @pp_proc       = Assert::U.stdlib_pp_proc
       @use_diff_proc = Assert::U.default_use_diff_proc
       @run_diff_proc = Assert::U.syscmd_diff_proc

--- a/test/unit/utils_tests.rb
+++ b/test/unit/utils_tests.rb
@@ -16,6 +16,7 @@ module Assert::Utils
     should have_imeths :show, :show_for_diff
     should have_imeths :tempfile
     should have_imeths :stdlib_pp_proc, :default_use_diff_proc, :syscmd_diff_proc
+    should have_imeths :git_changed_proc
 
   end
 


### PR DESCRIPTION
This makes it consistent with the other util procs and consistent
with how other config procs are defaulted.

Closes #159 

@jcredding ready for review.
