### PR TITLE
formally configure the test file suffixes

### DIFF
--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -3,7 +3,6 @@ require 'assert/cli'
 module Assert
 
   class AssertRunner
-    TEST_FILE_SUFFIXES  = ['_tests.rb', '_test.rb']
     USER_SETTINGS_FILE  = ".assert/init.rb"
     LOCAL_SETTINGS_FILE = ".assert.rb"
 
@@ -86,7 +85,7 @@ module Assert
     end
 
     def is_test_file?(path)
-      TEST_FILE_SUFFIXES.inject(false) do |result, suffix|
+      self.config.test_file_suffixes.inject(false) do |result, suffix|
         result || path =~ /#{suffix}$/
       end
     end

--- a/lib/assert/config.rb
+++ b/lib/assert/config.rb
@@ -14,7 +14,7 @@ module Assert
     end
 
     settings :view, :suite, :runner
-    settings :test_dir, :test_helper, :runner_seed
+    settings :test_dir, :test_helper, :test_file_suffixes, :runner_seed
     settings :changed_proc, :pp_proc, :use_diff_proc, :run_diff_proc
     settings :capture_output, :halt_on_fail, :changed_only, :pp_objects, :debug
 
@@ -25,6 +25,7 @@ module Assert
 
       @test_dir    = "test"
       @test_helper = "helper.rb"
+      @test_file_suffixes = ['_tests.rb', '_test.rb']
       @runner_seed   = begin; srand; srand % 0xFFFF; end.to_i
 
       @changed_proc  = Assert::U.git_changed_proc

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -11,7 +11,7 @@ class Assert::Config
     subject{ @config }
 
     should have_imeths :suite, :view, :runner
-    should have_imeths :test_dir, :test_helper, :runner_seed
+    should have_imeths :test_dir, :test_helper, :test_file_suffixes, :runner_seed
     should have_imeths :changed_proc, :pp_proc, :use_diff_proc, :run_diff_proc
     should have_imeths :capture_output, :halt_on_fail, :changed_only, :pp_objects, :debug
     should have_imeths :apply
@@ -22,9 +22,10 @@ class Assert::Config
       assert_kind_of Assert::Runner, subject.runner
     end
 
-    should "default the test dir/helper" do
+    should "default the test dir/helper/suffixes/seed" do
       assert_equal 'test', subject.test_dir
       assert_equal 'helper.rb', subject.test_helper
+      assert_equal ['_tests.rb', "_test.rb"], subject.test_file_suffixes
       assert_not_nil subject.runner_seed
     end
 


### PR DESCRIPTION
This adds a formal config for what suffixes test files have.  This
removes the const that previously defined them and formally tests
the default config values.  This is to make this option configurable
like any other option.

@jcredding just a cleanup - ready for review.
