### PR TITLE
show tests-per-sec and resuls-per-sec in views

### DIFF
--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -32,6 +32,14 @@ module Assert
       @end_time - @start_time
     end
 
+    def test_rate
+      get_rate(self.tests.size, self.run_time.to_f)
+    end
+
+    def result_rate
+      get_rate(self.results.size, self.run_time.to_f)
+    end
+
     alias_method :ordered_tests, :tests
 
     def results
@@ -117,6 +125,12 @@ module Assert
 
       # uniq and remove any that don't start with 'test'
       methods.uniq.delete_if {|method_name| method_name !~ TEST_METHOD_REGEX }
+    end
+
+    private
+
+    def get_rate(count, time)
+      time == 0 ? 0.0 : (count.to_f / time.to_f)
     end
 
   end

--- a/lib/assert/view/default_view.rb
+++ b/lib/assert/view/default_view.rb
@@ -68,7 +68,7 @@ module Assert::View
 
       puts "#{result_count_statement}: #{styled_results_sentence}"
       puts
-      puts "(#{run_time} seconds)"
+      puts "(#{run_time} seconds, #{test_rate} tests/s, #{result_rate} results/s)"
     end
 
   end

--- a/lib/assert/view/helpers/common.rb
+++ b/lib/assert/view/helpers/common.rb
@@ -6,11 +6,6 @@ module Assert::View::Helpers
       receiver.class_eval{ extend ClassMethods }
     end
 
-    # get the formatted suite run time
-    def run_time(format='%.6f')
-      format % self.suite.run_time
-    end
-
     def runner_seed
       self.config.runner_seed
     end
@@ -25,6 +20,21 @@ module Assert::View::Helpers
 
     def all_pass?
       self.count(:pass) == self.count(:results)
+    end
+
+    # get the formatted suite run time
+    def run_time(format = '%.6f')
+      format % self.suite.run_time
+    end
+
+    # get the formatted suite test rate
+    def test_rate(format = '%.6f')
+      format % self.suite.test_rate
+    end
+
+    # get the formatted suite result rate
+    def result_rate(format = '%.6f')
+      format % self.suite.result_rate
     end
 
     # get a uniq list of contexts for the test suite

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -14,7 +14,8 @@ class Assert::Suite
     subject{ @suite }
 
     should have_accessors :config, :tests, :test_methods, :start_time, :end_time
-    should have_imeths :ordered_tests, :results, :ordered_results, :run_time
+    should have_imeths :ordered_tests, :results, :ordered_results
+    should have_imeths :run_time, :test_rate, :result_rate
     should have_imeths :count, :test_count, :result_count
     should have_imeths :setup, :startup, :teardown, :shutdown
 
@@ -24,10 +25,11 @@ class Assert::Suite
       assert_equal(exp, act)
     end
 
-    should "have zero a run time by default" do
+    should "have a zero run time, test rate and result by default" do
       assert_equal 0, subject.run_time
+      assert_equal 0, subject.test_rate
+      assert_equal 0, subject.result_rate
     end
-
 
   end
 

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -19,7 +19,8 @@ class Assert::View::Base
     should have_imeths :before_test, :after_test, :on_result
 
     # common methods
-    should have_imeths :run_time, :runner_seed, :count, :tests?, :all_pass?
+    should have_imeths :runner_seed, :count, :tests?, :all_pass?
+    should have_imeths :run_time, :test_rate, :result_rate
     should have_imeths :suite_contexts, :ordered_suite_contexts
     should have_imeths :suite_files, :ordered_suite_files
     should have_imeths :result_details_for, :show_result_details?


### PR DESCRIPTION
This has the suite start calculating the rate of tests and results
so that the view can have access to the it.  It also adds it to the
summary of the default view.

This is just so the user has extra stats to keep an eye on their
test suite run time.  It provides a more granular measurement on
the changes in suite run time.  Plus it is fun.

Closes #143.

@jcredding ready for review.
