### PR TITLE
`suite` DSL method on context classes

### DIFF
--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -1,6 +1,7 @@
 require 'assert/assertions'
 require 'assert/context/setup_dsl'
 require 'assert/context/subject_dsl'
+require 'assert/context/suite_dsl'
 require 'assert/context/test_dsl'
 require 'assert/macros/methods'
 require 'assert/result'
@@ -13,6 +14,7 @@ module Assert
     # put all logic in DSL methods to keep context instances pure for running tests
     extend SetupDSL
     extend SubjectDSL
+    extend SuiteDSL
     extend TestDSL
     include Assert::Assertions
     include Assert::Macros::Methods
@@ -29,16 +31,16 @@ module Assert
       if method_name.to_s =~ Suite::TEST_METHOD_REGEX
         klass_method_name = "#{self}##{method_name}"
 
-        if Assert.suite.test_methods.include?(klass_method_name)
+        if self.suite.test_methods.include?(klass_method_name)
           puts "WARNING: redefining '#{klass_method_name}'"
           puts "  from: #{called_from}"
         else
-          Assert.suite.test_methods << klass_method_name
+          self.suite.test_methods << klass_method_name
         end
 
         ci = Suite::ContextInfo.new(self, nil, caller.first)
-        test = Test.new(method_name.to_s, ci, Assert.config, :code => method_name)
-        Assert.suite.tests << test
+        test = Test.new(method_name.to_s, ci, self.suite.config, :code => method_name)
+        self.suite.tests << test
       end
     end
 

--- a/lib/assert/context/setup_dsl.rb
+++ b/lib/assert/context/setup_dsl.rb
@@ -4,13 +4,13 @@ class Assert::Context
   module SetupDSL
 
     def setup_once(&block)
-      Assert.suite.setup(&block)
+      self.suite.setup(&block)
     end
     alias_method :before_once, :setup_once
     alias_method :startup, :setup_once
 
     def teardown_once(&block)
-      Assert.suite.teardown(&block)
+      self.suite.teardown(&block)
     end
     alias_method :after_once, :teardown_once
     alias_method :shutdown, :teardown_once

--- a/lib/assert/context/suite_dsl.rb
+++ b/lib/assert/context/suite_dsl.rb
@@ -1,0 +1,20 @@
+module Assert; end
+class Assert::Context
+
+  module SuiteDSL
+
+    def suite(suite_obj = nil)
+      if suite_obj
+        @suite = suite_obj
+      else
+        @suite || if superclass.respond_to?(:suite)
+          superclass.suite
+        else
+          Assert.suite
+        end
+      end
+    end
+
+  end
+
+end

--- a/lib/assert/context/test_dsl.rb
+++ b/lib/assert/context/test_dsl.rb
@@ -15,7 +15,7 @@ class Assert::Context
         test_name = desc_or_macro
 
         # create a test from the given code block
-        Assert.suite.tests << Assert::Test.new(test_name, ci, Assert.config, &block)
+        self.suite.tests << Assert::Test.new(test_name, ci, self.suite.config, &block)
       else
         test_eventually(desc_or_macro, called_from, first_caller || caller.first, &block)
       end
@@ -27,7 +27,7 @@ class Assert::Context
       skip_block = block.nil? ? Proc.new { skip 'TODO' } : Proc.new { skip }
 
       # create a test from a proc that just skips
-      Assert.suite.tests << Assert::Test.new(test_name, ci, Assert.config, &skip_block)
+      self.suite.tests << Assert::Test.new(test_name, ci, self.suite.config, &skip_block)
     end
     alias_method :test_skip, :test_eventually
 

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -3,16 +3,6 @@ require 'assert/test'
 module Assert
   class Suite
 
-    class ContextInfo
-      attr_reader :called_from, :klass, :file
-
-      def initialize(klass, called_from=nil, first_caller=nil)
-        @called_from = called_from || first_caller
-        @klass = klass
-        @file = @called_from.gsub(/\:[0-9]+.*$/, '') if @called_from
-      end
-    end
-
     TEST_METHOD_REGEX = /^test./
 
     # A suite is a set of tests to run.  When a test class subclasses
@@ -100,6 +90,12 @@ module Assert
     end
     alias_method :shutdown, :teardown
 
+    def inspect
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)}"\
+      " test_count=#{self.test_count.inspect}"\
+      " result_count=#{self.result_count.inspect}>"
+    end
+
     protected
 
     def setups
@@ -131,6 +127,16 @@ module Assert
 
     def get_rate(count, time)
       time == 0 ? 0.0 : (count.to_f / time.to_f)
+    end
+
+    class ContextInfo
+      attr_reader :called_from, :klass, :file
+
+      def initialize(klass, called_from=nil, first_caller=nil)
+        @called_from = called_from || first_caller
+        @klass = klass
+        @file = @called_from.gsub(/\:[0-9]+.*$/, '') if @called_from
+      end
     end
 
   end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -55,4 +55,16 @@ module Factory
     })
   end
 
+  def self.modes_off_suite
+    Assert::Suite.new(self.modes_off_config)
+  end
+
+  def self.modes_off_context_class(*args, &block)
+    suite_obj = self.modes_off_suite
+    self.context_class(*args) do
+      suite(suite_obj)
+      instance_eval(&block) if !block.nil?
+    end
+  end
+
 end

--- a/test/unit/assertions_tests.rb
+++ b/test/unit/assertions_tests.rb
@@ -6,7 +6,7 @@ module Assert::Assertions
   class UnitTests < Assert::Context
     desc "An assert context"
     setup do
-      @context_class = Factory.context_class
+      @context_class = Factory.modes_off_context_class
       @test = Factory.test
       @context = @context_class.new(@test, @test.config)
     end

--- a/test/unit/context/setup_dsl_tests.rb
+++ b/test/unit/context/setup_dsl_tests.rb
@@ -13,18 +13,15 @@ module Assert::Context::SetupDSL
     desc "once methods"
     setup do
       block = @block = ::Proc.new{ something_once = true }
-      @context_class = Factory.context_class do
+      @context_class = Factory.modes_off_context_class do
         setup_once(&block)
         teardown_once(&block)
       end
     end
-    teardown do
-      Assert.suite.send(:setups).reject!{ |b| b == @block }
-    end
 
     should "add the block to the suite" do
-      assert_includes @block, Assert.suite.send(:setups)
-      assert_includes @block, Assert.suite.send(:teardowns)
+      assert_includes @block, subject.suite.send(:setups)
+      assert_includes @block, subject.suite.send(:teardowns)
     end
 
   end
@@ -33,7 +30,7 @@ module Assert::Context::SetupDSL
     desc "methods"
     setup do
       block = @block = ::Proc.new{ something = true }
-      @context_class = Factory.context_class do
+      @context_class = Factory.modes_off_context_class do
         setup(&block)
         teardown(&block)
       end
@@ -50,7 +47,7 @@ module Assert::Context::SetupDSL
     desc "methods given a method name"
     setup do
       method_name = @method_name = :something_amazing
-      @context_class = Factory.context_class do
+      @context_class = Factory.modes_off_context_class do
         setup(method_name)
         teardown(method_name)
       end
@@ -68,14 +65,14 @@ module Assert::Context::SetupDSL
     setup do
       parent_setup_block    = ::Proc.new{ self.setup_status    =  "the setup"    }
       parent_teardown_block = ::Proc.new{ self.teardown_status += "the teardown" }
-      @parent_class = Factory.context_class do
+      @parent_class = Factory.modes_off_context_class do
         setup(&parent_setup_block)
         teardown(&parent_teardown_block)
       end
 
       context_setup_block    = ::Proc.new{ self.setup_status    += " has been run" }
       context_teardown_block = ::Proc.new{ self.teardown_status += "has been run " }
-      @context_class = Factory.context_class(@parent_class) do
+      @context_class = Factory.modes_off_context_class(@parent_class) do
         setup(&context_setup_block)
         setup(:setup_something)
         teardown(:teardown_something)

--- a/test/unit/context/subject_dsl_tests.rb
+++ b/test/unit/context/subject_dsl_tests.rb
@@ -13,7 +13,7 @@ module Assert::Context::SubjectDSL
     desc "`descriptions` method"
     setup do
       descs = @descs = [ "something amazing", "it really is" ]
-      @context_class = Factory.context_class do
+      @context_class = Factory.modes_off_context_class do
         descs.each{ |text| desc text }
       end
     end
@@ -28,11 +28,11 @@ module Assert::Context::SubjectDSL
     desc "`description` method"
     setup do
       parent_text = @parent_desc = "parent description"
-      @parent_class = Factory.context_class do
+      @parent_class = Factory.modes_off_context_class do
         desc parent_text
       end
       text = @desc = "and the description for this context"
-      @context_class = Factory.context_class(@parent_class) do
+      @context_class = Factory.modes_off_context_class(@parent_class) do
         desc text
       end
     end
@@ -45,35 +45,34 @@ module Assert::Context::SubjectDSL
   end
 
   class SubjectFromLocalTests < UnitTests
-    desc "subject method using local context"
+    desc "`subject` method using local context"
     setup do
       subject_block = @subject_block = ::Proc.new{ @something }
-      @context_class = Factory.context_class do
+      @context_class = Factory.modes_off_context_class do
         subject(&subject_block)
       end
     end
-    subject{ @subject_block }
 
     should "set the subject block on the context class" do
-      assert_equal @context_class.subject, subject
+      assert_equal @subject_block, @context_class.subject
     end
 
   end
 
   class SubjectFromParentTests < UnitTests
-    desc "subject method using parent context"
+    desc "`subject` method using parent context"
     setup do
       parent_block = @parent_block = ::Proc.new{ @something }
-      @parent_class = Factory.context_class do
+      @parent_class = Factory.modes_off_context_class do
         subject(&parent_block)
       end
-      @context_class = Factory.context_class(@parent_class)
+      @context_class = Factory.modes_off_context_class(@parent_class)
     end
-    subject{ @parent_block }
 
     should "default to it's parents subject block" do
-      assert_equal @context_class.subject, subject
+      assert_equal @parent_block, @context_class.subject
     end
+
   end
 
 end

--- a/test/unit/context/suite_dsl_tests.rb
+++ b/test/unit/context/suite_dsl_tests.rb
@@ -1,0 +1,47 @@
+require 'assert'
+require 'assert/context/suite_dsl'
+
+require 'assert/suite'
+
+module Assert::Context::SuiteDSL
+
+  class UnitTests < Assert::Context
+    desc "Assert::Context::SuiteDSL"
+    setup do
+      @custom_suite = Factory.modes_off_suite
+      @context_class = Factory.context_class
+    end
+    subject{ @context_class }
+
+    should "use `Assert.suite` by default" do
+      assert_equal Assert.suite, subject.suite
+    end
+
+    should "use any given custom suite" do
+      subject.suite(@custom_suite)
+      assert_equal @custom_suite, subject.suite
+    end
+
+  end
+
+  class SuiteFromParentTests < UnitTests
+    desc "`suite` method using parent context"
+    setup do
+      @parent_class = Factory.context_class
+      @parent_class.suite(@custom_suite)
+      @context_class = Factory.context_class(@parent_class)
+    end
+
+    should "default to it's parents subject block" do
+      assert_equal @custom_suite, subject.suite
+    end
+
+    should "use any given custom suite" do
+      another_suite = Factory.modes_off_suite
+      subject.suite(another_suite)
+      assert_equal another_suite, subject.suite
+    end
+
+  end
+
+end

--- a/test/unit/context/test_dsl_tests.rb
+++ b/test/unit/context/test_dsl_tests.rb
@@ -6,19 +6,18 @@ module Assert::Context::TestDSL
   class UnitTests < Assert::Context
     desc "Assert::Context::TestDSL"
     setup do
-      @test_count_before = Assert.suite.tests.size
       @test_desc = "be true"
       @test_block = ::Proc.new{ assert(true) }
     end
 
     should "build a test using `test` with a desc and code block" do
       d, b = @test_desc, @test_block
-      Factory.context_class { test(d, &b) }
+      context_class = Factory.modes_off_context_class{ test(d, &b) }
 
-      assert_equal @test_count_before+1, Assert.suite.tests.size
+      assert_equal 1, context_class.suite.tests.size
 
       exp_test_name = @test_desc
-      built_test = Assert.suite.tests.last
+      built_test = context_class.suite.tests.first
       assert_kind_of Assert::Test, built_test
       assert_equal exp_test_name, built_test.name
       assert_equal @test_block, built_test.code
@@ -26,12 +25,12 @@ module Assert::Context::TestDSL
 
     should "build a test using `should` with a desc and code block" do
       d, b = @test_desc, @test_block
-      Factory.context_class { should(d, &b) }
+      context_class = Factory.modes_off_context_class{ should(d, &b) }
 
-      assert_equal @test_count_before+1, Assert.suite.tests.size
+      assert_equal 1, context_class.suite.tests.size
 
       exp_test_name = "should #{@test_desc}"
-      built_test = Assert.suite.tests.last
+      built_test = context_class.suite.tests.last
       assert_kind_of Assert::Test, built_test
       assert_equal exp_test_name, built_test.name
       assert_equal @test_block, built_test.code
@@ -41,10 +40,10 @@ module Assert::Context::TestDSL
       d, b = @test_desc, @test_block
       context = build_eval_context{ test_eventually(d, &b) }
       err = capture_err(Assert::Result::TestSkipped) do
-        context.instance_eval(&Assert.suite.tests.last.code)
+        context.instance_eval(&context.class.suite.tests.last.code)
       end
 
-      assert_equal @test_count_before+1, Assert.suite.tests.size
+      assert_equal 1, context.class.suite.tests.size
       assert_equal "", err.message
     end
 
@@ -52,10 +51,10 @@ module Assert::Context::TestDSL
       d, b = @test_desc, @test_block
       context = build_eval_context{ should_eventually(d, &b) }
       err = capture_err(Assert::Result::TestSkipped) do
-        context.instance_eval(&Assert.suite.tests.last.code)
+        context.instance_eval(&context.class.suite.tests.last.code)
       end
 
-      assert_equal @test_count_before+1, Assert.suite.tests.size
+      assert_equal 1, context.class.suite.tests.size
       assert_equal "", err.message
     end
 
@@ -63,10 +62,10 @@ module Assert::Context::TestDSL
       d = @test_desc
       context = build_eval_context { test(d) } # no block passed
       err = capture_err(Assert::Result::TestSkipped) do
-        context.instance_eval(&Assert.suite.tests.last.code)
+        context.instance_eval(&context.class.suite.tests.last.code)
       end
 
-      assert_equal @test_count_before+1, Assert.suite.tests.size
+      assert_equal 1, context.class.suite.tests.size
       assert_equal "TODO", err.message
     end
 
@@ -74,10 +73,10 @@ module Assert::Context::TestDSL
       d = @test_desc
       context = build_eval_context { should(d) } # no block passed
       err = capture_err(Assert::Result::TestSkipped) do
-        context.instance_eval(&Assert.suite.tests.last.code)
+        context.instance_eval(&context.class.suite.tests.last.code)
       end
 
-      assert_equal @test_count_before+1, Assert.suite.tests.size
+      assert_equal 1, context.class.suite.tests.size
       assert_equal "TODO", err.message
     end
 
@@ -85,10 +84,10 @@ module Assert::Context::TestDSL
       d = @test_desc
       context = build_eval_context{ test_eventually(d) } # no block given
       err = capture_err(Assert::Result::TestSkipped) do
-        context.instance_eval(&Assert.suite.tests.last.code)
+        context.instance_eval(&context.class.suite.tests.last.code)
       end
 
-      assert_equal @test_count_before+1, Assert.suite.tests.size
+      assert_equal 1, context.class.suite.tests.size
       assert_equal "TODO", err.message
     end
 
@@ -96,27 +95,27 @@ module Assert::Context::TestDSL
       d = @test_desc
       context = build_eval_context{ should_eventually(d) } # no block given
       err = capture_err(Assert::Result::TestSkipped) do
-        context.instance_eval(&Assert.suite.tests.last.code)
+        context.instance_eval(&context.class.suite.tests.last.code)
       end
 
-      assert_equal @test_count_before+1, Assert.suite.tests.size
+      assert_equal 1, context.class.suite.tests.size
       assert_equal "TODO", err.message
     end
 
     should "build a test from a macro using `test`" do
       d, b = @test_desc, @test_block
       m = Assert::Macro.new{ test(d, &b); test(d, &b) }
-      Factory.context_class { test(m) }
+      context_class = Factory.modes_off_context_class{ test(m) }
 
-      assert_equal @test_count_before+2, Assert.suite.tests.size
+      assert_equal 2, context_class.suite.tests.size
     end
 
     should "build a test from a macro using `should`" do
       d, b = @test_desc, @test_block
       m = Assert::Macro.new{ should(d, &b); should(d, &b) }
-      Factory.context_class { should(m) }
+      context_class = Factory.modes_off_context_class{ should(m) }
 
-      assert_equal @test_count_before+2, Assert.suite.tests.size
+      assert_equal 2, context_class.suite.tests.size
     end
 
     should "build a test that skips from a macro using `test_eventually`" do
@@ -124,9 +123,9 @@ module Assert::Context::TestDSL
       m = Assert::Macro.new{ test(d, &b); test(d, &b) }
       context = build_eval_context{ test_eventually(m) }
 
-      assert_equal @test_count_before+1, Assert.suite.tests.size
+      assert_equal 1, context.class.suite.tests.size
       assert_raises(Assert::Result::TestSkipped) do
-        context.instance_eval(&Assert.suite.tests.last.code)
+        context.instance_eval(&context.class.suite.tests.last.code)
       end
     end
 
@@ -135,9 +134,9 @@ module Assert::Context::TestDSL
       m = Assert::Macro.new{ should(d, &b); should(d, &b) }
       context = build_eval_context{ should_eventually(m) }
 
-      assert_equal @test_count_before+1, Assert.suite.tests.size
+      assert_equal 1, context.class.suite.tests.size
       assert_raises(Assert::Result::TestSkipped) do
-        context.instance_eval(&Assert.suite.tests.last.code)
+        context.instance_eval(&context.class.suite.tests.last.code)
       end
 
     end
@@ -145,7 +144,7 @@ module Assert::Context::TestDSL
     private
 
     def build_eval_context(&build_block)
-      context_class = Factory.context_class &build_block
+      context_class = Factory.modes_off_context_class &build_block
       context_info  = Factory.context_info(context_class)
       test = Factory.test("whatever", context_info)
       context_class.new(test, test.config)

--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -16,7 +16,7 @@ class Assert::Context
     subject{ @context }
 
     # DSL methods
-    should have_cmeths :description, :desc, :describe, :subject
+    should have_cmeths :description, :desc, :describe, :subject, :suite
     should have_cmeths :setup_once, :before_once, :startup
     should have_cmeths :teardown_once, :after_once, :shutdown
     should have_cmeths :setup, :before, :setups
@@ -221,7 +221,7 @@ class Assert::Context
     desc "subject method"
     setup do
       expected = @expected = "amazing"
-      @context_class = Factory.context_class do
+      @context_class = Factory.modes_off_context_class do
         subject{ @something = expected }
       end
       @context = @context_class.new(@test, @test.config)

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -36,7 +36,7 @@ class Assert::Suite
   class WithTestsTests < UnitTests
     desc "a suite with tests"
     setup do
-      ci = Factory.context_info(Factory.context_class)
+      ci = Factory.context_info(Factory.modes_off_context_class)
       @suite.tests = [
         Factory.test("should nothing", ci){ },
         Factory.test("should pass",    ci){ assert(1==1); refute(1==0) },

--- a/test/unit/test_tests.rb
+++ b/test/unit/test_tests.rb
@@ -9,7 +9,7 @@ class Assert::Test
     desc "a test obj"
     setup do
       @test_code = lambda{ assert(true) }
-      @context_class = Factory.context_class{ desc "context class" }
+      @context_class = Factory.modes_off_context_class{ desc "context class" }
       @context_info  = Factory.context_info(@context_class)
       @test = Factory.test("should do something amazing", @context_info, :code => @test_code)
     end


### PR DESCRIPTION
This adds a `suite` DSL method to the context class.  Use this method
to inject custom suite objects.  The method defaults to `Assert.suite`
if no custom suite has been specified and honors its superclass suite.

The main reason for doing this is that has no effect on the external
API but allows for much easier and robust testing of contexts  and
their suite-related concerns without impacting live code.

Closes #163 

@jcredding ready for review.  No behavior changes - just test cleanups and reduced occurrence of `Assert.suite`. 
