### PR TITLE
only display ANSI styled output if the view IO is a tty

### DIFF
--- a/lib/assert/view/base.rb
+++ b/lib/assert/view/base.rb
@@ -31,6 +31,10 @@ module Assert::View
       @output_io.sync = true if @output_io.respond_to?(:sync=)
     end
 
+    def is_tty?
+      !!@output_io.isatty
+    end
+
     def view
       self
     end

--- a/lib/assert/view/helpers/ansi_styles.rb
+++ b/lib/assert/view/helpers/ansi_styles.rb
@@ -9,7 +9,7 @@ module Assert::View::Helpers
     end
 
     def ansi_styled_msg(msg, styles=[])
-      if !(style = ansi_style(*styles)).empty?
+      if !(style = ansi_style(*styles)).empty? && self.is_tty?
         style + msg + ANSI.send(:reset)
       else
         msg

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -8,13 +8,14 @@ class Assert::View::Base
   class UnitTests < Assert::Context
     desc "Assert::View::Base"
     setup do
+      @io = StringIO.new("", "w+")
       @config = Factory.modes_off_config
-      @view = Assert::View::Base.new(StringIO.new("", "w+"), @config, @config.suite)
+      @view = Assert::View::Base.new(@io, @config, @config.suite)
     end
     subject{ @view }
 
     # accessors, base methods
-    should have_imeths :view, :config, :suite, :fire
+    should have_imeths :is_tty?, :view, :config, :suite, :fire
     should have_imeths :before_load, :after_load, :on_start, :on_finish
     should have_imeths :before_test, :after_test, :on_result
 
@@ -35,6 +36,10 @@ class Assert::View::Base
       assert_equal 'I', subject.ignore_abbrev
       assert_equal 'S', subject.skip_abbrev
       assert_equal 'E', subject.error_abbrev
+    end
+
+    should "know if it is a tty" do
+      assert_equal !!@io.isatty, subject.is_tty?
     end
 
   end


### PR DESCRIPTION
This updates the view to know whether it is a tty or not and only
display ansi styled output if it is a tty - regardless of any other
config settings.  This is to be a good citizen and not output ANSI
style coded output to IOs that don't know what to do with it.

Closes #172.

@jcredding ready for review.
