### PR TITLE
cleanups/standardizations to assertion fail messages

### DIFF
--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -9,7 +9,7 @@ module Assert
     end
 
     def assert_not_block(desc = nil)
-      assert(!yield, desc){ "Expected block to return a false value." }
+      assert(!yield, desc){ "Expected block to not return a true value." }
     end
     alias_method :refute_block, :assert_not_block
 
@@ -36,7 +36,7 @@ module Assert
           "Expected does not equal actual, diff:\n"\
           "#{c.run_diff_proc.call(exp_show, act_show)}"
         else
-          "Expected #{Assert::U.show(exp, c)}, not #{Assert::U.show(act, c)}."
+          "Expected #{Assert::U.show(act, c)} to be equal to #{Assert::U.show(exp, c)}."
         end
       end
     end
@@ -51,7 +51,7 @@ module Assert
           "Expected equals actual, diff:\n"\
           "#{c.run_diff_proc.call(exp_show, act_show)}"
         else
-          "#{Assert::U.show(act, c)} not expected to equal #{Assert::U.show(exp, c)}."
+          "Expected #{Assert::U.show(act, c)} to not be equal to #{Assert::U.show(exp, c)}."
         end
       end
     end
@@ -97,8 +97,8 @@ module Assert
 
     def assert_not_instance_of(klass, instance, desc = nil)
       assert(!instance.instance_of?(klass), desc) do
-        "#{Assert::U.show(instance, __assert_config__)} (#{instance.class})"\
-        " not expected to be an instance of #{klass}."
+        "Expected #{Assert::U.show(instance, __assert_config__)} (#{instance.class})"\
+        " to not be an instance of #{klass}."
       end
     end
     alias_method :refute_instance_of, :assert_not_instance_of
@@ -112,8 +112,8 @@ module Assert
 
     def assert_not_kind_of(klass, instance, desc = nil)
       assert(!instance.kind_of?(klass), desc) do
-        "#{Assert::U.show(instance, __assert_config__)}"\
-        " not expected to be a kind of #{klass}."
+        "Expected #{Assert::U.show(instance, __assert_config__)} (#{instance.class})"\
+        " to not be a kind of #{klass}."
       end
     end
     alias_method :refute_kind_of, :assert_not_kind_of
@@ -129,8 +129,8 @@ module Assert
     def assert_not_match(exp, act, desc = nil)
       exp = String === exp && String === act ? /#{Regexp.escape(exp)}/ : exp
       assert(act !~ exp, desc) do
-        "#{Assert::U.show(act, __assert_config__)}"\
-        " not expected to match #{Assert::U.show(exp, __assert_config__)}."
+        "Expected #{Assert::U.show(act, __assert_config__)}"\
+        " to not match #{Assert::U.show(exp, __assert_config__)}."
       end
     end
     alias_method :refute_match, :assert_not_match
@@ -138,7 +138,7 @@ module Assert
 
     def assert_nil(object, desc = nil)
       assert(object.nil?, desc) do
-        "Expected nil, not #{Assert::U.show(object, __assert_config__)}."
+        "Expected #{Assert::U.show(object, __assert_config__)} to be nil."
       end
     end
 
@@ -174,8 +174,8 @@ module Assert
 
     def assert_not_respond_to(method, object, desc = nil)
       assert(!object.respond_to?(method), desc) do
-        "#{Assert::U.show(object, __assert_config__)} (#{object.class})"\
-        " not expected to respond to `#{method}`."
+        "Expected #{Assert::U.show(object, __assert_config__)} (#{object.class})"\
+        " to not respond to `#{method}`."
       end
     end
     alias_method :assert_not_responds_to, :assert_not_respond_to
@@ -191,10 +191,10 @@ module Assert
         act_id = "#<#{act.class}:#{'0x0%x' % (act.object_id << 1)}>"
 
         if c.use_diff_proc.call(exp_show, act_show)
-          "#{act_id} expected to be the same as #{exp_id}, diff:\n"\
+          "Expected #{act_id} to be the same as #{exp_id}, diff:\n"\
           "#{c.run_diff_proc.call(exp_show, act_show)}"
         else
-          "#{Assert::U.show(act, c)} (#{act_id}) expected to be the same as"\
+          "Expected #{Assert::U.show(act, c)} (#{act_id}) to be the same as"\
           " #{Assert::U.show(exp, c)} (#{exp_id})."
         end
       end
@@ -209,10 +209,10 @@ module Assert
         act_id = "#<#{act.class}:#{'0x0%x' % (act.object_id << 1)}>"
 
         if c.use_diff_proc.call(exp_show, act_show)
-          "#{act_id} not expected to be the same as #{exp_id}, diff:\n"\
+          "Expected #{act_id} to not be the same as #{exp_id}, diff:\n"\
           "#{c.run_diff_proc.call(exp_show, act_show)}"
         else
-          "#{Assert::U.show(act, c)} (#{act_id}) not expected to be the same as"\
+          "Expected #{Assert::U.show(act, c)} (#{act_id}) to not be the same as"\
           " #{Assert::U.show(exp, c)} (#{exp_id})."
         end
       end

--- a/test/unit/assertions/assert_block_tests.rb
+++ b/test/unit/assertions/assert_block_tests.rb
@@ -4,7 +4,7 @@ require 'assert/assertions'
 module Assert::Assertions
 
   class AssertBlockTests < Assert::Context
-    desc "the `assert_block` helper"
+    desc "`assert_block`"
     setup do
       desc = @desc = "assert block fail desc"
       @test = Factory.test do
@@ -29,7 +29,7 @@ module Assert::Assertions
   end
 
   class AssertNotBlockTests < Assert::Context
-    desc "the assert_not_block helper"
+    desc "`assert_not_block`"
     setup do
       desc = @desc = "assert not block fail desc"
       @test = Factory.test do
@@ -47,7 +47,7 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@desc}\nExpected block to return a false value."
+      exp = "#{@desc}\nExpected block to not return a true value."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_empty_tests.rb
+++ b/test/unit/assertions/assert_empty_tests.rb
@@ -6,7 +6,7 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertEmptyTests < Assert::Context
-    desc "the assert_empty helper"
+    desc "`assert_empty`"
     setup do
       desc = @desc = "assert empty fail desc"
       args = @args = [ [ 1 ], desc ]
@@ -33,7 +33,7 @@ module Assert::Assertions
   end
 
   class AssertNotEmptyTests < Assert::Context
-    desc "the assert_not_empty helper"
+    desc "`assert_not_empty`"
     setup do
       desc = @desc = "assert not empty fail desc"
       args = @args = [ [], desc ]

--- a/test/unit/assertions/assert_equal_tests.rb
+++ b/test/unit/assertions/assert_equal_tests.rb
@@ -26,7 +26,8 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@a[2]}\nExpected #{Assert::U.show(@a[0], @c)}, not #{Assert::U.show(@a[1], @c)}."
+      exp = "#{@a[2]}\nExpected #{Assert::U.show(@a[1], @c)}"\
+            " to be equal to #{Assert::U.show(@a[0], @c)}."
       assert_equal exp, subject.fail_results.first.message
     end
 
@@ -53,7 +54,8 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@a[2]}\n#{Assert::U.show(@a[1], @c)} not expected to equal #{Assert::U.show(@a[0], @c)}."
+      exp = "#{@a[2]}\nExpected #{Assert::U.show(@a[1], @c)}"\
+            " to not be equal to #{Assert::U.show(@a[0], @c)}."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_file_exists_tests.rb
+++ b/test/unit/assertions/assert_file_exists_tests.rb
@@ -6,7 +6,7 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertFileExistsTests < Assert::Context
-    desc "the assert_file_exists helper"
+    desc "`assert_file_exists`"
     setup do
       desc = @desc = "assert file exists empty fail desc"
       args = @args = [ '/a/path/to/some/file/that/no/exists', desc ]
@@ -33,7 +33,7 @@ module Assert::Assertions
   end
 
   class AssertNotFileExistsTests < Assert::Context
-    desc "the assert_not_file_exists helper"
+    desc "`assert_not_file_exists`"
     setup do
       desc = @desc = "assert not file exists empty fail desc"
       args = @args = [ __FILE__, desc ]

--- a/test/unit/assertions/assert_includes_tests.rb
+++ b/test/unit/assertions/assert_includes_tests.rb
@@ -6,7 +6,7 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertIncludesTests < Assert::Context
-    desc "the assert_includes helper"
+    desc "`assert_includes`"
     setup do
       desc = @desc = "assert includes fail desc"
       args = @args = [ 2, [ 1 ], desc ]
@@ -35,7 +35,7 @@ module Assert::Assertions
   end
 
   class AssertNotIncluded < Assert::Context
-    desc "the assert_not_included helper"
+    desc "`assert_not_included`"
     setup do
       desc = @desc = "assert not included fail desc"
       args = @args = [ 1, [ 1 ], desc ]

--- a/test/unit/assertions/assert_instance_of_tests.rb
+++ b/test/unit/assertions/assert_instance_of_tests.rb
@@ -6,7 +6,7 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertInstanceOfTests < Assert::Context
-    desc "the assert_instance_of helper"
+    desc "`assert_instance_of`"
     setup do
       desc = @desc = "assert instance of fail desc"
       args = @args = [ Array, "object", desc ]
@@ -26,15 +26,15 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class}) to"\
-            " be an instance of #{@args[0]}."
+      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
+            " to be an instance of #{@args[0]}."
       assert_equal exp, subject.fail_results.first.message
     end
 
   end
 
   class AssertNotInstanceOfTests < Assert::Context
-    desc "the assert_not_instance_of helper"
+    desc "`assert_not_instance_of`"
     setup do
       desc = @desc = "assert not instance of fail desc"
       args = @args = [ String, "object", desc ]
@@ -54,8 +54,8 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n#{Assert::U.show(@args[1], @c)} (#{@args[1].class}) not expected to"\
-            " be an instance of #{@args[0]}."
+      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
+            " to not be an instance of #{@args[0]}."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_kind_of_tests.rb
+++ b/test/unit/assertions/assert_kind_of_tests.rb
@@ -6,7 +6,7 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertKindOfTests < Assert::Context
-    desc "the assert_kind_of helper"
+    desc "`assert_kind_of`"
     setup do
       desc = @desc = "assert kind of fail desc"
       args = @args = [ Array, "object", desc ]
@@ -26,15 +26,15 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class}) to"\
-            " be a kind of #{@args[0]}."
+      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
+            " to be a kind of #{@args[0]}."
       assert_equal exp, subject.fail_results.first.message
     end
 
   end
 
   class AssertNotKindOfTests < Assert::Context
-    desc "the assert_not_kind_of helper"
+    desc "`assert_not_kind_of`"
     setup do
       desc = @desc = "assert not kind of fail desc"
       args = @args = [ String, "object", desc ]
@@ -54,7 +54,8 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n#{Assert::U.show(@args[1], @c)} not expected to be a kind of #{@args[0]}."
+      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
+            " to not be a kind of #{@args[0]}."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_match_tests.rb
+++ b/test/unit/assertions/assert_match_tests.rb
@@ -6,7 +6,7 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertMatchTests < Assert::Context
-    desc "the assert_match helper"
+    desc "`assert_match`"
     setup do
       desc = @desc = "assert match fail desc"
       args = @args = [ "not", "a string", desc ]
@@ -34,7 +34,7 @@ module Assert::Assertions
   end
 
   class AssertNotMatchTests < Assert::Context
-    desc "the assert_not_match helper"
+    desc "`assert_not_match`"
     setup do
       desc = @desc = "assert not match fail desc"
       args = @args = [ /a/, "a string", desc ]
@@ -54,8 +54,8 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n#{Assert::U.show(@args[1], @c)}"\
-            " not expected to match #{Assert::U.show(@args[0], @c)}."
+      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)}"\
+            " to not match #{Assert::U.show(@args[0], @c)}."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_nil_tests.rb
+++ b/test/unit/assertions/assert_nil_tests.rb
@@ -6,7 +6,7 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertNilTests < Assert::Context
-    desc "the assert_nil helper"
+    desc "`assert_nil`"
     setup do
       desc = @desc = "assert nil empty fail desc"
       args = @args = [ 1, desc ]
@@ -26,14 +26,14 @@ module Assert::Assertions
     end
 
     should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected nil, not #{Assert::U.show(@args[0], @c)}."
+      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to be nil."
       assert_equal exp, subject.fail_results.first.message
     end
 
   end
 
   class AssertNotNilTests < Assert::Context
-    desc "the assert_not_nil helper"
+    desc "`assert_not_nil`"
     setup do
       desc = @desc = "assert not nil empty fail desc"
       args = @args = [ nil, desc ]

--- a/test/unit/assertions/assert_raises_tests.rb
+++ b/test/unit/assertions/assert_raises_tests.rb
@@ -4,7 +4,7 @@ require 'assert/assertions'
 module Assert::Assertions
 
   class AssertRaisesTests < Assert::Context
-    desc "the assert_raises helper"
+    desc "`assert_raises`"
     setup do
       d = @d = "assert raises fail desc"
       @test = Factory.test do
@@ -38,7 +38,7 @@ module Assert::Assertions
   end
 
   class AssertNothingRaisedTests < Assert::Context
-    desc "the assert_nothing_raised helper"
+    desc "`assert_nothing_raised`"
     setup do
       d = @d = "assert nothing raised fail desc"
       @test = Factory.test do

--- a/test/unit/assertions/assert_respond_to_tests.rb
+++ b/test/unit/assertions/assert_respond_to_tests.rb
@@ -6,7 +6,7 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertRespondToTest < Assert::Context
-    desc "the assert_respond_to helper"
+    desc "`assert_respond_to`"
     setup do
       desc = @desc = "assert respond to fail desc"
       args = @args = [ :abs, "1", desc ]
@@ -35,7 +35,7 @@ module Assert::Assertions
   end
 
   class AssertNotRespondToTests < Assert::Context
-    desc "the assert_not_respond_to helper"
+    desc "`assert_not_respond_to`"
     setup do
       desc = @desc = "assert not respond to fail desc"
       args = @args = [ :abs, 1, desc ]
@@ -56,8 +56,8 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "#{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
-            " not expected to respond to `#{@args[0]}`."
+            "Expected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
+            " to not respond to `#{@args[0]}`."
       assert_equal exp, subject.fail_results.first.message
     end
 

--- a/test/unit/assertions/assert_same_tests.rb
+++ b/test/unit/assertions/assert_same_tests.rb
@@ -28,9 +28,9 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "#{Assert::U.show(@args[1], @c)}"\
+            "Expected #{Assert::U.show(@args[1], @c)}"\
             " (#<#{@args[1].class}:#{'0x0%x' % (@args[1].object_id << 1)}>)"\
-            " expected to be the same as #{Assert::U.show(@args[0], @c)}"\
+            " to be the same as #{Assert::U.show(@args[0], @c)}"\
             " (#<#{@args[0].class}:#{'0x0%x' % (@args[0].object_id << 1)}>)."
       assert_equal exp, subject.fail_results.first.message
     end
@@ -60,9 +60,9 @@ module Assert::Assertions
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
-            "#{Assert::U.show(@args[1], @c)}"\
+            "Expected #{Assert::U.show(@args[1], @c)}"\
             " (#<#{@args[1].class}:#{'0x0%x' % (@args[1].object_id << 1)}>)"\
-            " not expected to be the same as #{Assert::U.show(@args[0], @c)}"\
+            " to not be the same as #{Assert::U.show(@args[0], @c)}"\
             " (#<#{@args[0].class}:#{'0x0%x' % (@args[0].object_id << 1)}>)."
       assert_equal exp, subject.fail_results.first.message
     end
@@ -97,8 +97,8 @@ module Assert::Assertions
     subject{ @test }
 
     should "include diff output in the fail messages" do
-      exp = "#<#{@act_obj.class}:#{'0x0%x' % (@act_obj.object_id << 1)}>"\
-            " expected to be the same as"\
+      exp = "Expected #<#{@act_obj.class}:#{'0x0%x' % (@act_obj.object_id << 1)}>"\
+            " to be the same as"\
             " #<#{@exp_obj.class}:#{'0x0%x' % (@exp_obj.object_id << 1)}>"\
             ", diff:\n"\
             "#{Assert::U.syscmd_diff_proc.call(@exp_obj_show, @act_obj_show)}"
@@ -122,8 +122,8 @@ module Assert::Assertions
     subject{ @test }
 
     should "include diff output in the fail messages" do
-      exp = "#<#{@act_obj.class}:#{'0x0%x' % (@act_obj.object_id << 1)}>"\
-            " not expected to be the same as"\
+      exp = "Expected #<#{@act_obj.class}:#{'0x0%x' % (@act_obj.object_id << 1)}>"\
+            " to not be the same as"\
             " #<#{@exp_obj.class}:#{'0x0%x' % (@exp_obj.object_id << 1)}>"\
             ", diff:\n"\
             "#{Assert::U.syscmd_diff_proc.call(@exp_obj_show, @act_obj_show)}"


### PR DESCRIPTION
This standardizes all assertion fail messages to use the format:
`"Expected {act-value} to {not }be {something|exp-value}".

Before, the messages had difference formats depending on various
things like the nature of the assertion, when the assertion was
added, and whether it was a "not" assertion.  This cleans things
up and makes them consistent so there is no guessing how to write
the fail messages when implementing a new assertion.

This also includes some cleanups to the assertion tests.

@jcredding - no new behavior, just cleanups (since this latest assert effort is becoming mainly about cleanups).  Ready for review.
