### PR TITLE
assert true/false assertions

### DIFF
--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -149,6 +149,32 @@ module Assert
     end
     alias_method :refute_nil, :assert_not_nil
 
+    def assert_true(object, desc = nil)
+      assert(object == true, desc) do
+        "Expected #{Assert::U.show(object, __assert_config__)} to be true."
+      end
+    end
+
+    def assert_not_true(object, desc = nil)
+      assert(object != true, desc) do
+        "Expected #{Assert::U.show(object, __assert_config__)} to not be true."
+      end
+    end
+    alias_method :refute_true, :assert_not_true
+
+    def assert_false(object, desc = nil)
+      assert(object == false, desc) do
+        "Expected #{Assert::U.show(object, __assert_config__)} to be false."
+      end
+    end
+
+    def assert_not_false(object, desc = nil)
+      assert(object != false, desc) do
+        "Expected #{Assert::U.show(object, __assert_config__)} to not be false."
+      end
+    end
+    alias_method :refute_false, :assert_not_false
+
     def assert_raises(*exceptions, &block)
       desc = exceptions.last.kind_of?(String) ? exceptions.pop : nil
       err = RaisedException.new(exceptions, &block)

--- a/test/unit/assertions/assert_true_false_tests.rb
+++ b/test/unit/assertions/assert_true_false_tests.rb
@@ -1,0 +1,116 @@
+require 'assert'
+require 'assert/assertions'
+
+require 'assert/utils'
+
+module Assert::Assertions
+
+  class AssertTrueTests < Assert::Context
+    desc "`assert_true`"
+    setup do
+      desc = @desc = "assert true fail desc"
+      args = @args = [ 'whatever', desc ]
+      @test = Factory.test do
+        assert_true(true)  # pass
+        assert_true(*args) # fail
+      end
+      @c = @test.config
+      @test.run
+    end
+    subject{ @test }
+
+    should "produce results as expected" do
+      assert_equal 2, subject.result_count
+      assert_equal 1, subject.result_count(:pass)
+      assert_equal 1, subject.result_count(:fail)
+    end
+
+    should "have a fail message with custom and generic explanations" do
+      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to be true."
+      assert_equal exp, subject.fail_results.first.message
+    end
+
+  end
+
+  class AssertNotTrueTests < Assert::Context
+    desc "`assert_not_true`"
+    setup do
+      desc = @desc = "assert not true fail desc"
+      args = @args = [ true, desc ]
+      @test = Factory.test do
+        assert_not_true(false) # pass
+        assert_not_true(*args) # fail
+      end
+      @c = @test.config
+      @test.run
+    end
+    subject{ @test }
+
+    should "produce results as expected" do
+      assert_equal 2, subject.result_count
+      assert_equal 1, subject.result_count(:pass)
+      assert_equal 1, subject.result_count(:fail)
+    end
+
+    should "have a fail message with custom and generic explanations" do
+      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to not be true."
+      assert_equal exp, subject.fail_results.first.message
+    end
+
+  end
+
+  class AssertFalseTests < Assert::Context
+    desc "`assert_false`"
+    setup do
+      desc = @desc = "assert false fail desc"
+      args = @args = [ 'whatever', desc ]
+      @test = Factory.test do
+        assert_false(false) # pass
+        assert_false(*args) # fail
+      end
+      @c = @test.config
+      @test.run
+    end
+    subject{ @test }
+
+    should "produce results as expected" do
+      assert_equal 2, subject.result_count
+      assert_equal 1, subject.result_count(:pass)
+      assert_equal 1, subject.result_count(:fail)
+    end
+
+    should "have a fail message with custom and generic explanations" do
+      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to be false."
+      assert_equal exp, subject.fail_results.first.message
+    end
+
+  end
+
+  class AssertNotFalseTests < Assert::Context
+    desc "`assert_not_false`"
+    setup do
+      desc = @desc = "assert not false fail desc"
+      args = @args = [ false, desc ]
+      @test = Factory.test do
+        assert_not_false(true)  # pass
+        assert_not_false(*args) # fail
+      end
+      @c = @test.config
+      @test.run
+    end
+    subject{ @test }
+
+    should "produce results as expected" do
+      assert_equal 2, subject.result_count
+      assert_equal 1, subject.result_count(:pass)
+      assert_equal 1, subject.result_count(:fail)
+    end
+
+    should "have a fail message with custom and generic explanations" do
+      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to not be false."
+      assert_equal exp, subject.fail_results.first.message
+    end
+
+  end
+
+end

--- a/test/unit/assertions_tests.rb
+++ b/test/unit/assertions_tests.rb
@@ -28,6 +28,8 @@ module Assert::Assertions
     should have_imeths :assert_included, :assert_not_included
     should have_imeths :refute_includes, :refute_included
     should have_imeths :assert_nil, :assert_not_nil, :refute_nil
+    should have_imeths :assert_true, :assert_not_true, :refute_true
+    should have_imeths :assert_false, :assert_not_false, :refute_false
     should have_imeths :assert_file_exists, :assert_not_file_exists, :refute_file_exists
 
   end


### PR DESCRIPTION
This adds new assertions for asserting things are (not) true/false.
This provides a more expressive form of doing an "equal true/false"
assertion.

Closes #175 

@jcredding ready for review.
