### PR TITLE
cleanup/rework how setups/teardowns are run

### DIFF
--- a/lib/assert/test.rb
+++ b/lib/assert/test.rb
@@ -89,7 +89,7 @@ module Assert
     def run_test_setup(scope)
       capture_output do
         # run any assert style 'setup do' setups
-        self.context_class.setup(scope)
+        self.context_class.send('run_setups', scope)
 
         # run any classic test/unit style 'def setup' setups
         scope.setup if scope.respond_to?(:setup)
@@ -112,7 +112,7 @@ module Assert
         scope.teardown if scope.respond_to?(:teardown)
 
         # run any assert style 'teardown do' teardowns
-        self.context_class.teardown(scope)
+        self.context_class.send('run_teardowns', scope)
       end
     end
 

--- a/test/unit/context/setup_dsl_tests.rb
+++ b/test/unit/context/setup_dsl_tests.rb
@@ -91,10 +91,10 @@ module Assert::Context::SetupDSL
     end
 
     should "run it's parent and it's own blocks in the correct order" do
-      subject.setup(obj = @test_status_class.new)
+      subject.send('run_setups', obj = @test_status_class.new)
       assert_equal "the setup has been run with something", obj.setup_status
 
-      subject.teardown(obj = @test_status_class.new)
+      subject.send('run_teardowns', obj = @test_status_class.new)
       assert_equal "with something has been run the teardown", obj.teardown_status
     end
 

--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -19,8 +19,8 @@ class Assert::Context
     should have_cmeths :description, :desc, :describe, :subject, :suite
     should have_cmeths :setup_once, :before_once, :startup
     should have_cmeths :teardown_once, :after_once, :shutdown
-    should have_cmeths :setup, :before, :setups
-    should have_cmeths :teardown, :after, :teardowns
+    should have_cmeths :setup, :before, :setups, :run_setups
+    should have_cmeths :teardown, :after, :teardowns, :run_teardowns
     should have_cmeths :test, :test_eventually, :test_skip
     should have_cmeths :should, :should_eventually, :should_skip
 


### PR DESCRIPTION
Previously the single `setup` method was used both to add blocks
or methods _and_ to run the added setups.  This was originally
done to minimize "method pollution" on the context class, but this
reasoning doesn't seem to outweigh the added complexity of determining
which case this method is being called for.

This breaks out a new method `run_setup` to more implicitly know
when you are adding a setup or running them.

Same thing goes for the teardowns.  This doesn't change the "intended"
API as `run_setup` is only called internally.  This is in prep for
doing the "around" callbacks feature.

@jcredding ready for review.
