### PR TITLE
`around` context callback

### DIFF
--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -21,6 +21,7 @@ class Assert::Context
     should have_cmeths :teardown_once, :after_once, :shutdown
     should have_cmeths :setup, :before, :setups, :run_setups
     should have_cmeths :teardown, :after, :teardowns, :run_teardowns
+    should have_cmeths :around, :arounds, :run_arounds
     should have_cmeths :test, :test_eventually, :test_skip
     should have_cmeths :should, :should_eventually, :should_skip
 


### PR DESCRIPTION
This method is designed to run before and after the test runs.  It
should expect a block argument and should call the block at some
point to ensure the test runs.

This is designed to be used with things that need to run blocks
manually - things like:
- `File.open do`
- `Benchmark.new do`
- `Transaction.new do`
  etc.

Closes #157.

@jcredding ready for review.
