### PR TITLE
capture individual test run time and result rate

### DIFF
--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -23,11 +23,11 @@ module Assert
     end
 
     def test_rate
-      get_rate(self.tests.size, self.run_time.to_f)
+      get_rate(self.tests.size, self.run_time)
     end
 
     def result_rate
-      get_rate(self.results.size, self.run_time.to_f)
+      get_rate(self.results.size, self.run_time)
     end
 
     alias_method :ordered_tests, :tests

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -25,7 +25,7 @@ class Assert::Suite
       assert_equal(exp, act)
     end
 
-    should "have a zero run time, test rate and result by default" do
+    should "have a zero run time, test rate and result rate by default" do
       assert_equal 0, subject.run_time
       assert_equal 0, subject.test_rate
       assert_equal 0, subject.result_rate

--- a/test/unit/test_tests.rb
+++ b/test/unit/test_tests.rb
@@ -16,8 +16,8 @@ class Assert::Test
     subject{ @test }
 
     should have_readers :name, :context_info, :config, :code
-    should have_accessors :results, :output
-    should have_imeths :run, :result_count, :context_class
+    should have_accessors :results, :output, :run_time
+    should have_imeths :run, :result_count, :result_rate, :context_class
     should have_imeths *Assert::Result.types.keys.collect{ |k| "#{k}_results" }
 
     should "build its name from the context description" do
@@ -45,6 +45,17 @@ class Assert::Test
 
     should "have zero results before running" do
       assert_equal 0, subject.result_count
+    end
+
+    should "have a zero run time and result rate by default" do
+      assert_equal 0, subject.run_time
+      assert_equal 0, subject.result_rate
+    end
+
+    should "have a non-zero run time and result rate after it is run" do
+      subject.run
+      assert_not_equal 0, subject.run_time
+      assert_not_equal 0, subject.result_rate
     end
 
     should "have a custom inspect that only shows limited attributes" do


### PR DESCRIPTION
Much like the suite, the captures run time and result rate for
individual tests.  More stats the better, right?  This will be used
in an upcoming feature to display test details and profile info in
the default view.

I choose this benchmark implementation b/c it had the least amount
of performance impact.

Related to #142.

@jcredding ready for review.
