### PR TITLE
add option to show test profile info; add to the default view

### DIFF
--- a/lib/assert/cli.rb
+++ b/lib/assert/cli.rb
@@ -42,6 +42,9 @@ module Assert
         option 'pp_objects', 'pretty-print objects in fail messages', {
           :abbrev => 'p'
         }
+        option 'profile', 'output test profile info', {
+          :abbrev => 'e'
+        }
         # show loaded test files, cli err backtraces, etc
         option 'debug', 'run in debug mode'
       end

--- a/lib/assert/config.rb
+++ b/lib/assert/config.rb
@@ -16,7 +16,8 @@ module Assert
     settings :view, :suite, :runner
     settings :test_dir, :test_helper, :test_file_suffixes, :runner_seed
     settings :changed_proc, :pp_proc, :use_diff_proc, :run_diff_proc
-    settings :capture_output, :halt_on_fail, :changed_only, :pp_objects, :debug
+    settings :capture_output, :halt_on_fail, :changed_only, :pp_objects
+    settings :debug, :profile
 
     def initialize(settings = nil)
       @suite  = Assert::Suite.new(self)
@@ -39,6 +40,7 @@ module Assert
       @changed_only   = false
       @pp_objects     = false
       @debug          = false
+      @profile        = false
 
       self.apply(settings || {})
     end

--- a/lib/assert/view/default_view.rb
+++ b/lib/assert/view/default_view.rb
@@ -61,6 +61,17 @@ module Assert::View
         end
       end
 
+      # show profile output
+      if show_test_profile_info?
+        ordered_profile_tests.each do |test|
+          puts "#{test_run_time(test)} seconds,"\
+               " #{test.result_count} results,"\
+               " #{test_result_rate(test)} results/s --"\
+               " #{test.context_class}: #{test.name.inspect}"
+        end
+        puts
+      end
+
       # style the summaries of each result set
       styled_results_sentence = results_summary_sentence do |summary, sym|
         ansi_styled_msg(summary, result_ansi_styles(sym))

--- a/lib/assert/view/helpers/common.rb
+++ b/lib/assert/view/helpers/common.rb
@@ -37,6 +37,16 @@ module Assert::View::Helpers
       format % self.suite.result_rate
     end
 
+    # get the formatted run time for an idividual test
+    def test_run_time(test, format = '%.6f')
+      format % test.run_time
+    end
+
+    # get the formatted result rate for an individual test
+    def test_result_rate(test, format = '%.6f')
+      format % test.result_rate
+    end
+
     # get a uniq list of contexts for the test suite
     def suite_contexts
       @suite_contexts ||= self.suite.tests.inject([]) do |contexts, test|
@@ -57,6 +67,14 @@ module Assert::View::Helpers
 
     def ordered_suite_files
       self.suite_files.sort{|a,b| a.to_s <=> b.to_s}
+    end
+
+    def ordered_profile_tests
+      suite.ordered_tests.sort{ |a, b| a.run_time <=> b.run_time }
+    end
+
+    def show_test_profile_info?
+      !!config.profile
     end
 
     # get all the result details for a set of tests

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -13,7 +13,8 @@ class Assert::Config
     should have_imeths :suite, :view, :runner
     should have_imeths :test_dir, :test_helper, :test_file_suffixes, :runner_seed
     should have_imeths :changed_proc, :pp_proc, :use_diff_proc, :run_diff_proc
-    should have_imeths :capture_output, :halt_on_fail, :changed_only, :pp_objects, :debug
+    should have_imeths :capture_output, :halt_on_fail, :changed_only, :pp_objects
+    should have_imeths :debug, :profile
     should have_imeths :apply
 
     should "default the view, suite, and runner" do
@@ -42,6 +43,7 @@ class Assert::Config
       assert_not subject.changed_only
       assert_not subject.pp_objects
       assert_not subject.debug
+      assert_not subject.profile
     end
 
     should "apply settings given from a hash" do

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -22,9 +22,11 @@ class Assert::View::Base
     # common methods
     should have_imeths :runner_seed, :count, :tests?, :all_pass?
     should have_imeths :run_time, :test_rate, :result_rate
+    should have_imeths :test_run_time, :test_result_rate
     should have_imeths :suite_contexts, :ordered_suite_contexts
     should have_imeths :suite_files, :ordered_suite_files
-    should have_imeths :result_details_for, :show_result_details?
+    should have_imeths :ordered_profile_tests, :show_test_profile_info?
+    should have_imeths :result_details_for, :matched_result_details_for, :show_result_details?
     should have_imeths :ocurring_result_types, :result_summary_msg
     should have_imeths :all_pass_result_summary_msg, :results_summary_sentence
     should have_imeths :test_count_statement, :result_count_statement


### PR DESCRIPTION
This adds a new cli option, `-e`, to switch whether to show test
profile info.  This also adds some common view methods for querying
and displaying profile info.  The tests are outputted from fastest
run time to slowest so the slowest tests are the most obvious.

Finally, this adds displaying this profile info if that option is on
to the default view.  In the default view, "profile info" means
the test run time, test result count, test result rate, plus the test
class/name for each test.

@jcredding ready for review.  I'll add some notes/screenshots to show the output.
