### PR TITLE
fixes to get the test suite passing in ree, mri, and rbx.

### DIFF
--- a/lib/assert/context/setup_dsl.rb
+++ b/lib/assert/context/setup_dsl.rb
@@ -29,8 +29,6 @@ class Assert::Context
     end
     alias_method :after, :teardown
 
-    protected
-
     def arounds
       @arounds ||= []
     end

--- a/test/unit/utils_tests.rb
+++ b/test/unit/utils_tests.rb
@@ -47,7 +47,7 @@ module Assert::Utils
     desc "`show_for_diff`"
     setup do
       @w_newlines = { :string => "herp derp, derp herp\nherpderpedia" }
-      @w_obj_id = Struct.new(:a, :b).new('aye', 'bee')
+      @w_obj_id = Class.new.new
     end
 
     should "call show, escaping newlines" do
@@ -56,7 +56,7 @@ module Assert::Utils
     end
 
     should "make any obj ids generic" do
-      exp_out = "#<struct #<Class:0xXXXXXX> a=\"aye\", b=\"bee\">"
+      exp_out = "#<#<Class:0xXXXXXX>:0xXXXXXX>"
       assert_equal exp_out, subject.show_for_diff(@w_obj_id, Factory.modes_off_config)
     end
 


### PR DESCRIPTION
In rbx/mri, structs don't output hex id information in their inspects,
so I switched to using an anonymous class for the test to obfuscate
hex obj ids in show output for diffs.

I switched to making the protected context setup dsl methods public.
This is because mri/rbx require pass `true` as the second arg if
testing responds to on private/protected methods.  There really isn't
any value in these singleton methods being protected and I'm testing
and using them in tests as if they are public anyway.

Overall, this gets the gem's test suite passing on these ruby versions:
- ree-1.8.7
- mri-2.1.0
- rbx-2.2.3

Closes #182.

@jcredding ready for review.
