### PR TITLE
basic factory for generating random raw data

### DIFF
--- a/lib/assert/factory.rb
+++ b/lib/assert/factory.rb
@@ -1,0 +1,146 @@
+require 'date'
+require 'time'
+
+module Assert
+
+  module Factory
+    extend self
+
+    def integer(max = nil)
+      self.type_cast(Random.integer(max), :integer)
+    end
+
+    def float(max = nil)
+      self.type_cast(Random.float(max), :float)
+    end
+
+    DAYS_IN_A_YEAR = 365
+    SECONDS_IN_DAY = 24 * 60 * 60
+
+    def date
+      @date ||= self.type_cast(Random.date_string, :date)
+      @date + Random.integer(DAYS_IN_A_YEAR)
+    end
+
+    def time
+      @time ||= self.type_cast(Random.time_string, :time)
+      @time + (Random.float(DAYS_IN_A_YEAR) * SECONDS_IN_DAY).to_i
+    end
+
+    def datetime
+      @datetime ||= self.type_cast(Random.datetime_string, :datetime)
+      @datetime + (Random.float(DAYS_IN_A_YEAR) * SECONDS_IN_DAY).to_i
+    end
+
+    def string(length = nil)
+      self.type_cast(Random.string(length), :string)
+    end
+
+    def text(length = nil)
+      self.type_cast(Random.string(length || 20), :string)
+    end
+
+    def slug(length = nil)
+      self.type_cast(Random.slug_string(length), :string)
+    end
+
+    def hex(length = nil)
+      self.type_cast(Random.hex_string(length), :string)
+    end
+
+    def file_name(length = nil)
+      self.type_cast(Random.file_name_string(length), :string)
+    end
+
+    def dir_path(length = nil)
+      self.type_cast(Random.dir_path_string(length), :string)
+    end
+
+    def file_path
+      self.type_cast(Random.file_path_string, :string)
+    end
+
+    def binary
+      self.type_cast(Random.binary, :binary)
+    end
+
+    def boolean
+      self.type_cast(Random.integer.even?, :boolean)
+    end
+
+    def type_cast(value, type)
+      self.type_converter.send(type, value)
+    end
+
+    def type_converter; TypeConverter; end
+
+    module TypeConverter
+      def self.string(input);    input.to_s;                 end
+      def self.integer(input);   input.to_i;                 end
+      def self.float(input);     input.to_f;                 end
+      def self.datetime(input);  DateTime.parse(input.to_s); end
+      def self.time(input);      Time.parse(input.to_s);     end
+      def self.date(input);      Date.parse(input.to_s);     end
+      def self.boolean(input);   !!input;                    end
+      def self.binary(input);    input;                      end
+    end
+
+    module Random
+      def self.integer(max = nil)
+        rand(max || 100) + 1
+      end
+
+      # `rand` with no args gives a float between 0 and 1
+      def self.float(max = nil)
+        (self.integer((max || 100) - 1) + rand).to_f
+      end
+
+      def self.date_string
+        Time.now.strftime("%Y-%m-%d")
+      end
+
+      def self.datetime_string
+        Time.now.strftime("%Y-%m-%d %H:%M:%S")
+      end
+
+      def self.time_string
+        Time.now.strftime("%H:%M:%S")
+      end
+
+      DICTIONARY = [*'a'..'z'].freeze
+      def self.string(length = nil)
+        [*0..((length || 10) - 1)].map{ |n| DICTIONARY[rand(DICTIONARY.size)] }.join
+      end
+
+      def self.slug_string(length = nil)
+        length ||= 8
+        self.string(length).scan(/.{1,4}/).join('-')
+      end
+
+      def self.hex_string(length = nil)
+        length ||= 10
+        self.integer(("f" * length).hex - 1).to_s(16).rjust(length, '0')
+      end
+
+      def self.file_name_string(length = nil)
+        length ||= 6
+        "#{self.string(length)}.#{self.string(3)}"
+      end
+
+      def self.dir_path_string(length = nil)
+        length ||= 12
+        File.join(*self.string(length).scan(/.{1,4}/))
+      end
+
+      def self.file_path_string
+        File.join(self.dir_path_string, self.file_name_string)
+      end
+
+      def self.binary
+        [ self.integer(10000) ].pack('N*')
+      end
+    end
+
+  end
+
+end

--- a/test/unit/factory_tests.rb
+++ b/test/unit/factory_tests.rb
@@ -1,0 +1,132 @@
+require 'assert'
+require 'assert/factory'
+
+module Assert::Factory
+
+  class UnitTests < Assert::Context
+    desc "Assert::Factory"
+    subject{ Assert::Factory }
+
+    should have_imeths :integer, :float
+    should have_imeths :date, :time, :datetime
+    should have_imeths :string, :text, :slug, :hex
+    should have_imeths :file_name, :dir_path, :file_path
+    should have_imeths :binary, :boolean
+    should have_imeths :type_cast, :type_converter
+
+    should "return a random integer using `integer`" do
+      assert_kind_of Integer, subject.integer
+    end
+
+    should "allow passing a maximum value using `integer`" do
+      assert_includes subject.integer(2), [ 1, 2 ]
+    end
+
+    should "return a random float using `float`" do
+      assert_kind_of Float, subject.float
+    end
+
+    should "allow passing a maximum value using `float`" do
+      float = subject.float(2)
+      assert float <= 2
+      assert float >= 1
+    end
+
+    should "return a random date using `date`" do
+      assert_kind_of Date, subject.date
+    end
+
+    should "return a random time object using `time`" do
+      assert_kind_of Time, subject.time
+    end
+
+    should "return a random time object using `datetime`" do
+      assert_kind_of DateTime, subject.datetime
+    end
+
+    should "return a random string using `string`" do
+      assert_kind_of String, subject.string
+      assert_equal 10, subject.string.length
+    end
+
+    should "allow passing a maximum length using `string`" do
+      assert_equal 1, subject.string(1).length
+    end
+
+    should "return a random string using `text`" do
+      assert_kind_of String, subject.text
+      assert_equal 20, subject.text.length
+    end
+
+    should "allow passing a maximum length using `text`" do
+      assert_equal 1, subject.text(1).length
+    end
+
+    should "return a random hex string using `hex`" do
+      assert_kind_of String, subject.hex
+      assert_match /\A[0-9a-f]{10}\Z/, subject.hex
+    end
+
+    should "allow passing a maximum length using `hex`" do
+      assert_equal 1, subject.hex(1).length
+    end
+
+    should "return a random slug string using `slug`" do
+      assert_kind_of String, subject.slug
+      segments = subject.slug.split('-')
+      assert_equal 2, segments.size
+      segments.each{ |s| assert_match /\A[a-z]{4}\Z/, s }
+    end
+
+    should "allow passing a maximum length using `slug`" do
+      assert_equal 1, subject.slug(1).length
+    end
+
+    should "return a random file name string using `file_name`" do
+      assert_kind_of String, subject.file_name
+      assert_match /\A[a-z]{6}\.[a-z]{3}\Z/, subject.file_name
+    end
+
+    should "allow passing a name length using `file_name`" do
+      assert_match /\A[a-z]{1}.[a-z]{3}\Z/, subject.file_name(1)
+    end
+
+    should "return a random folder path string using `dir_path`" do
+      assert_kind_of String, subject.dir_path
+      path_segments = subject.dir_path.split('/')
+      assert_equal 3, path_segments.size
+      path_segments.each{ |s| assert_match /\A[a-z]{4}\Z/, s }
+    end
+
+    should "allow passing a maximum length using `dir_path`" do
+      assert_equal 1, subject.dir_path(1).length
+    end
+
+    should "return a random folder path and file name using `file_path`" do
+      assert_kind_of String, subject.file_path
+      segments = subject.file_path.split('/')
+      assert_equal 4, segments.size
+      segments[0..-2].each{ |s| assert_match /\A[a-z]{4}\Z/, s }
+      assert_match /\A[a-z]{6}\.[a-z]{3}\Z/, segments.last
+    end
+
+    should "return a random binary string using `binary`" do
+      assert_kind_of String, subject.binary
+    end
+
+    should "return a random boolean using `boolean`" do
+      assert_includes subject.boolean.class, [ TrueClass, FalseClass ]
+    end
+
+    should "type cast values to a specified type using `type_cast`" do
+      expected = Date.parse('2013-01-01')
+      assert_equal expected, subject.type_cast('2013-01-01', :date)
+    end
+
+    should "use `TypedConverter` for the default type converter" do
+      assert_equal TypeConverter, subject.type_converter
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a helper module `Factory` that will generate random raw
data values.  Use this to seed test objects with data.  Because
the data is random, it helps prevent false-positive tests due to
hard coded expectations, etc.

This module is optional so it isn't required as part of requiring
in assert proper.

Closes #185.

@jcredding I ripped this from the similar stuff you did in MR (the relevant parts anyway).  Thoughts?  This came up b/c I was writing tests in a non-db app (so not using MR) and I found myself wanting to just shove in some random "factory" data in my object-under-test.  I'm hoping we can alter MR to use some of this (really it would extend it).  Anyway, let me know what you think.
