### PR TITLE
use the equality operator of the exp value in equal assertions

### DIFF
--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -27,7 +27,7 @@ module Assert
     alias_method :refute_empty, :assert_not_empty
 
     def assert_equal(exp, act, desc = nil)
-      assert(act == exp, desc) do
+      assert(exp == act, desc) do
         c = __assert_config__
         exp_show = Assert::U.show_for_diff(exp, c)
         act_show = Assert::U.show_for_diff(act, c)
@@ -42,7 +42,7 @@ module Assert
     end
 
     def assert_not_equal(exp, act, desc = nil)
-      assert(act != exp, desc) do
+      assert(exp != act, desc) do
         c = __assert_config__
         exp_show = Assert::U.show_for_diff(exp, c)
         act_show = Assert::U.show_for_diff(act, c)

--- a/test/unit/assertions/assert_equal_tests.rb
+++ b/test/unit/assertions/assert_equal_tests.rb
@@ -61,6 +61,27 @@ module Assert::Assertions
 
   end
 
+  class EqualOrderTests < Assert::Context
+    desc "with objects that define custom equality operators"
+    setup do
+      is_class = Class.new do
+        def ==(other); true; end
+      end
+      @is = is_class.new
+
+      is_not_class = Class.new do
+        def ==(other); false; end
+      end
+      @is_not = is_not_class.new
+    end
+
+    should "use the equality operator of the exp value" do
+      assert_equal @is, @is_not
+      assert_not_equal @is_not, @is
+    end
+
+  end
+
   class DiffTests < Assert::Context
     desc "with objects that should use diff when showing"
     setup do


### PR DESCRIPTION
This switches the order of the equality comparison in
`assert_equal` to prefer the equality operator of the expected
value.  The idea is that the expected value is known and intended
so it should be the "basis" for the equality test as opposed to
the actual value that is unknown not always intended.

This is a very subtle change that really only comes into play when
you are comparing two objects that both define a custom equality
operator.

Closes #184.

@jcredding ready for review.
