### PR TITLE
add factories for `path` and `url`

### DIFF
--- a/lib/assert/factory.rb
+++ b/lib/assert/factory.rb
@@ -60,6 +60,12 @@ module Assert
       self.type_cast(Random.file_path_string, :string)
     end
 
+    alias_method :path, :dir_path
+
+    def url(host = nil, length = nil)
+      self.type_cast(Random.url_string(host, length), :string)
+    end
+
     def binary
       self.type_cast(Random.binary, :binary)
     end
@@ -134,6 +140,10 @@ module Assert
 
       def self.file_path_string
         File.join(self.dir_path_string, self.file_name_string)
+      end
+
+      def self.url_string(host = nil, length = nil)
+        File.join(host.to_s, self.dir_path_string(length))
       end
 
       def self.binary

--- a/test/unit/factory_tests.rb
+++ b/test/unit/factory_tests.rb
@@ -11,6 +11,7 @@ module Assert::Factory
     should have_imeths :date, :time, :datetime
     should have_imeths :string, :text, :slug, :hex
     should have_imeths :file_name, :dir_path, :file_path
+    should have_imeths :path, :url
     should have_imeths :binary, :boolean
     should have_imeths :type_cast, :type_converter
 
@@ -108,6 +109,25 @@ module Assert::Factory
       assert_equal 4, segments.size
       segments[0..-2].each{ |s| assert_match /\A[a-z]{4}\Z/, s }
       assert_match /\A[a-z]{6}\.[a-z]{3}\Z/, segments.last
+    end
+
+    should "return a random url string using `url`" do
+      u = subject.url
+      segments = u.split('/')
+
+      assert_kind_of String, u
+      assert_match /\A\//, u
+      assert_equal 4, segments.size
+      segments[1..-1].each{ |s| assert_match /\A[a-z]{4}\Z/, s }
+    end
+
+    should "allow passing a host string using `url`" do
+      host = "example.com"
+      assert_match /\A#{host}\//, subject.url(host)
+    end
+
+    should "allow passing a maximum length using `url`" do
+      assert_equal 2, subject.url('', 1).length # plus leading '/'
     end
 
     should "return a random binary string using `binary`" do


### PR DESCRIPTION
This adds some factories for generating random paths and urls.  The
`path` factory is just a more convenient alias for `dir_path`.  The
`url` factory builds on `path`, adding a leading `/` and an optional
host value.

These are just additions to make the factories more expressive.

Closes #189.

@jcredding this is ready for review.  I chose not to auto-require the factory module as it is an optional add-on and I kinda don't want to impose it on you.  I kinda want requiring `'assert'` to be about just adding the stuff needed to run a test and display its results.  Same reasoning for the upcoming `stub` module/add-on.

Let me know your thoughts - I could go either way on this but I'm leaning towards to auto-requiring it.
