### PR TITLE
up the default integer max

### DIFF
--- a/lib/assert/factory.rb
+++ b/lib/assert/factory.rb
@@ -97,7 +97,7 @@ module Assert
 
     module Random
       def self.integer(max = nil)
-        rand(max || 100) + 1
+        rand(max || 32_766) + 1
       end
 
       # `rand` with no args gives a float between 0 and 1


### PR DESCRIPTION
This switches the integer factory to return values up to the
highest signed 8bit integer (`32_767`) value by default.  In large
test suites making many integer factories, the odds of duplicating
an integer become very high.  This can cause uniqueness validations
for things that expect unique integers.

This doesn't totally solve that case, and you can argue you shouldn't
use this factory for things that demand unique integers, but this
increases the probability for getting unique values.

@jcredding going to go ahead and roll this.  FYI.
