### PR TITLE
stubbing class and api

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,69 @@ In addition, Assert adds some helpers and syntax sugar to enhance the way tests 
 
 **Note**: Assert is tested using itself.  The tests are a pretty good place to look for examples and usage patterns.
 
+## Defining tests
+
+TODO
+
+## Factory
+
+TODO
+
+## Stub
+
+```ruby
+myclass = Class.new do
+  def mymeth; 'meth'; end
+  def myval(val); val; end
+end
+myobj = myclass.new
+
+myobj.mymeth
+  # => 'meth'
+myobj.myval(123)
+  # => 123
+myobj.myval(456)
+  # => 456
+
+Assert.stub(myobj, :mymeth)
+myobj.mymeth
+  # => StubError: `mymeth` not stubbed.
+Assert.stub(myobj, :mymeth){ 'stub-meth' }
+myobj.mymeth
+  # => 'stub-meth'
+myobj.mymeth(123)
+  # => StubError: arity mismatch
+Assert.stub(myobj, :mymeth).with(123){ 'stub-meth' }
+  # => StubError: arity mismatch
+
+Assert.stub(myobj, :myval){ 'stub-meth' }
+  # => StubError: arity mismatch
+Assert.stub(myobj, :myval).with(123){ |val| val.to_s }
+myobj.myval
+  # => StubError: arity mismatch
+myobj.mymeth(123)
+  # => '123'
+myobj.mymeth(456)
+  # => StubError: `mymeth(456)` not stubbed.
+
+Assert.unstub(myobj, :mymeth)
+
+myobj.mymeth
+  # => 'meth'
+myobj.myval(123)
+  # => 123
+myobj.myval(456)
+  # => 456
+```
+
+Assert comes with a simple stubbing API - all it does is replace method calls.  In general it tries
+to be friendly and complain if stubbing doesn't match up with the object/method being stubbed:
+
+* each stub takes a block that is called in place of the method
+* complains if you stub a method that the object doesn't respond to
+* complains if you stub with an arity mismatch
+* no methods added to `Object`
+
 ## CLI
 
 ```sh

--- a/lib/assert.rb
+++ b/lib/assert.rb
@@ -3,6 +3,7 @@ require 'assert/version'
 require 'assert/config'
 require 'assert/context'
 require 'assert/runner'
+require 'assert/stub'
 require 'assert/suite'
 require 'assert/utils'
 require 'assert/view'
@@ -15,5 +16,19 @@ module Assert
   def self.view;   self.config.view;   end
   def self.suite;  self.config.suite;  end
   def self.runner; self.config.runner; end
+
+  def self.stubs
+    @stubs ||= {}
+  end
+
+  def self.stub(*args, &block)
+    (self.stubs[Assert::Stub.key(*args)] ||= Assert::Stub.new(*args)).tap do |s|
+      s.do = block
+    end
+  end
+
+  def self.unstub(*args)
+    (self.stubs.delete(Assert::Stub.key(*args)) || Assert::Stub::NullStub.new).teardown
+  end
 
 end

--- a/lib/assert/stub.rb
+++ b/lib/assert/stub.rb
@@ -1,0 +1,95 @@
+module Assert
+
+  StubError = Class.new(ArgumentError)
+
+  class Stub
+
+    NullStub = Class.new do
+      def teardown; end # no-op
+    end
+
+    def self.key(object, method_name)
+      "--#{object.object_id}--#{method_name}--"
+    end
+
+    attr_reader :method_name, :name, :do
+
+    def initialize(object, method_name, &block)
+      @metaclass = class << object; self; end
+      @method_name = method_name.to_s
+      @name = "__assert_stub__#{@method_name}"
+
+      setup(object)
+
+      @do = block || Proc.new do |*args, &block|
+        err_msg = "#{inspect_call(args)} not stubbed."
+        inspect_lookup_stubs.tap do |stubs|
+          err_msg += "\nStubs:\n#{stubs}" if !stubs.empty?
+        end
+        raise StubError, err_msg
+      end
+      @lookup = Hash.new{ |hash, key| self.do }
+    end
+
+    def call(*args, &block)
+      raise StubError, "artiy mismatch" unless arity_matches?(args)
+      @lookup[args].call(*args, &block)
+    end
+
+    def with(*args, &block)
+      raise StubError, "artiy mismatch" unless arity_matches?(args)
+      @lookup[args] = block
+    end
+
+    def do=(block)
+      @do = block || @do
+    end
+
+    def teardown
+      @metaclass.send(:undef_method, @method_name)
+      @metaclass.send(:alias_method, @method_name, @name)
+      @metaclass.send(:undef_method, @name)
+    end
+
+    protected
+
+    def setup(object)
+      unless object.respond_to?(@method_name)
+        raise StubError, "#{object.inspect} does not respond to `#{@method_name}`"
+      end
+      if !object.methods.map(&:to_s).include?(@method_name)
+        @metaclass.send(:define_method, @method_name) do |*args, &block|
+          super(*args, &block)
+        end
+      end
+
+      if !object.respond_to?(@name) # already stubbed
+        @metaclass.send(:alias_method, @name, @method_name)
+      end
+      @method = object.method(@name)
+
+      stub = self
+      @metaclass.send(:define_method, @method_name) do |*args, &block|
+        stub.call(*args, &block)
+      end
+    end
+
+    private
+
+    def arity_matches?(args)
+      return true if @method.arity == args.size # mandatory args
+      return true if @method.arity < 0 && args.size >= (@method.arity+1).abs # variable args
+      return false
+    end
+
+    def inspect_lookup_stubs
+      @lookup.keys.map{ |args| "    - #{inspect_call(args)}" }.join("\n")
+    end
+
+    def inspect_call(args)
+      "`#{@method_name}(#{args.map(&:inspect).join(',')})`"
+    end
+
+  end
+
+end

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 
 require 'assert/config'
+require 'assert/stub'
 
 module Assert
 
@@ -9,6 +10,7 @@ module Assert
     subject { Assert }
 
     should have_imeths :config, :configure, :view, :suite, :runner
+    should have_imeths :stub, :unstub
 
     should "know its config instance" do
       assert_kind_of Assert::Config, subject.config
@@ -22,6 +24,46 @@ module Assert
 
     # Note: don't really need to explicitly test the configure method as
     # nothing runs if it isn't working
+
+  end
+
+  class StubTests < UnitTests
+    setup do
+      @myclass = Class.new do
+        def mymeth; 'meth'; end
+      end
+      @myobj = @myclass.new
+    end
+
+    should "build a stub" do
+      stub1 = Assert.stub(@myobj, :mymeth)
+      assert_kind_of Assert::Stub, stub1
+    end
+
+    should "lookup stubs that have been called before" do
+      stub1 = Assert.stub(@myobj, :mymeth)
+      stub2 = Assert.stub(@myobj, :mymeth)
+      assert_same stub1, stub2
+    end
+
+    should "set the stub's do block if given a block" do
+      Assert.stub(@myobj, :mymeth)
+      assert_raises(StubError){ @myobj.mymeth }
+      Assert.stub(@myobj, :mymeth){ 'mymeth' }
+      assert_equal 'mymeth', @myobj.mymeth
+    end
+
+    should "teardown stubs" do
+      assert_equal 'meth', @myobj.mymeth
+      Assert.unstub(@myobj, :mymeth)
+      assert_equal 'meth', @myobj.mymeth
+
+      assert_equal 'meth', @myobj.mymeth
+      Assert.stub(@myobj, :mymeth){ 'mymeth' }
+      assert_equal 'mymeth', @myobj.mymeth
+      Assert.unstub(@myobj, :mymeth)
+      assert_equal 'meth', @myobj.mymeth
+    end
 
   end
 

--- a/test/unit/stub_tests.rb
+++ b/test/unit/stub_tests.rb
@@ -1,0 +1,195 @@
+require 'assert'
+require 'assert/stub'
+
+class Assert::Stub
+
+  class UnitTests < Assert::Context
+    desc "Assert::Stub"
+    setup do
+      @myclass = Class.new do
+        def mymeth; 'meth'; end
+        def myval(val); val; end
+        def myargs(*args); args; end
+        def myvalargs(val1, val2, *args); [val1, val2, args]; end
+        def myblk(&block); block.call; end
+      end
+      @myobj = @myclass.new
+
+      @stub = Assert::Stub.new(@myobj, :mymeth)
+    end
+    subject{ @stub }
+
+    should have_readers :method_name, :name, :do
+    should have_writers :do
+    should have_cmeths :key
+
+    should "generate a key given an object and method name" do
+      obj = @myobj
+      meth = :mymeth
+      assert_equal "--#{obj.object_id}--#{meth}--", Assert::Stub.key(obj, meth)
+    end
+
+    should "know its names" do
+      assert_equal 'mymeth', subject.method_name
+      assert_equal "__assert_stub__#{subject.method_name}", subject.name
+    end
+
+    should "complain when called if no do block was given" do
+      assert_raises Assert::StubError do
+        @myobj.mymeth
+      end
+
+      subject.do = proc{ 'mymeth' }
+      assert_nothing_raised do
+        @myobj.mymeth
+      end
+
+      assert_nothing_raised do
+        Assert::Stub.new(@myobj, :mymeth){ 'mymeth' }
+      end
+    end
+
+    should "complain if stubbing a method that the object doesn't respond to" do
+      assert_raises Assert::StubError do
+        Assert::Stub.new(@myobj, :some_other_meth)
+      end
+    end
+
+    should "complain if stubbed and called with no `do` proc given" do
+      assert_raises(Assert::StubError){ @myobj.mymeth }
+    end
+
+    should "complain if stubbed and called with mismatched arity" do
+      Assert::Stub.new(@myobj, :myval){ 'myval' }
+      assert_raises(Assert::StubError){ @myobj.myval }
+      assert_nothing_raised { @myobj.myval(1) }
+      assert_raises(Assert::StubError){ @myobj.myval(1,2) }
+
+      Assert::Stub.new(@myobj, :myargs){ 'myargs' }
+      assert_nothing_raised { @myobj.myargs }
+      assert_nothing_raised { @myobj.myargs(1) }
+      assert_nothing_raised { @myobj.myargs(1,2) }
+
+      Assert::Stub.new(@myobj, :myvalargs){ 'myvalargs' }
+      assert_raises(Assert::StubError){ @myobj.myvalargs }
+      assert_raises(Assert::StubError){ @myobj.myvalargs(1) }
+      assert_nothing_raised { @myobj.myvalargs(1,2) }
+      assert_nothing_raised { @myobj.myvalargs(1,2,3) }
+    end
+
+    should "complain if stubbed with mismatched arity" do
+      assert_raises(Assert::StubError) do
+        Assert::Stub.new(@myobj, :myval).with(){ 'myval' }
+      end
+      assert_raises(Assert::StubError) do
+        Assert::Stub.new(@myobj, :myval).with(1,2){ 'myval' }
+      end
+      assert_nothing_raised do
+        Assert::Stub.new(@myobj, :myval).with(1){ 'myval' }
+      end
+
+      assert_nothing_raised do
+        Assert::Stub.new(@myobj, :myargs).with(){ 'myargs' }
+      end
+      assert_nothing_raised do
+        Assert::Stub.new(@myobj, :myargs).with(1,2){ 'myargs' }
+      end
+      assert_nothing_raised do
+        Assert::Stub.new(@myobj, :myargs).with(1){ 'myargs' }
+      end
+
+      assert_raises(Assert::StubError) do
+        Assert::Stub.new(@myobj, :myvalargs).with(){ 'myvalargs' }
+      end
+      assert_raises(Assert::StubError) do
+        Assert::Stub.new(@myobj, :myvalargs).with(1){ 'myvalargs' }
+      end
+      assert_nothing_raised do
+        Assert::Stub.new(@myobj, :myvalargs).with(1,2){ 'myvalargs' }
+      end
+      assert_nothing_raised do
+        Assert::Stub.new(@myobj, :myvalargs).with(1,2,3){ 'myvalargs' }
+      end
+    end
+
+    should "stub methods with no args" do
+      subject.teardown
+
+      assert_equal 'meth', @myobj.mymeth
+      Assert::Stub.new(@myobj, :mymeth){ 'mymeth' }
+      assert_equal 'mymeth', @myobj.mymeth
+    end
+
+    should "stub methods with required arg" do
+      assert_equal 1, @myobj.myval(1)
+      stub = Assert::Stub.new(@myobj, :myval){ |val| val.to_s }
+      assert_equal '1', @myobj.myval(1)
+      assert_equal '2', @myobj.myval(2)
+      stub.with(2){ 'two' }
+      assert_equal 'two', @myobj.myval(2)
+    end
+
+    should "stub methods with variable args" do
+      assert_equal [1,2], @myobj.myargs(1,2)
+      stub = Assert::Stub.new(@myobj, :myargs){ |*args| args.join(',') }
+      assert_equal '1,2', @myobj.myargs(1,2)
+      assert_equal '3,4,5', @myobj.myargs(3,4,5)
+      stub.with(3,4,5){ 'three-four-five' }
+      assert_equal 'three-four-five', @myobj.myargs(3,4,5)
+    end
+
+    should "stub methods with required args and variable args" do
+      assert_equal [1,2, [3]], @myobj.myvalargs(1,2,3)
+      stub = Assert::Stub.new(@myobj, :myvalargs){ |*args| args.join(',') }
+      assert_equal '1,2,3', @myobj.myvalargs(1,2,3)
+      assert_equal '3,4,5', @myobj.myvalargs(3,4,5)
+      stub.with(3,4,5){ 'three-four-five' }
+      assert_equal 'three-four-five', @myobj.myvalargs(3,4,5)
+    end
+
+    should "stub methods that yield blocks" do
+      blkcalled = false
+      blk = proc{ blkcalled = true }
+      @myobj.myblk(&blk)
+      assert_equal true, blkcalled
+
+      blkcalled = false
+      Assert::Stub.new(@myobj, :myblk){ blkcalled = 'true' }
+      @myobj.myblk(&blk)
+      assert_equal 'true', blkcalled
+    end
+
+    should "stub methods even if they are from a super class" do
+      mysubclass = Class.new(@myclass)
+      mysubobj = mysubclass.new
+
+      assert_equal 1, mysubobj.myval(1)
+      stub = Assert::Stub.new(mysubobj, :myval){ |val| val.to_s }
+      assert_equal '1', mysubobj.myval(1)
+      assert_equal '2', mysubobj.myval(2)
+      stub.with(2){ 'two' }
+      assert_equal 'two', mysubobj.myval(2)
+    end
+
+    should "be removable" do
+      assert_equal 1, @myobj.myval(1)
+      stub = Assert::Stub.new(@myobj, :myval){ |val| val.to_s }
+      assert_equal '1', @myobj.myval(1)
+      stub.teardown
+      assert_equal 1, @myobj.myval(1)
+    end
+
+  end
+
+  class NullStubTests < UnitTests
+    desc "NullStub"
+    setup do
+      @ns = NullStub.new
+    end
+    subject{ @ns }
+
+    should have_imeths :teardown
+
+  end
+
+end


### PR DESCRIPTION
This adds a stub class that can be used to stub method calls.  It
takes an object and method name and sets itself up on the object.
If given a block when created, that block will now be called in
place of _any_ method calls.  Calling `.with` on the stub adds
args-specific call stubbing.  Call `.teardown` to remove the stub
from the object.

Stubbing is noisy - it will complain anytime something seems off
(ie you stub a method the object doesn't respond to or add a with
stub with mismatched arity).

Stubs are safe to create on the same object/method repeatedly.  Stubs
are not overly smart - you define with a block and it replaces the
call - that's it.

You can create/access/teardown theses stubs using the `Assert.stub`
and `Assert.unstub` helper methods.  These methods track created
stubs and allow easy access to them and to tearing them down.

Closes #150.
