### PR TITLE
auto-unstub on context teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ to be friendly and complain if stubbing doesn't match up with the object/method 
 * complains if you stub a method that the object doesn't respond to
 * complains if you stub with an arity mismatch
 * no methods added to `Object`
+* stubs are auto-unstubbed on test teardown
 
 ## CLI
 

--- a/lib/assert.rb
+++ b/lib/assert.rb
@@ -31,4 +31,14 @@ module Assert
     (self.stubs.delete(Assert::Stub.key(*args)) || Assert::Stub::NullStub.new).teardown
   end
 
+  def self.unstub!
+    self.stubs.keys.each{ |key| self.stubs.delete(key).teardown }
+  end
+
+  class Context
+
+    teardown{ Assert.unstub! } # unstub all stubs automatically
+
+  end
+
 end

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -10,7 +10,7 @@ module Assert
     subject { Assert }
 
     should have_imeths :config, :configure, :view, :suite, :runner
-    should have_imeths :stub, :unstub
+    should have_imeths :stubs, :stub, :unstub, :unstub!
 
     should "know its config instance" do
       assert_kind_of Assert::Config, subject.config
@@ -63,6 +63,32 @@ module Assert
       assert_equal 'mymeth', @myobj.mymeth
       Assert.unstub(@myobj, :mymeth)
       assert_equal 'meth', @myobj.mymeth
+    end
+
+    should "know and teardown all stubs" do
+      assert_equal 'meth', @myobj.mymeth
+
+      Assert.stub(@myobj, :mymeth){ 'mymeth' }
+      assert_equal 'mymeth', @myobj.mymeth
+      assert_equal 1, Assert.stubs.size
+
+      Assert.unstub!
+      assert_equal 'meth', @myobj.mymeth
+      assert_empty Assert.stubs
+    end
+
+    should "auto-unstub any stubs on teardown" do
+      context_class = ::Factory.modes_off_context_class do
+        setup do
+          Assert.stub('1', :to_s){ 'one' }
+        end
+      end
+
+      context_class.run_setups('scope')
+      assert_equal 1, Assert.stubs.size
+
+      context_class.run_teardowns('scope')
+      assert_empty Assert.stubs
     end
 
   end


### PR DESCRIPTION
This adds a new helper method, `unstub!`.  This method unstubs any
existing stubs.  Then this adds calling that method automatically
on any context teardown.

The effect is that Assert will auto-unstub any stubs on test teardown.
This means devs don't have to remember to do it and it minimizes
the opportunity for memory leaks due to stubbing.

@jcredding ready for review.
