### PR TITLE
fix stubbing when methods are not local to the object

### DIFF
--- a/lib/assert/stub.rb
+++ b/lib/assert/stub.rb
@@ -58,9 +58,11 @@ module Assert
         raise StubError, "#{object.inspect} does not respond to `#{@method_name}`"
       end
       if !object.methods.map(&:to_s).include?(@method_name)
-        @metaclass.send(:define_method, @method_name) do |*args, &block|
-          super(*args, &block)
-        end
+        @metaclass.class_eval <<-method
+          def #{@method_name}(*args, &block)
+            super(*args, &block)
+          end
+        method
       end
 
       if !object.respond_to?(@name) # already stubbed


### PR DESCRIPTION
This case mainly applies to objects that delegate method calls.  When
stubbing, assert will define the method locally on the object first
before method-chaining the stubbed method.  Defining this method
needs to be done a certain way to avoid erroneous arity mismatches.

The "bug" or "feature" is that when defining a method using
`define_method`, if a block is specified as an arg, the newly defined
method will always have an arity of 1 (no matter what the actual
arity should be).  This causes incorrect arity mismatches if you
stub with any other arity.

This changes the way the method is defined to instead class eval
a string traditionally defining the method with the name interpolated.
This causes the method to have a correct arity and solves the
wrong arity mismatches.

Our tests missed this for two reasons.  One, we were just testing
the subclass scenario.  In this scenario superclass methods are
still local to the subclass, so this above handling is never invoked.
Two, the method we were using in the tests has an arity of 1 so it
wouldn't have mismatched anyway.

To improve the tests, I switched from a subclass to a delegate object
and switched to using a method with a non-1 arity.

@jcredding ready for review.
