### PR TITLE
allow requiring stub logic standalone

### DIFF
--- a/lib/assert.rb
+++ b/lib/assert.rb
@@ -17,28 +17,9 @@ module Assert
   def self.suite;  self.config.suite;  end
   def self.runner; self.config.runner; end
 
-  def self.stubs
-    @stubs ||= {}
-  end
-
-  def self.stub(*args, &block)
-    (self.stubs[Assert::Stub.key(*args)] ||= Assert::Stub.new(*args)).tap do |s|
-      s.do = block
-    end
-  end
-
-  def self.unstub(*args)
-    (self.stubs.delete(Assert::Stub.key(*args)) || Assert::Stub::NullStub.new).teardown
-  end
-
-  def self.unstub!
-    self.stubs.keys.each{ |key| self.stubs.delete(key).teardown }
-  end
-
+  # unstub all stubs automatically (see stub.rb)
   class Context
-
-    teardown{ Assert.unstub! } # unstub all stubs automatically
-
+    teardown{ Assert.unstub! }
   end
 
 end

--- a/lib/assert/stub.rb
+++ b/lib/assert/stub.rb
@@ -1,5 +1,23 @@
 module Assert
 
+  def self.stubs
+    @stubs ||= {}
+  end
+
+  def self.stub(*args, &block)
+    (self.stubs[Assert::Stub.key(*args)] ||= Assert::Stub.new(*args)).tap do |s|
+      s.do = block
+    end
+  end
+
+  def self.unstub(*args)
+    (self.stubs.delete(Assert::Stub.key(*args)) || Assert::Stub::NullStub.new).teardown
+  end
+
+  def self.unstub!
+    self.stubs.keys.each{ |key| self.stubs.delete(key).teardown }
+  end
+
   StubError = Class.new(ArgumentError)
 
   class Stub


### PR DESCRIPTION
This reorganizes the stub logic to put all logic needed to stub
into the assert/stub file.  This allows you to require 'assert/stub'
standalone without having to require in all of assert.

The api is now fully in stub.rb.  The auto unstub context logic is
kept in the main assert file as it is only needed when running tests
and you have to require 'assert' when running tests.

Overall, this means you can use stubs outside of tests and not have
to require in all of assert.

@jcredding ready for review.
