### PR TITLE
Handle stub args whose `hash` changes

### DIFF
--- a/lib/assert/stub.rb
+++ b/lib/assert/stub.rb
@@ -19,6 +19,8 @@ module Assert
   end
 
   StubError = Class.new(ArgumentError)
+  NotStubbedError = Class.new(StubError)
+  StubArityError = Class.new(StubError)
 
   class Stub
 
@@ -44,18 +46,21 @@ module Assert
         inspect_lookup_stubs.tap do |stubs|
           err_msg += "\nStubs:\n#{stubs}" if !stubs.empty?
         end
-        raise StubError, err_msg
+        raise NotStubbedError, err_msg
       end
       @lookup = Hash.new{ |hash, key| self.do }
     end
 
     def call(*args, &block)
-      raise StubError, "artiy mismatch" unless arity_matches?(args)
+      raise StubArityError, "artiy mismatch" unless arity_matches?(args)
+      @lookup[args].call(*args, &block)
+    rescue NotStubbedError => exception
+      @lookup.rehash
       @lookup[args].call(*args, &block)
     end
 
     def with(*args, &block)
-      raise StubError, "artiy mismatch" unless arity_matches?(args)
+      raise StubArityError, "artiy mismatch" unless arity_matches?(args)
       @lookup[args] = block
     end
 

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -48,7 +48,7 @@ module Assert
 
     should "set the stub's do block if given a block" do
       Assert.stub(@myobj, :mymeth)
-      assert_raises(StubError){ @myobj.mymeth }
+      assert_raises(NotStubbedError){ @myobj.mymeth }
       Assert.stub(@myobj, :mymeth){ 'mymeth' }
       assert_equal 'mymeth', @myobj.mymeth
     end


### PR DESCRIPTION
This updates the stub `call` logic to `rehash` its `Hash` when
it can't find a matching stub for a set of args. The goal of this
is to fix a bug with args whose `hash` changes after they have
been used in a stub. When this happens, a `Hash` can't reliably
find the object. In practice, a method would be stubbed, some code
would execute that modifies the `hash` of the args and then when
the stub was called, it would raise an error saying there wasn't
a matching stub.

This also changes the exception classes that are thrown. With this
change, the rescue needs to only rescue not stubbed errors and not
the arity mismatch errors. There is now a not stubbed error and
an arity error and they are thrown for their specific scenarios.

@kellyredding - Ready for review.
