### PR TITLE
Add readable inspect to `Stub`

### DIFF
--- a/lib/assert/stub.rb
+++ b/lib/assert/stub.rb
@@ -78,6 +78,12 @@ module Assert
       @metaclass.send(:undef_method, @name)
     end
 
+    def inspect
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)}" \
+      " @object=#{@object} @method_name=#{@method_name.inspect}" \
+      ">"
+    end
+
     protected
 
     def setup

--- a/test/unit/stub_tests.rb
+++ b/test/unit/stub_tests.rb
@@ -199,6 +199,12 @@ class Assert::Stub
       assert_equal 1, @myobj.myval(1)
     end
 
+    should "have a readable inspect" do
+      expected = "#<#{subject.class}:#{'0x0%x' % (subject.object_id << 1)}" \
+                 " @object=#{@myobj} @method_name=#{subject.method_name.inspect}>"
+      assert_equal expected, subject.inspect
+    end
+
   end
 
   class MutatingArgsStubTests < UnitTests


### PR DESCRIPTION
This adds a readable inspect to `Stub` to help with cleaner
output. Since asserts stubbing now writes instance variables, the
default inspect for objects will show the stubs that have been
written to an object. This would inspect the instances of `Stub`
on the object which would show all of its instance variables. The
output of this was noisy and difficult to read. This cleans up
the output and makes it simpler to read.

@kellyredding - Ready for review.
