### PR TITLE
Match arity when defining proxy method with stubbing

### DIFF
--- a/test/system/stub_tests.rb
+++ b/test/system/stub_tests.rb
@@ -278,28 +278,28 @@ class Assert::Stub
       assert_equal 'default', subject.withblock{ 'my-block' }
     end
 
-    should "allow stubbing methods with invalid arity" do
-      assert_nothing_raised{ Assert.stub(subject, :noargs).with(1){ } }
+    should "not allow stubbing methods with invalid arity" do
+      assert_raises{ Assert.stub(subject, :noargs).with(1){ } }
 
-      assert_nothing_raised{ Assert.stub(subject, :withargs).with{ } }
-      assert_nothing_raised{ Assert.stub(subject, :withargs).with(1, 2){ } }
+      assert_raises{ Assert.stub(subject, :withargs).with{ } }
+      assert_raises{ Assert.stub(subject, :withargs).with(1, 2){ } }
 
-      assert_nothing_raised{ Assert.stub(subject, :minargs).with{ } }
-      assert_nothing_raised{ Assert.stub(subject, :minargs).with(1){ } }
+      assert_raises{ Assert.stub(subject, :minargs).with{ } }
+      assert_raises{ Assert.stub(subject, :minargs).with(1){ } }
 
-      assert_nothing_raised{ Assert.stub(subject, :withblock).with(1){ } }
+      assert_raises{ Assert.stub(subject, :withblock).with(1){ } }
     end
 
-    should "allow calling methods with invalid arity" do
-      assert_nothing_raised{ subject.noargs(1) }
+    should "not allow calling methods with invalid arity" do
+      assert_raises{ subject.noargs(1) }
 
-      assert_nothing_raised{ subject.withargs }
-      assert_nothing_raised{ subject.withargs(1, 2) }
+      assert_raises{ subject.withargs }
+      assert_raises{ subject.withargs(1, 2) }
 
-      assert_nothing_raised{ subject.minargs }
-      assert_nothing_raised{ subject.minargs(1) }
+      assert_raises{ subject.minargs }
+      assert_raises{ subject.minargs(1) }
 
-      assert_nothing_raised{ subject.withblock(1) }
+      assert_raises{ subject.withblock(1) }
     end
 
   end
@@ -427,28 +427,28 @@ class Assert::Stub
       assert_equal 'default', subject.withblock{ 'my-block' }
     end
 
-    should "allow stubbing methods with invalid arity" do
-      assert_nothing_raised{ Assert.stub(subject, :noargs).with(1){ } }
+    should "not allow stubbing methods with invalid arity" do
+      assert_raises{ Assert.stub(subject, :noargs).with(1){ } }
 
-      assert_nothing_raised{ Assert.stub(subject, :withargs).with{ } }
-      assert_nothing_raised{ Assert.stub(subject, :withargs).with(1, 2){ } }
+      assert_raises{ Assert.stub(subject, :withargs).with{ } }
+      assert_raises{ Assert.stub(subject, :withargs).with(1, 2){ } }
 
-      assert_nothing_raised{ Assert.stub(subject, :minargs).with{ } }
-      assert_nothing_raised{ Assert.stub(subject, :minargs).with(1){ } }
+      assert_raises{ Assert.stub(subject, :minargs).with{ } }
+      assert_raises{ Assert.stub(subject, :minargs).with(1){ } }
 
-      assert_nothing_raised{ Assert.stub(subject, :withblock).with(1){ } }
+      assert_raises{ Assert.stub(subject, :withblock).with(1){ } }
     end
 
-    should "allow calling methods with invalid arity" do
-      assert_nothing_raised{ subject.noargs(1) }
+    should "not allow calling methods with invalid arity" do
+      assert_raises{ subject.noargs(1) }
 
-      assert_nothing_raised{ subject.withargs }
-      assert_nothing_raised{ subject.withargs(1, 2) }
+      assert_raises{ subject.withargs }
+      assert_raises{ subject.withargs(1, 2) }
 
-      assert_nothing_raised{ subject.minargs }
-      assert_nothing_raised{ subject.minargs(1) }
+      assert_raises{ subject.minargs }
+      assert_raises{ subject.minargs(1) }
 
-      assert_nothing_raised{ subject.withblock(1) }
+      assert_raises{ subject.withblock(1) }
     end
 
   end


### PR DESCRIPTION
This updates the stubbing logic to define its proxy method with
matching arity to the method being stubbed. This ensures that
singleton methods extended/inherited on a class will properly
check their arity. For these cases, assert will define a proxy
method that is aliased instead of using the inherited/extended
method when. This is because using the inherited/extended method
can effect other singletons and ensures assert is only modifying
the current object it is working on. Previously, the proxy method
was always defined to take any args, which had the side effect
of allowing any number of args when stubbing or calling the method.
This is against the spirit of assert's stubbing, so this updates
the proxy method to match the arity of the method it is proxying.
This allows the arity checking to properly ensure that a stub is
created or called with the proper number of args.

@kellyredding - Ready for review.
