### PR TITLE
Better arity error messages

### DIFF
--- a/lib/assert/stub.rb
+++ b/lib/assert/stub.rb
@@ -55,7 +55,12 @@ module Assert
     end
 
     def call(*args, &block)
-      raise StubArityError, "artiy mismatch" unless arity_matches?(args)
+      unless arity_matches?(args)
+        message = "arity mismatch on `#{@method_name}`: " \
+                  "expected #{number_of_args(@method.arity)}, " \
+                  "called with #{args.size}"
+        raise StubArityError, message
+      end
       @lookup[args].call(*args, &block)
     rescue NotStubbedError => exception
       @lookup.rehash
@@ -63,7 +68,12 @@ module Assert
     end
 
     def with(*args, &block)
-      raise StubArityError, "artiy mismatch" unless arity_matches?(args)
+      unless arity_matches?(args)
+        message = "arity mismatch on `#{@method_name}`: " \
+                  "expected #{number_of_args(@method.arity)}, " \
+                  "stubbed with #{args.size}"
+        raise StubArityError, message
+      end
       @lookup[args] = block
     end
 
@@ -129,6 +139,14 @@ module Assert
 
     def inspect_call(args)
       "`#{@method_name}(#{args.map(&:inspect).join(',')})`"
+    end
+
+    def number_of_args(arity)
+      if arity < 0
+        "at least #{(arity + 1).abs}"
+      else
+        arity
+      end
     end
 
   end


### PR DESCRIPTION
This adds better error messages to the arity exceptions that are
raised when stubbing a method or calling it with the wrong arity.
This should help with identifying the issue and what needs to be
addressed. The message now clearly explains the method that was
called/stubbed with the wrong arity, how many args it expected
and how many it got.

@kellyredding - Ready for review. Here's a sampling of the error messages that you can get (I generated these using the system tests):

```
arity mismatch on `noargs`: expected 0, stubbed with 1 (Assert::StubArityError)
arity mismatch on `noargs`: expected 0, called with 1 (Assert::StubArityError)
arity mismatch on `withargs`: expected 1, stubbed with 0 (Assert::StubArityError)
arity mismatch on `withargs`: expected 1, called with 0 (Assert::StubArityError)
arity mismatch on `withargs`: expected 1, stubbed with 2 (Assert::StubArityError)
arity mismatch on `withargs`: expected 1, called with 2 (Assert::StubArityError)
arity mismatch on `minargs`: expected at least 2, stubbed with 0 (Assert::StubArityError)
arity mismatch on `minargs`: expected at least 2, called with 0 (Assert::StubArityError)
arity mismatch on `minargs`: expected at least 2, stubbed with 1 (Assert::StubArityError)
arity mismatch on `minargs`: expected at least 2, called with 1 (Assert::StubArityError)
```
