### PR TITLE
verbose output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,24 @@ Using an ENV var:
 $ ASSERT_RUNNER_SEED=1234 assert
 ```
 
+### Verbose Output
+
+By default, Assert shows terse runtime test result information.  It provides a setting to turn on/off more verbose information:
+
+In user/local settings file:
+
+```ruby
+Assert.configure do |config|
+  config.verbose true
+end
+```
+
+Using the CLI:
+
+```sh
+$ assert [-v|--verbose|--no-verbose]
+```
+
 ### Capture Output
 
 By default, Assert shows any output on `$stdout` produced while running a test.  It provides a setting to override whether to show this output or to 'capture' it and display it in the test result details:

--- a/lib/assert/cli.rb
+++ b/lib/assert/cli.rb
@@ -45,6 +45,9 @@ module Assert
         option 'profile', 'output test profile info', {
           :abbrev => 'e'
         }
+        option 'verbose', 'output verbose runtime test info', {
+          :abbrev => 'v'
+        }
         # show loaded test files, cli err backtraces, etc
         option 'debug', 'run in debug mode'
       end

--- a/lib/assert/config.rb
+++ b/lib/assert/config.rb
@@ -17,7 +17,7 @@ module Assert
     settings :test_dir, :test_helper, :test_file_suffixes, :runner_seed
     settings :changed_proc, :pp_proc, :use_diff_proc, :run_diff_proc
     settings :capture_output, :halt_on_fail, :changed_only, :pp_objects
-    settings :debug, :profile
+    settings :debug, :profile, :verbose
 
     def initialize(settings = nil)
       @suite  = Assert::Suite.new(self)
@@ -41,6 +41,7 @@ module Assert
       @pp_objects     = false
       @debug          = false
       @profile        = false
+      @verbose        = false
 
       self.apply(settings || {})
     end

--- a/lib/assert/view/default_view.rb
+++ b/lib/assert/view/default_view.rb
@@ -31,11 +31,27 @@ module Assert::View
       end
     end
 
+    def before_test(test)
+      if show_test_verbose_info?
+        puts  "#{test.name.inspect} (#{test.context_class})"
+        puts  "    #{test.file_line}"
+        print "    "
+      end
+    end
+
     def on_result(result)
       result_abbrev = self.send("#{result.to_sym}_abbrev")
       styled_abbrev = ansi_styled_msg(result_abbrev, result_ansi_styles(result))
 
       print styled_abbrev
+    end
+
+    def after_test(test)
+      if show_test_verbose_info?
+        print " #{test_run_time(test)} seconds,"\
+              " #{test.result_count} results,"\
+              " #{test_result_rate(test)} results/s\n"
+      end
     end
 
     def on_finish

--- a/lib/assert/view/helpers/common.rb
+++ b/lib/assert/view/helpers/common.rb
@@ -77,6 +77,10 @@ module Assert::View::Helpers
       !!config.profile
     end
 
+    def show_test_verbose_info?
+      !!config.verbose
+    end
+
     # get all the result details for a set of tests
     def result_details_for(tests, result_order = :normal)
       test_index = 0

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -14,7 +14,7 @@ class Assert::Config
     should have_imeths :test_dir, :test_helper, :test_file_suffixes, :runner_seed
     should have_imeths :changed_proc, :pp_proc, :use_diff_proc, :run_diff_proc
     should have_imeths :capture_output, :halt_on_fail, :changed_only, :pp_objects
-    should have_imeths :debug, :profile
+    should have_imeths :debug, :profile, :verbose
     should have_imeths :apply
 
     should "default the view, suite, and runner" do
@@ -44,6 +44,7 @@ class Assert::Config
       assert_not subject.pp_objects
       assert_not subject.debug
       assert_not subject.profile
+      assert_not subject.verbose
     end
 
     should "apply settings given from a hash" do

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -27,6 +27,7 @@ class Assert::View::Base
     should have_imeths :suite_contexts, :ordered_suite_contexts
     should have_imeths :suite_files, :ordered_suite_files
     should have_imeths :ordered_profile_tests, :show_test_profile_info?
+    should have_imeths :show_test_verbose_info?
     should have_imeths :result_details_for, :matched_result_details_for, :show_result_details?
     should have_imeths :ocurring_result_types, :result_summary_msg
     should have_imeths :all_pass_result_summary_msg, :results_summary_sentence


### PR DESCRIPTION
This adds a verbose runtime output mode flag to the CLI and config.
This also adds a method for querying this flag to the common view
helpers.  Finally, this updates the default view to honor the
flag in its output.

This goal here is to be able to give more details about what is
running at runtime.

Closes #208.

@jcredding ready for review