### PR TITLE
track the file and line number for each test

### DIFF
--- a/lib/assert/context/subject_dsl.rb
+++ b/lib/assert/context/subject_dsl.rb
@@ -10,9 +10,7 @@ class Assert::Context
       else
         parent = self.superclass.desc if self.superclass.respond_to?(:desc)
         own = self.descriptions
-        [parent, *own].compact.reject do |p|
-          p.to_s.empty?
-        end.join(" ")
+        [parent, *own].compact.reject(&:empty?).join(" ")
       end
     end
     alias_method :desc, :description

--- a/lib/assert/macros/methods.rb
+++ b/lib/assert/macros/methods.rb
@@ -13,7 +13,7 @@ module Assert::Macros
         called_from = (methods.last.kind_of?(Array) ? methods.pop : caller).first
         Assert::Macro.new do
           methods.each{ |m| _methods_macro_instance_methods << [m, called_from] }
-          _methods_macro_test
+          _methods_macro_test called_from
         end
       end
       alias_method :have_instance_methods, :have_instance_method
@@ -24,7 +24,7 @@ module Assert::Macros
         called_from = (methods.last.kind_of?(Array) ? methods.pop : caller).first
         Assert::Macro.new do
           methods.each{ |m| _methods_macro_not_instance_methods << [m, called_from] }
-          _methods_macro_test
+          _methods_macro_test called_from
         end
       end
       alias_method :not_have_instance_methods, :not_have_instance_method
@@ -35,7 +35,7 @@ module Assert::Macros
         called_from = (methods.last.kind_of?(Array) ? methods.pop : caller).first
         Assert::Macro.new do
           methods.each{ |m| _methods_macro_class_methods << [m, called_from] }
-          _methods_macro_test
+          _methods_macro_test called_from
         end
       end
       alias_method :have_class_methods, :have_class_method
@@ -46,7 +46,7 @@ module Assert::Macros
         called_from = (methods.last.kind_of?(Array) ? methods.pop : caller).first
         Assert::Macro.new do
           methods.each{ |m| _methods_macro_not_class_methods << [m, called_from] }
-          _methods_macro_test
+          _methods_macro_test called_from
         end
       end
       alias_method :not_have_class_methods, :not_have_class_method
@@ -99,8 +99,8 @@ module Assert::Macros
 
       # private
 
-      def _methods_macro_test
-        @_methods_macro_test ||= should "respond to methods" do
+      def _methods_macro_test(called_from)
+        @_methods_macro_test ||= should "respond to methods", called_from do
 
           self.class._methods_macro_instance_methods.each do |(method, called_from)|
             msg = "#{subject.class.name} does not have instance method ##{method}"

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,12 +1,14 @@
 require 'assert/config'
+require 'assert/factory'
 require 'assert/result'
 require 'assert/suite'
 require 'assert/test'
 
 module Factory
+  extend Assert::Factory
 
   def self.context_info_called_from
-    "/path/to_file.rb:1234"
+    "#{Factory.path}.rb:#{Factory.integer}"
   end
 
   def self.context_info(context_klass = nil)

--- a/test/unit/test_tests.rb
+++ b/test/unit/test_tests.rb
@@ -15,15 +15,11 @@ class Assert::Test
     end
     subject{ @test }
 
-    should have_readers :name, :context_info, :config, :code
+    should have_readers :context_info, :config
+    should have_readers :name, :file, :line_number, :code
     should have_accessors :results, :output, :run_time
     should have_imeths :run, :result_count, :result_rate, :context_class
     should have_imeths *Assert::Result.types.keys.collect{ |k| "#{k}_results" }
-
-    should "build its name from the context description" do
-      exp_name = "context class should do something amazing"
-      assert_equal exp_name, subject.name
-    end
 
     should "know it's context class" do
       assert_equal @context_class, subject.context_class
@@ -32,6 +28,15 @@ class Assert::Test
     should "know its config" do
       cust_config = Assert::Config.new
       assert_equal cust_config, Factory.test(cust_config).config
+    end
+
+    should "know its name, file and line number" do
+      exp = "context class should do something amazing"
+      assert_equal exp, subject.name
+
+      exp_file, exp_line = @context_info.called_from.split(':')
+      assert_equal exp_file, subject.file
+      assert_equal exp_line, subject.line_number
     end
 
     should "get its code from any passed opt, falling back on any given block" do


### PR DESCRIPTION
Using the context info's called from attribute, we can pull out
and track which file and line number a test is defined on.  This
will allow running tests by file/line-number and is prep for that
feature.

Note: this also updates the methods macro to properly pass called from
context to its test definition.  The single methods test will be
seen a defined on the line of the first methods macro in the test
file.  I noticed this was incorrect while debugging for the file
line number change.

Note also: this updates assert's own factory to extend assert factory.
This opens up all the factory methods for use in assert's own test
suite.  Note really sure why this wasn't done already - it was 
probably just missed.  I switched to using factory methods to build
the context info called from factory.

Related to #120.

@jcredding ready for review.