### PR TITLE
dump test results on interrupt

### DIFF
--- a/lib/assert/cli.rb
+++ b/lib/assert/cli.rb
@@ -62,7 +62,7 @@ module Assert
         puts "#{exception.message}\n\n"
         puts  Assert.config.debug ? exception.backtrace.join("\n") : help
         exit(1)
-      rescue Exception => exception
+      rescue StandardError => exception
         puts "#{exception.class}: #{exception.message}"
         puts exception.backtrace.join("\n")
         exit(1)

--- a/lib/assert/test.rb
+++ b/lib/assert/test.rb
@@ -2,6 +2,7 @@ require 'stringio'
 require 'assert/result'
 
 module Assert
+
   class Test
 
     # a Test is some code/method to run in the scope of a Context.  After a
@@ -69,7 +70,7 @@ module Assert
       "#<#{self.class}:#{'0x0%x' % (object_id << 1)} #{attributes_string}>"
     end
 
-    protected
+    private
 
     def run_test_main(scope)
       begin
@@ -143,11 +144,10 @@ module Assert
       ].compact.reject{|p| p.empty?}.join(" ")
     end
 
-    private
-
     def get_rate(count, time)
       time == 0 ? 0.0 : (count.to_f / time.to_f)
     end
 
   end
+
 end

--- a/lib/assert/view/base.rb
+++ b/lib/assert/view/base.rb
@@ -58,17 +58,19 @@ module Assert::View
     # and sent to the io stream.
 
     # available callbacks from the runner:
-    # * `before_load`: called at the beginning, before the suite is loaded
-    # * `after_load`:  called after the suite is loaded, just before `on_start`
-    #                  functionally equivalent to `on_start`
-    # * `on_start`:    called when a loaded test suite starts running
-    # * `before_test`: called before a test starts running
-    #                  the test is passed as an arg
-    # * `on_result`:   called when a running tests generates a result
-    #                  the result is passed as an arg
-    # * `after_test`:  called after a test finishes running
-    #                  the test is passed as an arg
-    # * `on_finish`:   called when the test suite is finished running
+    # * `before_load`:  called at the beginning, before the suite is loaded
+    # * `after_load`:   called after the suite is loaded, just before `on_start`
+    #                   functionally equivalent to `on_start`
+    # * `on_start`:     called when a loaded test suite starts running
+    # * `before_test`:  called before a test starts running
+    #                   the test is passed as an arg
+    # * `on_result`:    called when a running tests generates a result
+    #                   the result is passed as an arg
+    # * `after_test`:   called after a test finishes running
+    #                   the test is passed as an arg
+    # * `on_finish`:    called when the test suite is finished running
+    # * `on_interrupt`: called when the test suite is interrupted while running
+    #                   the interrupt exception is passed as an arg
 
     def before_load(test_files); end
     def after_load;              end
@@ -77,6 +79,7 @@ module Assert::View
     def on_result(result);       end
     def after_test(test);        end
     def on_finish;               end
+    def on_interrupt(err);       end
 
     # IO capture
 

--- a/lib/assert/view/default_view.rb
+++ b/lib/assert/view/default_view.rb
@@ -40,25 +40,7 @@ module Assert::View
 
     def on_finish
       if tests?
-        print "\n"
-        puts
-
-        # output detailed results for the tests in reverse test/result order
-        tests = suite.ordered_tests.reverse
-        result_details_for(tests, :reversed).each do |details|
-          if show_result_details?(details.result)
-            # output the styled result details
-            result = details.result
-            puts ansi_styled_msg(result.to_s, result_ansi_styles(result))
-
-            # output any captured stdout
-            output = details.output
-            puts captured_output(output) if output && !output.empty?
-
-            # add an empty line between each result detail
-            puts
-          end
-        end
+        dump_test_results
       end
 
       # show profile output
@@ -80,6 +62,34 @@ module Assert::View
       puts "#{result_count_statement}: #{styled_results_sentence}"
       puts
       puts "(#{run_time} seconds, #{test_rate} tests/s, #{result_rate} results/s)"
+    end
+
+    def on_interrupt(err)
+      dump_test_results
+    end
+
+    private
+
+    def dump_test_results
+      print "\n"
+      puts
+
+      # output detailed results for the tests in reverse test/result order
+      tests = suite.ordered_tests.reverse
+      result_details_for(tests, :reversed).each do |details|
+        if show_result_details?(details.result)
+          # output the styled result details
+          result = details.result
+          puts ansi_styled_msg(result.to_s, result_ansi_styles(result))
+
+          # output any captured stdout
+          output = details.output
+          puts captured_output(output) if output && !output.empty?
+
+          # add an empty line between each result detail
+          puts
+        end
+      end
     end
 
   end

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -16,7 +16,8 @@ class Assert::View::Base
 
     # accessors, base methods
     should have_imeths :is_tty?, :view, :config, :suite, :fire
-    should have_imeths :before_load, :after_load, :on_start, :on_finish
+    should have_imeths :before_load, :after_load
+    should have_imeths :on_start, :on_finish, :on_interrupt
     should have_imeths :before_test, :after_test, :on_result
 
     # common methods


### PR DESCRIPTION
This updates the runner to catch `Interrupt` exceptions and to fire
a new view callback `on_interrupt` before re-raising the interrupt.
This allows view handlers to handle the interrupt scenario.

This also updates the default view to dump its test results on
interrupt just like it would on finish.  This allows you to
interrupt a long test suite run that is producing a bunch of errors
and see what those errors are before having to wait for the test
suite run to finish.

Closes #207.

@jcredding ready for review.