### PR TITLE
`FileLine` helper class for file/line-number handling

### DIFF
--- a/lib/assert/file_line.rb
+++ b/lib/assert/file_line.rb
@@ -1,0 +1,25 @@
+module Assert
+
+  class FileLine
+
+    def self.parse(file_line_path)
+      self.new(*file_line_path.match(/(.+)\:(.+)/)[1..2])
+    end
+
+    attr_reader :file, :line
+
+    def initialize(file, line)
+      @file, @line = file.to_s, line.to_s
+    end
+
+    def to_s
+      "#{self.file}:#{self.line}"
+    end
+
+    def ==(other_file_line)
+      self.file == other_file_line.file && self.line == other_file_line.line
+    end
+
+  end
+
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -8,7 +8,7 @@ module Factory
   extend Assert::Factory
 
   def self.context_info_called_from
-    "#{Factory.path}.rb:#{Factory.integer}"
+    "#{Factory.path}_tests.rb:#{Factory.integer}"
   end
 
   def self.context_info(context_klass = nil)

--- a/test/unit/file_line_tests.rb
+++ b/test/unit/file_line_tests.rb
@@ -1,0 +1,54 @@
+require 'assert'
+require 'assert/file_line'
+
+class Assert::FileLine
+
+  class UnitTests < Assert::Context
+    desc "Assert::FileLine"
+    setup do
+      @file = "#{Factory.path}_tests.rb"
+      @line = Factory.integer.to_s
+    end
+    subject{ Assert::FileLine }
+
+    should have_imeths :parse
+
+    should "know how to parse and init from a file line path string" do
+      file_line_path = "#{@file}:#{@line}"
+      file_line = subject.parse(file_line_path)
+
+      assert_equal @file, file_line.file
+      assert_equal @line, file_line.line
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @file_line = Assert::FileLine.new(@file, @line)
+    end
+    subject{ @file_line }
+
+    should have_readers :file, :line
+
+    should "know its file and line" do
+      assert_equal @file, subject.file
+      assert_equal @line, subject.line
+    end
+
+    should "know its string representation" do
+      assert_equal "#{subject.file}:#{subject.line}", subject.to_s
+    end
+
+    should "know if it is equal to another file line" do
+      yes = Assert::FileLine.new(@file, @line)
+      no = Assert::FileLine.new("#{Factory.path}_tests.rb", Factory.integer.to_s)
+
+      assert_equal     yes, subject
+      assert_not_equal no,  subject
+    end
+
+  end
+
+end

--- a/test/unit/test_tests.rb
+++ b/test/unit/test_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'assert/test'
 
 require 'assert/config'
+require 'assert/file_line'
 
 class Assert::Test
 
@@ -16,12 +17,13 @@ class Assert::Test
     subject{ @test }
 
     should have_readers :context_info, :config
-    should have_readers :name, :file, :line_number, :code
+    should have_readers :name, :file_line, :code
     should have_accessors :results, :output, :run_time
-    should have_imeths :run, :result_count, :result_rate, :context_class
+    should have_imeths :context_class, :file, :line_number
+    should have_imeths :run, :result_count, :result_rate
     should have_imeths *Assert::Result.types.keys.collect{ |k| "#{k}_results" }
 
-    should "know it's context class" do
+    should "know its context class" do
       assert_equal @context_class, subject.context_class
     end
 
@@ -30,13 +32,15 @@ class Assert::Test
       assert_equal cust_config, Factory.test(cust_config).config
     end
 
-    should "know its name, file and line number" do
+    should "know its name, file line, file and number" do
       exp = "context class should do something amazing"
       assert_equal exp, subject.name
 
-      exp_file, exp_line = @context_info.called_from.split(':')
-      assert_equal exp_file, subject.file
-      assert_equal exp_line, subject.line_number
+      exp = Assert::FileLine.new(*@context_info.called_from.split(':'))
+      assert_equal exp, subject.file_line
+
+      assert_equal subject.file_line.file, subject.file
+      assert_equal subject.file_line.line, subject.line_number
     end
 
     should "get its code from any passed opt, falling back on any given block" do


### PR DESCRIPTION
This adds a helper class for dealing with test file/line-numbers.
It includes the basic readers but also defines how these are
represented in strings and also how to parse from a string.  It
also encapsulates comparison logic.

In addition, this defines an `AnyFileLine` utility class.  This
class is special in that it will be equal to any file line it is
compared with.

`Test` has been backported to track its file line.  This will be
used in the coming run-by-line-number feature.  File lines will
be taken as args from the cli and only run tests with matching file
lines will be run.  This will also be used on the coming verbose
output feature as we will display the test's file line in the
output.

Related to #120.

@jcredding ready for review.