### PR TITLE
changed ref CLI opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,16 +297,26 @@ Using the CLI:
 $ assert [-c|--changed-only|--no-changed-only]
 ```
 
+You can also optionally send a "reference" value to evaluate changes against.  This can be any value and it is passed to the proc that detects changes (see below).  Using the default git changed proc, this value would be any commit reference (ie HEAD, master, etc).
+
+Using the CLI:
+
+```sh
+$ assert -c [-r|--changed-ref] REF_VALUE
+```
+
+Note: This option has no effect unless used with the `-c` option.  One practical use of this is to test changes 1) after they have been staged (`assert -cr HEAD`) or 2) after they have been committed to a branch (`assert -cr master`) (for example).
+
 #### Changed Test File Detection
 
 The changed files are detected using two git commands by default:
 
 ```sh
-git diff --no-ext-diff --name-only        # changed files
+git diff --no-ext-diff --name-only {ref}  # changed files
 git ls-files --others --exclude-standard  # added files
 ```
 
-The git cmds have ` -- #{test_paths}` appended to them to scope their results to just the test paths specified by the CLI and are run together using ` && `.
+The git cmds have ` -- #{test_paths}` appended to them to scope their results to just the test paths specified by the CLI and are run together using ` && `.  The `{ref}` above is any reference value given using the `-r` CLI opt.
 
 This, of course, assumes you are working in a git repository.  If you are not or you want to use custom logic to determine the changed files, configure a custom proc.  The proc should take two parameters: the config and an array of test paths specified by the CLI.
 

--- a/lib/assert/cli.rb
+++ b/lib/assert/cli.rb
@@ -39,6 +39,9 @@ module Assert
         option 'changed_only', 'only run test files with changes', {
           :abbrev => 'c'
         }
+        option 'changed_ref', 'reference for changes, use with `-c` opt', {
+          :abbrev => 'r', :value => ''
+        }
         option 'pp_objects', 'pretty-print objects in fail messages', {
           :abbrev => 'p'
         }

--- a/lib/assert/config.rb
+++ b/lib/assert/config.rb
@@ -16,8 +16,8 @@ module Assert
     settings :view, :suite, :runner
     settings :test_dir, :test_helper, :test_file_suffixes, :runner_seed
     settings :changed_proc, :pp_proc, :use_diff_proc, :run_diff_proc
-    settings :capture_output, :halt_on_fail, :changed_only, :pp_objects
-    settings :debug, :profile, :verbose
+    settings :capture_output, :halt_on_fail, :changed_only, :changed_ref
+    settings :pp_objects, :debug, :profile, :verbose
 
     def initialize(settings = nil)
       @suite  = Assert::Suite.new(self)
@@ -38,6 +38,7 @@ module Assert
       @capture_output = false
       @halt_on_fail   = true
       @changed_only   = false
+      @changed_ref    = ''
       @pp_objects     = false
       @debug          = false
       @profile        = false

--- a/lib/assert/utils.rb
+++ b/lib/assert/utils.rb
@@ -63,8 +63,8 @@ module Assert
       Proc.new do |config, test_paths|
         files = []
         cmd = [
-          "git diff --no-ext-diff --name-only",       # changed files
-          "git ls-files --others --exclude-standard"  # added files
+          "git diff --no-ext-diff --name-only #{config.changed_ref}", # changed files
+          "git ls-files --others --exclude-standard"                  # added files
         ].map{ |c| "#{c} -- #{test_paths.join(' ')}" }.join(' && ')
         Assert::CLI.bench('Load only changed files') do
           files = `#{cmd}`.split("\n")

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -13,8 +13,8 @@ class Assert::Config
     should have_imeths :suite, :view, :runner
     should have_imeths :test_dir, :test_helper, :test_file_suffixes, :runner_seed
     should have_imeths :changed_proc, :pp_proc, :use_diff_proc, :run_diff_proc
-    should have_imeths :capture_output, :halt_on_fail, :changed_only, :pp_objects
-    should have_imeths :debug, :profile, :verbose
+    should have_imeths :capture_output, :halt_on_fail, :changed_only, :changed_ref
+    should have_imeths :pp_objects, :debug, :profile, :verbose
     should have_imeths :apply
 
     should "default the view, suite, and runner" do
@@ -38,13 +38,14 @@ class Assert::Config
     end
 
     should "default the mode flags" do
-      assert_not subject.capture_output
-      assert     subject.halt_on_fail
-      assert_not subject.changed_only
-      assert_not subject.pp_objects
-      assert_not subject.debug
-      assert_not subject.profile
-      assert_not subject.verbose
+      assert_not   subject.capture_output
+      assert       subject.halt_on_fail
+      assert_not   subject.changed_only
+      assert_empty subject.changed_ref
+      assert_not   subject.pp_objects
+      assert_not   subject.debug
+      assert_not   subject.profile
+      assert_not   subject.verbose
     end
 
     should "apply settings given from a hash" do


### PR DESCRIPTION
This updates the CLI and default changed proc to take a reference
value.  The goal here is to optionally pass a reference argument
when evaluating changed tests.

Practically, this can be used to test changed tests 1) after they
have been staged (`assert -cr HEAD`) or 2) after they have been
committed to a branch (`assert -cr master`).

This closes #214.

@jcredding ready for review.