### PR TITLE
`-l` option for listing out test files that would be loaded and run

### DIFF
--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -27,6 +27,11 @@ module Assert
         Assert::CLI.bench('Require test helper'){ require h }
       end
 
+      if self.config.list
+        $stdout.puts test_files
+        halt
+      end
+
       # load the test files
       self.config.view.fire(:before_load, test_files)
       Assert::CLI.bench("Require #{test_files.count} test files") do
@@ -43,7 +48,11 @@ module Assert
       self.config.runner.run(self.config.suite, self.config.view)
     end
 
-    protected
+    private
+
+    def halt
+      throw(:halt)
+    end
 
     def apply_user_settings
       safe_require("#{ENV['HOME']}/#{USER_SETTINGS_FILE}") if ENV['HOME']
@@ -60,8 +69,6 @@ module Assert
     def apply_env_settings
       self.config.runner_seed ENV['ASSERT_RUNNER_SEED'].to_i if ENV['ASSERT_RUNNER_SEED']
     end
-
-    private
 
     def test_files(test_paths)
       file_paths = if self.config.changed_only

--- a/lib/assert/cli.rb
+++ b/lib/assert/cli.rb
@@ -27,14 +27,8 @@ module Assert
     def initialize(*args)
       @args = args
       @cli = CLIRB.new do
-        option 'runner_seed', 'Use a given seed to run tests', {
+        option 'runner_seed', 'use a given seed to run tests', {
           :abbrev => 's', :value => Fixnum
-        }
-        option 'capture_output', 'capture stdout and display in result details', {
-          :abbrev => 'o'
-        }
-        option 'halt_on_fail', 'halt a test when it fails', {
-          :abbrev => 'h'
         }
         option 'changed_only', 'only run test files with changes', {
           :abbrev => 'c'
@@ -45,21 +39,34 @@ module Assert
         option 'pp_objects', 'pretty-print objects in fail messages', {
           :abbrev => 'p'
         }
+        option 'capture_output', 'capture stdout and display in result details', {
+          :abbrev => 'o'
+        }
+        option 'halt_on_fail', 'halt a test when it fails', {
+          :abbrev => 'h'
+        }
         option 'profile', 'output test profile info', {
           :abbrev => 'e'
         }
         option 'verbose', 'output verbose runtime test info', {
           :abbrev => 'v'
         }
+        option 'list', 'list test files on $stdout', {
+          :abbrev => 'l'
+        }
         # show loaded test files, cli err backtraces, etc
-        option 'debug', 'run in debug mode'
+        option 'debug', 'run in debug mode', {
+          :abbrev => 'd'
+        }
       end
     end
 
     def run
       begin
         @cli.parse!(@args)
-        Assert::AssertRunner.new(Assert.config, @cli.args, @cli.opts).run
+        catch(:halt) do
+          Assert::AssertRunner.new(Assert.config, @cli.args, @cli.opts).run
+        end
       rescue CLIRB::HelpExit
         puts help
       rescue CLIRB::VersionExit

--- a/lib/assert/config.rb
+++ b/lib/assert/config.rb
@@ -14,10 +14,10 @@ module Assert
     end
 
     settings :view, :suite, :runner
-    settings :test_dir, :test_helper, :test_file_suffixes, :runner_seed
+    settings :test_dir, :test_helper, :test_file_suffixes
     settings :changed_proc, :pp_proc, :use_diff_proc, :run_diff_proc
-    settings :capture_output, :halt_on_fail, :changed_only, :changed_ref
-    settings :pp_objects, :debug, :profile, :verbose
+    settings :runner_seed, :changed_only, :changed_ref, :pp_objects
+    settings :capture_output, :halt_on_fail, :profile, :verbose, :list, :debug
 
     def initialize(settings = nil)
       @suite  = Assert::Suite.new(self)
@@ -27,22 +27,23 @@ module Assert
       @test_dir    = "test"
       @test_helper = "helper.rb"
       @test_file_suffixes = ['_tests.rb', '_test.rb']
-      @runner_seed   = begin; srand; srand % 0xFFFF; end.to_i
 
       @changed_proc  = Assert::U.git_changed_proc
       @pp_proc       = Assert::U.stdlib_pp_proc
       @use_diff_proc = Assert::U.default_use_diff_proc
       @run_diff_proc = Assert::U.syscmd_diff_proc
 
-      # mode flags
-      @capture_output = false
-      @halt_on_fail   = true
+      # option settings
+      @runner_seed    = begin; srand; srand % 0xFFFF; end.to_i
       @changed_only   = false
       @changed_ref    = ''
       @pp_objects     = false
-      @debug          = false
+      @capture_output = false
+      @halt_on_fail   = true
       @profile        = false
       @verbose        = false
+      @list           = false
+      @debug          = false
 
       self.apply(settings || {})
     end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -11,11 +11,11 @@ class Assert::Config
     subject{ @config }
 
     should have_imeths :suite, :view, :runner
-    should have_imeths :test_dir, :test_helper, :test_file_suffixes, :runner_seed
+    should have_imeths :test_dir, :test_helper, :test_file_suffixes
     should have_imeths :changed_proc, :pp_proc, :use_diff_proc, :run_diff_proc
-    should have_imeths :capture_output, :halt_on_fail, :changed_only, :changed_ref
-    should have_imeths :pp_objects, :debug, :profile, :verbose
-    should have_imeths :apply
+    should have_imeths :runner_seed, :changed_only, :changed_ref, :pp_objects
+    should have_imeths :capture_output, :halt_on_fail, :profile, :verbose, :list
+    should have_imeths :debug, :apply
 
     should "default the view, suite, and runner" do
       assert_kind_of Assert::View::DefaultView, subject.view
@@ -23,11 +23,10 @@ class Assert::Config
       assert_kind_of Assert::Runner, subject.runner
     end
 
-    should "default the test dir/helper/suffixes/seed" do
+    should "default the test dir/helper/suffixes" do
       assert_equal 'test', subject.test_dir
       assert_equal 'helper.rb', subject.test_helper
       assert_equal ['_tests.rb', "_test.rb"], subject.test_file_suffixes
-      assert_not_nil subject.runner_seed
     end
 
     should "default the procs" do
@@ -37,15 +36,17 @@ class Assert::Config
       assert_not_nil subject.run_diff_proc
     end
 
-    should "default the mode flags" do
-      assert_not   subject.capture_output
-      assert       subject.halt_on_fail
-      assert_not   subject.changed_only
-      assert_empty subject.changed_ref
-      assert_not   subject.pp_objects
-      assert_not   subject.debug
-      assert_not   subject.profile
-      assert_not   subject.verbose
+    should "default the option settings" do
+      assert_not_nil subject.runner_seed
+      assert_not     subject.changed_only
+      assert_empty   subject.changed_ref
+      assert_not     subject.pp_objects
+      assert_not     subject.capture_output
+      assert         subject.halt_on_fail
+      assert_not     subject.profile
+      assert_not     subject.verbose
+      assert_not     subject.list
+      assert_not     subject.debug
     end
 
     should "apply settings given from a hash" do


### PR DESCRIPTION
Use this option to list out the test files the *would be* loaded
and run to stdout.  There are two goals here: 1) use this to help
debug and 2) use in a script to run each test file individually.

Note: this reorganizes the CLI options to list in a more relevent
order.  This also reorganizes the config option settings to group
them together and order them in the same order as the CLI defines
them.  Just cleanups and readability improvements here.

Closes #216.
Closes #215.

@jcredding ready for review.