### PR TITLE
break out common config helpers to share between runner/view

### DIFF
--- a/lib/assert/config_helpers.rb
+++ b/lib/assert/config_helpers.rb
@@ -1,0 +1,68 @@
+module Assert
+
+  module ConfigHelpers
+
+    def runner_seed
+      self.config.runner_seed
+    end
+
+    def count(type)
+      self.config.suite.count(type)
+    end
+
+    def tests?
+      self.count(:tests) > 0
+    end
+
+    def all_pass?
+      self.count(:pass) == self.count(:results)
+    end
+
+    # get the formatted suite run time
+    def run_time(format = '%.6f')
+      format % self.config.suite.run_time
+    end
+
+    # get the formatted suite test rate
+    def test_rate(format = '%.6f')
+      format % self.config.suite.test_rate
+    end
+
+    # get the formatted suite result rate
+    def result_rate(format = '%.6f')
+      format % self.config.suite.result_rate
+    end
+
+    # get a uniq list of contexts for the test suite
+    def suite_contexts
+      @suite_contexts ||= self.config.suite.tests.inject([]) do |contexts, test|
+        contexts << test.context_info.klass
+      end.uniq
+    end
+
+    def ordered_suite_contexts
+      self.suite_contexts.sort{ |a,b| a.to_s <=> b.to_s }
+    end
+
+    # get a uniq list of files containing contexts for the test suite
+    def suite_files
+      @suite_files ||= self.config.suite.tests.inject([]) do |files, test|
+        files << test.context_info.file
+      end.uniq
+    end
+
+    def ordered_suite_files
+      self.suite_files.sort{ |a,b| a.to_s <=> b.to_s }
+    end
+
+    def show_test_profile_info?
+      !!self.config.profile
+    end
+
+    def show_test_verbose_info?
+      !!self.config.verbose
+    end
+
+  end
+
+end

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -39,7 +39,7 @@ module Assert
 
     def tests_to_run(suite)
       srand self.config.runner_seed
-      suite.tests.sort.sort_by { rand suite.tests.size }
+      suite.tests.sort.sort_by{ rand suite.tests.size }
     end
 
   end

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -14,8 +14,8 @@ module Assert
       @config = config
       @tests = []
       @test_methods = []
-      @start_time = 0
-      @end_time = 0
+      @start_time = Time.now
+      @end_time = @start_time
     end
 
     def run_time
@@ -33,7 +33,7 @@ module Assert
     alias_method :ordered_tests, :tests
 
     def results
-      tests.inject([]) {|results, test| results += test.results}
+      tests.inject([]){ |results, test| results += test.results }
     end
     alias_method :ordered_results, :results
 

--- a/lib/assert/view/base.rb
+++ b/lib/assert/view/base.rb
@@ -1,13 +1,15 @@
 require 'assert/config'
+require 'assert/config_helpers'
 require 'assert/suite'
 require 'assert/result'
 
 module Assert::View
 
   class Base
+    include Assert::ConfigHelpers
 
     # include a bunch of common helper methods
-
+    # TODO: move these to 'view helpers'
     require 'assert/view/helpers/common'
     include Helpers::Common
 

--- a/lib/assert/view/helpers/common.rb
+++ b/lib/assert/view/helpers/common.rb
@@ -6,37 +6,6 @@ module Assert::View::Helpers
       receiver.class_eval{ extend ClassMethods }
     end
 
-    def runner_seed
-      self.config.runner_seed
-    end
-
-    def count(type)
-      self.suite.count(type)
-    end
-
-    def tests?
-      self.count(:tests) > 0
-    end
-
-    def all_pass?
-      self.count(:pass) == self.count(:results)
-    end
-
-    # get the formatted suite run time
-    def run_time(format = '%.6f')
-      format % self.suite.run_time
-    end
-
-    # get the formatted suite test rate
-    def test_rate(format = '%.6f')
-      format % self.suite.test_rate
-    end
-
-    # get the formatted suite result rate
-    def result_rate(format = '%.6f')
-      format % self.suite.result_rate
-    end
-
     # get the formatted run time for an idividual test
     def test_run_time(test, format = '%.6f')
       format % test.run_time
@@ -47,38 +16,8 @@ module Assert::View::Helpers
       format % test.result_rate
     end
 
-    # get a uniq list of contexts for the test suite
-    def suite_contexts
-      @suite_contexts ||= self.suite.tests.inject([]) do |contexts, test|
-        contexts << test.context_info.klass
-      end.uniq
-    end
-
-    def ordered_suite_contexts
-      self.suite_contexts.sort{|a,b| a.to_s <=> b.to_s}
-    end
-
-    # get a uniq list of files containing contexts for the test suite
-    def suite_files
-      @suite_files ||= self.suite.tests.inject([]) do |files, test|
-        files << test.context_info.file
-      end.uniq
-    end
-
-    def ordered_suite_files
-      self.suite_files.sort{|a,b| a.to_s <=> b.to_s}
-    end
-
     def ordered_profile_tests
       suite.ordered_tests.sort{ |a, b| a.run_time <=> b.run_time }
-    end
-
-    def show_test_profile_info?
-      !!config.profile
-    end
-
-    def show_test_verbose_info?
-      !!config.verbose
     end
 
     # get all the result details for a set of tests

--- a/test/unit/config_helpers_tests.rb
+++ b/test/unit/config_helpers_tests.rb
@@ -1,0 +1,87 @@
+require 'assert'
+require 'assert/config_helpers'
+
+require 'assert/config'
+
+module Assert::ConfigHelpers
+
+  class UnitTests < Assert::Context
+    desc "Assert::ConfigHelpers"
+    setup do
+      @helpers_class = Class.new do
+        include Assert::ConfigHelpers
+
+        def config
+          # use the assert config since it has tests, contexts, etc
+          # also maybe use a fresh config that is empty
+          @config ||= [Assert.config, Assert::Config.new].choice
+        end
+      end
+      @helpers = @helpers_class.new
+    end
+    subject{ @helpers }
+
+    should have_imeths :runner_seed, :count, :tests?, :all_pass?
+    should have_imeths :run_time, :test_rate, :result_rate
+    should have_imeths :suite_contexts, :ordered_suite_contexts
+    should have_imeths :suite_files, :ordered_suite_files
+    should have_imeths :show_test_profile_info?, :show_test_verbose_info?
+
+    should "know its runner seed" do
+      assert_equal subject.config.runner_seed, subject.runner_seed
+    end
+
+    should "know how to count things on the suite" do
+      thing = [:pass, :fail, :results, :tests].choice
+      assert_equal subject.config.suite.count(thing), subject.count(thing)
+    end
+
+    should "know if it has tests or not" do
+      exp = subject.count(:tests) > 0
+      assert_equal exp, subject.tests?
+    end
+
+    should "know its formatted run time, test rate and result rate" do
+      format = '%.6f'
+
+      exp = format % subject.config.suite.run_time
+      assert_equal exp, subject.run_time(format)
+
+      exp = format % subject.config.suite.test_rate
+      assert_equal exp, subject.test_rate(format)
+
+      exp = format % subject.config.suite.result_rate
+      assert_equal exp, subject.result_rate(format)
+    end
+
+    should "know its suite contexts and ordered suite contexts" do
+      exp = subject.config.suite.tests.inject([]) do |contexts, test|
+        contexts << test.context_info.klass
+      end.uniq
+      assert_equal exp, subject.suite_contexts
+
+      exp = subject.suite_contexts.sort{ |a,b| a.to_s <=> b.to_s }
+      assert_equal exp, subject.ordered_suite_contexts
+    end
+
+    should "know its suite files and ordered suite files" do
+      exp = subject.config.suite.tests.inject([]) do |files, test|
+        files << test.context_info.file
+      end.uniq
+      assert_equal exp, subject.suite_files
+
+      exp = subject.suite_files.sort{ |a,b| a.to_s <=> b.to_s }
+      assert_equal exp, subject.ordered_suite_files
+    end
+
+    should "know whether to show test profile info" do
+      assert_equal !!subject.config.profile, subject.show_test_profile_info?
+    end
+
+    should "know whether to show verbose info" do
+      assert_equal !!subject.config.verbose, subject.show_test_verbose_info?
+    end
+
+  end
+
+end

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -65,7 +65,7 @@ class Assert::Suite
     end
 
     should "know its ordered results" do
-      assert_equal subject.test_count, subject.ordered_tests.size
+      assert_equal subject.result_count, subject.ordered_results.size
     end
 
     should "know how many pass results it has" do

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -1,7 +1,10 @@
 require 'assert'
-require 'assert/suite'
 require 'assert/view/base'
+
 require 'stringio'
+require 'assert/config_helpers'
+require 'assert/suite'
+require 'assert/view/helpers/common'
 
 class Assert::View::Base
 
@@ -21,18 +24,21 @@ class Assert::View::Base
     should have_imeths :before_test, :after_test, :on_result
 
     # common methods
-    should have_imeths :runner_seed, :count, :tests?, :all_pass?
-    should have_imeths :run_time, :test_rate, :result_rate
     should have_imeths :test_run_time, :test_result_rate
-    should have_imeths :suite_contexts, :ordered_suite_contexts
-    should have_imeths :suite_files, :ordered_suite_files
-    should have_imeths :ordered_profile_tests, :show_test_profile_info?
-    should have_imeths :show_test_verbose_info?
+    should have_imeths :ordered_profile_tests
     should have_imeths :result_details_for, :matched_result_details_for, :show_result_details?
     should have_imeths :ocurring_result_types, :result_summary_msg
     should have_imeths :all_pass_result_summary_msg, :results_summary_sentence
     should have_imeths :test_count_statement, :result_count_statement
     should have_imeths :to_sentence
+
+    should "include the config helpers" do
+      assert_includes Assert::ConfigHelpers, subject.class
+    end
+
+    should "include the common view helpers" do
+      assert_includes Assert::View::Helpers::Common, subject.class
+    end
 
     should "default its result abbreviations" do
       assert_equal '.', subject.pass_abbrev


### PR DESCRIPTION
Really these helpers can be used on anything that provides a `config`
method.  This is prep for making the runner more powerful and
implementing a multi-process runner.

The runner will need to have some of these helpers available so
I figured why not make all config-based helpers available since the
runner knows its config.

In addition, this adds tests for all of the config helpers.  These
were previously untested.  There are also a number of minor cleanups,
mainly to some old tests, that I noticed while making these changes.

@jcredding ready for review.  I'm going through and making some cleanups to Assert internals in prep for doing Parassert.  I'll have a number of PRs all related to this.  None of these should change the external API or behavior - just reorganizing and making it easy/intended to extend the suite/runner for Parassert's needs.  FYI.