### PR TITLE
have runner describe how tests are going to be run

### DIFF
--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -26,9 +26,6 @@ module Assert
     end
 
     def on_start
-      if tests?
-        puts "Running tests in random order, seeded with \"#{runner_seed}\""
-      end
     end
 
     def before_test(test)

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -1,8 +1,10 @@
+require 'assert/config_helpers'
 require 'assert/suite'
 
 module Assert
 
   class Runner
+    include Assert::ConfigHelpers
 
     attr_reader :config
 
@@ -12,6 +14,9 @@ module Assert
 
     def run(suite, view)
       raise ArgumentError if !suite.kind_of?(Suite)
+      if tests?
+        view.puts "Running tests in random order, seeded with \"#{runner_seed}\""
+      end
       view.fire(:on_start)
 
       begin

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,16 +1,30 @@
 require 'assert'
+require 'assert/runner'
+
+require 'stringio'
+require 'assert/config_helpers'
 require 'assert/suite'
 require 'assert/view'
-require 'assert/runner'
 
 class Assert::Runner
 
   class UnitTests < Assert::Context
     desc "Assert::Runner"
+    subject{ Assert::Runner }
+
+    should "include the config helpers" do
+      assert_includes Assert::ConfigHelpers, subject
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
     setup do
       @config = Factory.modes_off_config
       @suite  = Assert::Suite.new(@config)
       @view   = Assert::View::Base.new(StringIO.new("", "w+"), @suite)
+
       @runner = Assert::Runner.new(@config)
     end
     subject { @runner }


### PR DESCRIPTION
Before, the runner just fired events on the view and the view
could determine what to say on start.  However, the default view
would make assumptions about the runner and say that we are running
tests in random order when in fact this may not be true.

This moves the logic of describing the run into the runner as it
isn't a view's concern.  This is prep for intending the runner to
be extended - different runners may want to both use the default view
but may run their tests in different manners.

Note: the view continues to have no control on the order that output is
displayed - the runner controls when events are fired which controls
when the different output pieces are displayed.

@jcredding ready for review.