### PR TITLE
simplify, standardize view constructor

### DIFF
--- a/lib/assert/config.rb
+++ b/lib/assert/config.rb
@@ -26,7 +26,7 @@ module Assert
 
     def initialize(settings = nil)
       @suite  = Assert::Suite.new(self)
-      @view   = Assert::DefaultView.new($stdout, self, @suite)
+      @view   = Assert::DefaultView.new(self, $stdout)
       @runner = Assert::Runner.new(self)
 
       @test_dir    = "test"

--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -53,7 +53,7 @@ module Assert
 
       # show profile output
       if show_test_profile_info?
-        suite.ordered_tests_by_run_time.each do |test|
+        config.suite.ordered_tests_by_run_time.each do |test|
           puts "#{test_run_time(test)} seconds,"\
                " #{test.result_count} results,"\
                " #{test_result_rate(test)} results/s --"\
@@ -83,7 +83,7 @@ module Assert
       puts
 
       # output detailed results for the tests in reverse test/result order
-      tests = suite.ordered_tests.reverse
+      tests = config.suite.ordered_tests.reverse
       result_details_for(tests, :reversed).each do |details|
         if show_result_details?(details.result)
           # output the styled result details

--- a/lib/assert/view.rb
+++ b/lib/assert/view.rb
@@ -44,28 +44,15 @@ module Assert
       option 'skip_abbrev',   'S'
       option 'error_abbrev',  'E'
 
-      attr_reader :config, :suite
+      attr_reader :config
 
-      def initialize(output_io, *args)
-        @output_io = output_io
-        @suite, @config = [
-          args.last.kind_of?(Assert::Suite)  ? args.pop : nil,
-          args.last.kind_of?(Assert::Config) ? args.pop : nil
-        ]
-
+      def initialize(config, output_io)
+        @config , @output_io, = config, output_io
         @output_io.sync = true if @output_io.respond_to?(:sync=)
       end
 
       def view
         self
-      end
-
-      def config
-        @config ||= Assert.config
-      end
-
-      def suite
-        @suite ||= Assert.suite
       end
 
       def is_tty?

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -21,12 +21,12 @@ module Assert::View
       @io     = StringIO.new("", "w+")
       @config = Factory.modes_off_config
 
-      @view = Assert::View::Base.new(@io, @config, @config.suite)
+      @view = Assert::View::Base.new(@config, @io)
     end
     subject{ @view }
 
-    should have_imeths :view, :config, :suite
-    should have_imeths :is_tty?, :ansi_styled_msg
+    should have_readers :config
+    should have_imeths :view, :is_tty?, :ansi_styled_msg
     should have_imeths :fire
     should have_imeths :before_load, :after_load
     should have_imeths :on_start, :on_finish, :on_interrupt
@@ -54,13 +54,12 @@ module Assert::View
       assert_equal 'E', subject.error_abbrev
     end
 
-    should "expose itself as `view`" do
-      assert_equal subject, subject.view
+    should "know its config" do
+      assert_equal @config, subject.config
     end
 
-    should "know its config and suite" do
-      assert_equal @config,       subject.config
-      assert_equal @config.suite, subject.suite
+    should "expose itself as `view`" do
+      assert_equal subject, subject.view
     end
 
     should "know if it is a tty" do


### PR DESCRIPTION
This removes the ability to dynamically specify view configs/suites.
This ability isn't really serving any purpose and is an artifact
of legacy implementations.  This is prep for Parassert - making
the core objects more intentionally extendable.

I also chose to change it so that you pass the config as the first
arg to the view constructor.  This makes is consistent with the
suite and runner objects.  I'm trying to centralize all handling
around the config object and locking things down so that the config
truly drives all settings.  #221 and #222 started this effort by
centralizing the helpers around the config object.

@jcredding ready for review.