### PR TITLE
simplify runner run method; remove suite/view injection

### DIFF
--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -45,7 +45,7 @@ module Assert
     end
 
     def run
-      self.config.runner.run(self.config.suite, self.config.view)
+      self.config.runner.run
     end
 
     private

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -12,7 +12,8 @@ module Assert
       @config = config
     end
 
-    def run(suite, view)
+    def run
+      suite, view = @config.suite, @config.view
       raise ArgumentError if !suite.kind_of?(Suite)
       if tests?
         view.puts "Running tests in random order, seeded with \"#{runner_seed}\""

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -22,8 +22,8 @@ class Assert::Runner
     desc "when init"
     setup do
       @config = Factory.modes_off_config
-      @suite  = Assert::Suite.new(@config)
-      @view   = Assert::View::Base.new(StringIO.new("", "w+"), @suite)
+      @config.suite Assert::Suite.new(@config)
+      @config.view  Assert::View::Base.new(@config, StringIO.new("", "w+"))
 
       @runner = Assert::Runner.new(@config)
     end
@@ -37,7 +37,7 @@ class Assert::Runner
     end
 
     should "return an integer exit code" do
-      assert_equal 0, subject.run(@suite, @view)
+      assert_equal 0, subject.run
     end
 
   end


### PR DESCRIPTION
This is similar to 226 and is prep for doing Parassert.  The goal
here is to make the runner intentionally extendable yet as simple
to work with as possible.  This also continues the efforts of 221
and 222 to make the config the common central point for all settings.

The `run` methods dependency injection is an artifact of previous
implementations and currently serves no purpose.  It only adds
complexity.

See #221, #222 and #226 for reference.