### PR TITLE
have tests capture their data in a specific "data" object

### DIFF
--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -44,8 +44,10 @@ module Assert
       end
     end
 
-    def initialize(running_test, config)
-      @__running_test__, @__assert_config__ = running_test, config
+    def initialize(running_test, config, result_callback)
+      @__running_test__    = running_test
+      @__assert_config__   = config
+      @__result_callback__ = result_callback
     end
 
     # check if the assertion is a truthy value, if so create a new pass result, otherwise
@@ -75,7 +77,7 @@ module Assert
 
     # adds a Pass result to the end of the test's results
     # does not break test execution
-    def pass(pass_msg=nil)
+    def pass(pass_msg = nil)
       capture_result do |test, backtrace|
         Assert::Result::Pass.new(test, pass_msg, backtrace)
       end
@@ -83,7 +85,7 @@ module Assert
 
     # adds an Ignore result to the end of the test's results
     # does not break test execution
-    def ignore(ignore_msg=nil)
+    def ignore(ignore_msg = nil)
       capture_result do |test, backtrace|
         Assert::Result::Ignore.new(test, ignore_msg, backtrace)
       end
@@ -103,7 +105,7 @@ module Assert
     alias_method :flunk, :fail
 
     # adds a Skip result to the end of the test's results and breaks test execution
-    def skip(skip_msg=nil)
+    def skip(skip_msg = nil)
       raise(Result::TestSkipped, skip_msg || '')
     end
 
@@ -147,7 +149,7 @@ module Assert
     def capture_result
       if block_given?
         result = yield __running_test__, caller
-        __running_test__.results << result
+        __running_test__.capture_result(result, @__result_callback__)
         result
       end
     end

--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -163,22 +163,6 @@ module Assert::Result
 
   end
 
-  # Utility Classes
-
-  class Set < ::Array
-    attr_accessor :callback
-
-    def initialize(callback=nil)
-      @callback = callback
-      super()
-    end
-
-    def <<(result)
-      super
-      @callback.call(result) if @callback
-    end
-  end
-
   class Backtrace < ::Array
     def initialize(value = nil)
       super([*(value || "No backtrace")])

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -66,7 +66,7 @@ module Assert
       self.tests.size
     end
 
-    def result_count(type=nil)
+    def result_count(type = nil)
       if type
         self.tests.inject(0) do |count, test|
           count += test.result_count(type)
@@ -136,7 +136,7 @@ module Assert
     class ContextInfo
       attr_reader :called_from, :klass, :file
 
-      def initialize(klass, called_from=nil, first_caller=nil)
+      def initialize(klass, called_from = nil, first_caller = nil)
         @called_from = called_from || first_caller
         @klass = klass
         @file = @called_from.gsub(/\:[0-9]+.*$/, '') if @called_from

--- a/test/system/test_tests.rb
+++ b/test/system/test_tests.rb
@@ -1,11 +1,15 @@
 require 'assert'
 
-class RunningSystemTests < Assert::Context
-  desc "Running a test (with no halt-on-fail) that"
-  subject{ @test }
+class Assert::Test
 
-  class NothingTests < RunningSystemTests
-    desc "does nothing"
+  class SystemTests < Assert::Context
+    desc "Assert::Test"
+    subject{ @test }
+
+  end
+
+  class NoResultsTests < SystemTests
+    desc "when producing no results"
     setup do
       @test = Factory.test
       @test.run
@@ -17,8 +21,8 @@ class RunningSystemTests < Assert::Context
 
   end
 
-  class PassTests < RunningSystemTests
-    desc "passes a single assertion"
+  class PassTests < SystemTests
+    desc "when passing a single assertion"
     setup do
       @test = Factory.test{ assert(1 == 1) }
       @test.run
@@ -34,8 +38,8 @@ class RunningSystemTests < Assert::Context
 
   end
 
-  class FailTests < RunningSystemTests
-    desc "fails a single assertion"
+  class FailTests < SystemTests
+    desc "when failing a single assertion"
     setup do
       @test = Factory.test{ assert(1 == 0) }
       @test.run
@@ -51,8 +55,8 @@ class RunningSystemTests < Assert::Context
 
   end
 
-  class SkipTests < RunningSystemTests
-    desc "skips once"
+  class SkipTests < SystemTests
+    desc "when skipping once"
     setup do
       @test = Factory.test{ skip }
       @test.run
@@ -68,8 +72,8 @@ class RunningSystemTests < Assert::Context
 
   end
 
-  class ErrorTests < RunningSystemTests
-    desc "errors once"
+  class ErrorTests < SystemTests
+    desc "when erroring once"
     setup do
       @test = Factory.test{ raise("WHAT") }
       @test.run
@@ -85,8 +89,8 @@ class RunningSystemTests < Assert::Context
 
   end
 
-  class MixedTests < RunningSystemTests
-    desc "has 1 pass and 1 fail assertion"
+  class MixedTests < SystemTests
+    desc "when passing 1 assertion and failing 1 assertion"
     setup do
       @test = Factory.test do
         assert(1 == 1)
@@ -109,8 +113,8 @@ class RunningSystemTests < Assert::Context
 
   end
 
-  class MixedSkipTests < RunningSystemTests
-    desc "has 1 pass and 1 fail assertion with a skip call in between"
+  class MixedSkipTests < SystemTests
+    desc "when passing 1 assertion and failing 1 assertion with a skip call in between"
     setup do
       @test = Factory.test do
         assert(1 == 1)
@@ -142,8 +146,8 @@ class RunningSystemTests < Assert::Context
 
   end
 
-  class MixedErrorTests < RunningSystemTests
-    desc "has 1 pass and 1 fail assertion with an exception raised in between"
+  class MixedErrorTests < SystemTests
+    desc "when passing 1 assertion and failing 1 assertion with an exception raised in between"
     setup do
       @test = Factory.test do
         assert(1 == 1)
@@ -153,12 +157,12 @@ class RunningSystemTests < Assert::Context
       @test.run
     end
 
-    should "have an error for its last result" do
-      assert_kind_of Assert::Result::Error, subject.results.last
-    end
-
     should "have 2 total results" do
       assert_equal 2, subject.result_count
+    end
+
+    should "have an error for its last result" do
+      assert_kind_of Assert::Result::Error, subject.results.last
     end
 
     should "have 1 pass result" do
@@ -175,8 +179,8 @@ class RunningSystemTests < Assert::Context
 
   end
 
-  class MixedPassTests < RunningSystemTests
-    desc "has 1 pass and 1 fail assertion with a pass call in between"
+  class MixedPassTests < SystemTests
+    desc "when passing 1 assertion and failing 1 assertion with a pass call in between"
     setup do
       @test = Factory.test do
         assert(1 == 1)
@@ -186,26 +190,26 @@ class RunningSystemTests < Assert::Context
       @test.run
     end
 
-    should "have a pass for its last result" do
-      assert_kind_of Assert::Result::Fail, subject.results.last
-    end
-
     should "have 3 total results" do
       assert_equal 3, subject.result_count
+    end
+
+    should "have a fail for its last result" do
+      assert_kind_of Assert::Result::Fail, subject.results.last
     end
 
     should "have 2 pass results" do
       assert_equal 2, subject.result_count(:pass)
     end
 
-    should "have 1 fail results" do
+    should "have 1 fail result" do
       assert_equal 1, subject.result_count(:fail)
     end
 
   end
 
-  class MixedFailTests < RunningSystemTests
-    desc "has 1 pass and 1 fail assertion with a fail call in between"
+  class MixedFailTests < SystemTests
+    desc "when failing 1 assertion and passing 1 assertion with a fail call in between"
     setup do
       @test = Factory.test do
         assert(1 == 0)
@@ -215,15 +219,15 @@ class RunningSystemTests < Assert::Context
       @test.run
     end
 
-    should "have a fail for its last result" do
-      assert_kind_of Assert::Result::Pass, subject.results.last
-    end
-
     should "have 3 total results" do
       assert_equal 3, subject.result_count
     end
 
-    should "have 1 pass results" do
+    should "have a pass for its last result" do
+      assert_kind_of Assert::Result::Pass, subject.results.last
+    end
+
+    should "have 1 pass result" do
       assert_equal 1, subject.result_count(:pass)
     end
 
@@ -233,8 +237,8 @@ class RunningSystemTests < Assert::Context
 
   end
 
-  class MixedFlunkTests < RunningSystemTests
-    desc "has 1 pass and 1 fail assertion with a flunk call in between"
+  class MixedFlunkTests < SystemTests
+    desc "has failing 1 assertion and passing 1 assertion with a flunk call in between"
     setup do
       @test = Factory.test do
         assert(1 == 0)
@@ -244,12 +248,12 @@ class RunningSystemTests < Assert::Context
       @test.run
     end
 
-    should "have a fail for its last result" do
-      assert_kind_of Assert::Result::Pass, subject.results.last
-    end
-
     should "have 3 total results" do
       assert_equal 3, subject.result_count
+    end
+
+    should "have a pass for its last result" do
+      assert_kind_of Assert::Result::Pass, subject.results.last
     end
 
     should "have 1 pass results" do
@@ -262,8 +266,8 @@ class RunningSystemTests < Assert::Context
 
   end
 
-  class WithSetupsTests < RunningSystemTests
-    desc "has tests that depend on setups"
+  class WithSetupsTests < SystemTests
+    desc "that has tests that depend on setups"
     setup do
       assert_style_msg = @asm = "set by assert style setup"
       testunit_style_msg = @tusm = "set by test/unit style setup"
@@ -307,8 +311,8 @@ class RunningSystemTests < Assert::Context
 
   end
 
-  class WithTeardownsTests < RunningSystemTests
-    desc "has tests that depend on teardowns"
+  class WithTeardownsTests < SystemTests
+    desc "that has tests that depend on teardowns"
     setup do
       assert_style_msg = @asm = "set by assert style teardown"
       testunit_style_msg = @tusm = "set by test/unit style teardown"
@@ -351,8 +355,8 @@ class RunningSystemTests < Assert::Context
 
   end
 
-  class WithAroundsTests < RunningSystemTests
-    desc "has arounds (in addition to setups/teardowns)"
+  class WithAroundsTests < SystemTests
+    desc "that has arounds (in addition to setups/teardowns)"
     setup do
       @parent_class = Factory.modes_off_context_class do
         around do |block|

--- a/test/unit/assertions_tests.rb
+++ b/test/unit/assertions_tests.rb
@@ -8,7 +8,7 @@ module Assert::Assertions
     setup do
       @context_class = Factory.modes_off_context_class
       @test = Factory.test
-      @context = @context_class.new(@test, @test.config)
+      @context = @context_class.new(@test, @test.config, proc{ |r| })
     end
     subject{ @context }
 

--- a/test/unit/context/test_dsl_tests.rb
+++ b/test/unit/context/test_dsl_tests.rb
@@ -147,7 +147,7 @@ module Assert::Context::TestDSL
       context_class = Factory.modes_off_context_class &build_block
       context_info  = Factory.context_info(context_class)
       test = Factory.test("whatever", context_info)
-      context_class.new(test, test.config)
+      context_class.new(test, test.config, proc{ |r| })
     end
 
     def capture_err(err_class, &block)


### PR DESCRIPTION
This is prep for making working with test/result data more flexible
and ultimately prep for implementing Parassert.  Parassert will
use these data objects to store test run info in a db and then
rebuild the data from the db when outputting test results.

In theory, test/result data is all that is needed to render test
output in the view (as opposed to the actual objects).  In order
to transition the views to using these "data" objects, we first
need to start collecting the data in the tests.

This adds the test data object and updates the test to compose it
for any applicable logic.  This allows us to get the data object
in place while avoiding double-storing the test attrs.

In a future effort, I'll add the result data object and then switch
the views/runner to use the data objects when outputting results.

Additionally, I updated how the results are captured and how the
result callback is handled.  I didn't want to store the callback
as mutable state so this switches to passing the callback around
as needed.  This allowed me to remove the superfulous `Result::Set`
class.

@jcredding ready for review.