### PR TITLE
test/unit handling cleanups

### DIFF
--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -33,7 +33,7 @@ module Assert
 
         if self.suite.test_methods.include?(klass_method_name)
           puts "WARNING: redefining '#{klass_method_name}'"
-          puts "  from: #{called_from}"
+          puts "  from: #{caller.first}"
         else
           self.suite.test_methods << klass_method_name
         end

--- a/lib/assert/test.rb
+++ b/lib/assert/test.rb
@@ -107,7 +107,7 @@ module Assert
       # run any assert style 'setup do' setups
       self.context_class.send('run_setups', scope)
 
-      # run any classic test/unit style 'def setup' setups
+      # run any test/unit style 'def setup' setups
       scope.setup if scope.respond_to?(:setup)
     end
 
@@ -120,11 +120,11 @@ module Assert
     end
 
     def run_test_teardown(scope)
-      # run any classic test/unit style 'def teardown' teardowns
-      scope.teardown if scope.respond_to?(:teardown)
-
       # run any assert style 'teardown do' teardowns
       self.context_class.send('run_teardowns', scope)
+
+      # run any test/unit style 'def teardown' teardowns
+      scope.teardown if scope.respond_to?(:teardown)
     end
 
     def capture_output(&block)

--- a/test/system/test_tests.rb
+++ b/test/system/test_tests.rb
@@ -304,7 +304,7 @@ class Assert::Test
     should "execute all teardown logic when run" do
       assert_equal 3, subject.result_count(:pass)
 
-      exp = ['TEST', 'test/unit style teardown', 'assert style teardown']
+      exp = ['TEST', 'assert style teardown', 'test/unit style teardown']
       assert_equal exp, subject.results.map(&:message)
     end
 


### PR DESCRIPTION
These were noticed while optimizing tests and trying to get more
test execution speed.

First this fixes a bug when defining duplicate test/unit style
test methods.  Second, this switches to calling test/unit style
teardowns *after* assert style teardowns just like we call test/unit
style setups *after* assert style setups.

@jcredding minor stuff I happened upon.  Ready for review.