### PR TITLE
update `slug` factory; don't have it include dashes

### DIFF
--- a/lib/assert/factory.rb
+++ b/lib/assert/factory.rb
@@ -33,7 +33,7 @@ module Assert
     end
 
     def string(length = nil)
-      self.type_cast(Random.string(length), :string)
+      self.type_cast(Random.string(length || 10), :string)
     end
 
     def text(length = nil)
@@ -41,7 +41,7 @@ module Assert
     end
 
     def slug(length = nil)
-      self.type_cast(Random.slug_string(length), :string)
+      self.type_cast(Random.string(length || 5), :string)
     end
 
     def hex(length = nil)
@@ -120,11 +120,6 @@ module Assert
       DICTIONARY = [*'a'..'z'].freeze
       def self.string(length = nil)
         [*0..((length || 10) - 1)].map{ |n| DICTIONARY[rand(DICTIONARY.size)] }.join
-      end
-
-      def self.slug_string(length = nil)
-        length ||= 8
-        self.string(length).scan(/.{1,4}/).join('-')
       end
 
       def self.hex_string(length = nil)

--- a/test/unit/factory_tests.rb
+++ b/test/unit/factory_tests.rb
@@ -63,6 +63,15 @@ module Assert::Factory
       assert_equal 1, subject.text(1).length
     end
 
+    should "return a random string using `slug`" do
+      assert_kind_of String, subject.slug
+      assert_equal 5, subject.slug.length
+    end
+
+    should "allow passing a maximum length using `slug`" do
+      assert_equal 1, subject.slug(1).length
+    end
+
     should "return a random hex string using `hex`" do
       assert_kind_of String, subject.hex
       assert_match /\A[0-9a-f]{10}\Z/, subject.hex
@@ -70,17 +79,6 @@ module Assert::Factory
 
     should "allow passing a maximum length using `hex`" do
       assert_equal 1, subject.hex(1).length
-    end
-
-    should "return a random slug string using `slug`" do
-      assert_kind_of String, subject.slug
-      segments = subject.slug.split('-')
-      assert_equal 2, segments.size
-      segments.each{ |s| assert_match /\A[a-z]{4}\Z/, s }
-    end
-
-    should "allow passing a maximum length using `slug`" do
-      assert_equal 1, subject.slug(1).length
     end
 
     should "return a random file name string using `file_name`" do


### PR DESCRIPTION
In hindsight this was to big of an assumption about the makeup of
a slug.  This switches to a simpler, more basic and more general
representation of a slug.  I chose to use a 5 char string by default
to help differentiate it from string factories.