### PR TITLE
bugfix: include the test backtrace on skip tests

### DIFF
--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -107,8 +107,10 @@ module Assert
     alias_method :flunk, :fail
 
     # adds a Skip result to the end of the test's results and breaks test execution
-    def skip(skip_msg = nil)
-      raise(Result::TestSkipped, skip_msg || '')
+    def skip(skip_msg = nil, called_from = nil)
+      err = Result::TestSkipped.new(skip_msg || '')
+      err.set_backtrace([called_from]) if called_from
+      raise(err)
     end
 
     # alter the backtraces of fail results generated in the given block

--- a/lib/assert/context/test_dsl.rb
+++ b/lib/assert/context/test_dsl.rb
@@ -25,11 +25,12 @@ class Assert::Context
 
     def test_eventually(desc_or_macro, called_from = nil, first_caller = nil, &block)
       # create a test from a proc that just skips
+      ci = Assert::Suite::ContextInfo.new(self, called_from, first_caller || caller.first)
       self.suite.tests << Assert::Test.for_block(
         desc_or_macro.kind_of?(Assert::Macro) ? desc_or_macro.name : desc_or_macro,
-        Assert::Suite::ContextInfo.new(self, called_from, first_caller || caller.first),
+        ci,
         self.suite.config,
-        &(block.nil? ? Proc.new { skip 'TODO' } : Proc.new { skip })
+        &proc { skip('TODO', ci.called_from) }
       )
     end
     alias_method :test_skip, :test_eventually

--- a/test/unit/context/test_dsl_tests.rb
+++ b/test/unit/context/test_dsl_tests.rb
@@ -17,10 +17,11 @@ module Assert::Context::TestDSL
       assert_equal 1, context_class.suite.tests.size
 
       exp_test_name = @test_desc
-      built_test = context_class.suite.tests.first
+      built_test    = context_class.suite.tests.first
+
       assert_kind_of Assert::Test, built_test
       assert_equal exp_test_name, built_test.name
-      assert_equal @test_block, built_test.code
+      assert_equal @test_block,   built_test.code
     end
 
     should "build a test using `should` with a desc and code block" do
@@ -30,10 +31,11 @@ module Assert::Context::TestDSL
       assert_equal 1, context_class.suite.tests.size
 
       exp_test_name = "should #{@test_desc}"
-      built_test = context_class.suite.tests.last
+      built_test    = context_class.suite.tests.last
+
       assert_kind_of Assert::Test, built_test
       assert_equal exp_test_name, built_test.name
-      assert_equal @test_block, built_test.code
+      assert_equal @test_block,   built_test.code
     end
 
     should "build a test that skips with no msg when `test_eventually` called" do
@@ -43,8 +45,9 @@ module Assert::Context::TestDSL
         context.instance_eval(&context.class.suite.tests.last.code)
       end
 
-      assert_equal 1, context.class.suite.tests.size
-      assert_equal "", err.message
+      assert_equal 1,      context.class.suite.tests.size
+      assert_equal 'TODO', err.message
+      assert_equal 1,      err.backtrace.size
     end
 
     should "build a test that skips with no msg  when `should_eventually` called" do
@@ -54,8 +57,9 @@ module Assert::Context::TestDSL
         context.instance_eval(&context.class.suite.tests.last.code)
       end
 
-      assert_equal 1, context.class.suite.tests.size
-      assert_equal "", err.message
+      assert_equal 1,      context.class.suite.tests.size
+      assert_equal 'TODO', err.message
+      assert_equal 1,      err.backtrace.size
     end
 
     should "skip with the msg \"TODO\" when `test` called with no block" do
@@ -65,8 +69,9 @@ module Assert::Context::TestDSL
         context.instance_eval(&context.class.suite.tests.last.code)
       end
 
-      assert_equal 1, context.class.suite.tests.size
-      assert_equal "TODO", err.message
+      assert_equal 1,      context.class.suite.tests.size
+      assert_equal 'TODO', err.message
+      assert_equal 1,      err.backtrace.size
     end
 
     should "skip with the msg \"TODO\" when `should` called with no block" do
@@ -76,8 +81,9 @@ module Assert::Context::TestDSL
         context.instance_eval(&context.class.suite.tests.last.code)
       end
 
-      assert_equal 1, context.class.suite.tests.size
-      assert_equal "TODO", err.message
+      assert_equal 1,      context.class.suite.tests.size
+      assert_equal 'TODO', err.message
+      assert_equal 1,      err.backtrace.size
     end
 
     should "skip with the msg \"TODO\" when `test_eventually` called with no block" do
@@ -87,8 +93,9 @@ module Assert::Context::TestDSL
         context.instance_eval(&context.class.suite.tests.last.code)
       end
 
-      assert_equal 1, context.class.suite.tests.size
-      assert_equal "TODO", err.message
+      assert_equal 1,      context.class.suite.tests.size
+      assert_equal 'TODO', err.message
+      assert_equal 1,      err.backtrace.size
     end
 
     should "skip with the msg \"TODO\" when `should_eventually` called with no block" do
@@ -98,8 +105,9 @@ module Assert::Context::TestDSL
         context.instance_eval(&context.class.suite.tests.last.code)
       end
 
-      assert_equal 1, context.class.suite.tests.size
-      assert_equal "TODO", err.message
+      assert_equal 1,      context.class.suite.tests.size
+      assert_equal 'TODO', err.message
+      assert_equal 1,      err.backtrace.size
     end
 
     should "build a test from a macro using `test`" do

--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -58,6 +58,15 @@ class Assert::Context
       assert_nil @callback_result
     end
 
+    should "use any given called from arg as the exception backtrace" do
+      assert_not_equal 1, @exception.backtrace.size
+
+      called_from = Factory.string
+      begin; @context.skip(@skip_msg, called_from); rescue Exception => exception; end
+      assert_equal 1,           exception.backtrace.size
+      assert_equal called_from, exception.backtrace.first
+    end
+
   end
 
   class IgnoreTests < UnitTests


### PR DESCRIPTION
So you can create "skip tests" using the `{test|should}_eventually`
methods or by creating a test with no given block.  These tests
automatically create a single skip result and (in the eventually
methods case) don't run any test code.

However, the results these skip tests produced had a backtrace that
was internal to assert as the skip call was happening from internal
assert code.  When the results were rendered they would appear to
have no trace info b/c the internal assert backtrace lines were all
being filtered out.

This fixes the issue by passing in the test called from info in to
the skip call.  If called from info is passed in to the skip call,
it updates the skip exception backtrace to the called from.  This
allows proper trace info to show up for the skip test results.

Note: this alters the skip behavior slightly.  Before the eventually
methods skip results would have no message.  This updates both the
eventually and the non-eventually skip tests to both set 'TODO' as
the result message.  This simplifies the logic and makes all skip
tests produces similar results.

@jcredding ready for review.