### PR TITLE
remove `fire` method on the base view

### DIFF
--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -33,7 +33,7 @@ module Assert
       end
 
       # load the test files
-      self.config.view.fire(:before_load, test_files)
+      self.config.view.before_load(test_files)
       Assert::CLI.bench("Require #{test_files.count} test files") do
         test_files.each{ |p| require p }
       end
@@ -41,7 +41,7 @@ module Assert
         puts Assert::CLI.debug_msg("Test files:")
         test_files.each{ |f| puts Assert::CLI.debug_msg("  #{f}") }
       end
-      self.config.view.fire(:after_load)
+      self.config.view.after_load
     end
 
     def run

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -18,26 +18,26 @@ module Assert
       if tests?
         view.puts "Running tests in random order, seeded with \"#{runner_seed}\""
       end
-      view.fire(:on_start)
+      view.on_start
 
       begin
         suite.setup
 
         suite.start_time = Time.now
         tests_to_run(suite).each do |test|
-          view.fire(:before_test, test)
-          test.run{ |result| view.fire(:on_result, result) }
-          view.fire(:after_test, test)
+          view.before_test(test)
+          test.run{ |result| view.on_result(result) }
+          view.after_test(test)
         end
         suite.end_time = Time.now
 
         suite.teardown
       rescue Interrupt => err
-        view.fire(:on_interrupt, err)
+        view.on_interrupt(err)
         raise(err)
       end
 
-      view.fire(:on_finish)
+      view.on_finish
       suite.count(:failed) + suite.count(:errored)
     end
 

--- a/lib/assert/view.rb
+++ b/lib/assert/view.rb
@@ -68,13 +68,8 @@ module Assert
 
       # Callbacks
 
-      # define callback handlers to output information.  handlers are
-      # instance_eval'd in the scope of the view instance.  any stdout is captured
-      # and sent to the io stream.
-
-      def fire(callback, *args)
-        self.send(callback, *args)
-      end
+      # define callback handlers to output information.  These will be called
+      # by the test runner.
 
       # available callbacks from the runner:
       # * `before_load`:  called at the beginning, before the suite is loaded

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -27,7 +27,6 @@ module Assert::View
 
     should have_readers :config
     should have_imeths :view, :is_tty?, :ansi_styled_msg
-    should have_imeths :fire
     should have_imeths :before_load, :after_load
     should have_imeths :on_start, :on_finish, :on_interrupt
     should have_imeths :before_test, :after_test, :on_result


### PR DESCRIPTION
Remove the ceremony of going through a custom dispatch method.  Just
call the methods directly.  There was nothing wrong with the previous
implementation, I'm just trying to simplify things.  This also updates
the callbacks comment to make it more accurate.

This is prep for adding a similar callback setup for the suite and
the runner.

@jcredding ready for review.