### PR TITLE
rework suite implementation/handling; add DefaultSuite

### DIFF
--- a/lib/assert/config.rb
+++ b/lib/assert/config.rb
@@ -1,6 +1,6 @@
+require 'assert/default_suite'
 require 'assert/default_view'
 require 'assert/runner'
-require 'assert/suite'
 require 'assert/utils'
 
 module Assert
@@ -25,7 +25,7 @@ module Assert
     settings :capture_output, :halt_on_fail, :profile, :verbose, :list, :debug
 
     def initialize(settings = nil)
-      @suite  = Assert::Suite.new(self)
+      @suite  = Assert::DefaultSuite.new(self)
       @view   = Assert::DefaultView.new(self, $stdout)
       @runner = Assert::Runner.new(self)
 

--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -3,6 +3,7 @@ require 'assert/context/setup_dsl'
 require 'assert/context/subject_dsl'
 require 'assert/context/suite_dsl'
 require 'assert/context/test_dsl'
+require 'assert/context_info'
 require 'assert/macros/methods'
 require 'assert/result'
 require 'assert/suite'
@@ -40,7 +41,7 @@ module Assert
 
         self.suite.tests << Test.for_method(
           method_name.to_s,
-          Suite::ContextInfo.new(self, nil, caller.first),
+          ContextInfo.new(self, nil, caller.first),
           self.suite.config
         )
       end

--- a/lib/assert/context/test_dsl.rb
+++ b/lib/assert/context/test_dsl.rb
@@ -1,3 +1,4 @@
+require 'assert/context_info'
 require 'assert/macro'
 require 'assert/suite'
 require 'assert/test'
@@ -14,7 +15,7 @@ class Assert::Context
         # create a test from the given code block
         self.suite.tests << Assert::Test.for_block(
           desc_or_macro.kind_of?(Assert::Macro) ? desc_or_macro.name : desc_or_macro,
-          Assert::Suite::ContextInfo.new(self, called_from, first_caller || caller.first),
+          Assert::ContextInfo.new(self, called_from, first_caller || caller.first),
           self.suite.config,
           &block
         )
@@ -25,7 +26,7 @@ class Assert::Context
 
     def test_eventually(desc_or_macro, called_from = nil, first_caller = nil, &block)
       # create a test from a proc that just skips
-      ci = Assert::Suite::ContextInfo.new(self, called_from, first_caller || caller.first)
+      ci = Assert::ContextInfo.new(self, called_from, first_caller || caller.first)
       self.suite.tests << Assert::Test.for_block(
         desc_or_macro.kind_of?(Assert::Macro) ? desc_or_macro.name : desc_or_macro,
         ci,

--- a/lib/assert/context_info.rb
+++ b/lib/assert/context_info.rb
@@ -1,0 +1,19 @@
+module Assert
+
+  class ContextInfo
+
+    attr_reader :called_from, :klass, :file
+
+    def initialize(klass, called_from = nil, first_caller = nil)
+      @called_from = called_from || first_caller
+      @klass = klass
+      @file = @called_from.gsub(/\:[0-9]+.*$/, '') if @called_from
+    end
+
+    def test_name(name)
+      [klass.description.to_s, name.to_s].compact.reject(&:empty?).join(' ')
+    end
+
+  end
+
+end

--- a/lib/assert/default_suite.rb
+++ b/lib/assert/default_suite.rb
@@ -1,0 +1,35 @@
+require 'assert/suite'
+
+module Assert
+
+  # This is the default suite used by assert.  It stores test/result data in-memory.
+
+  class DefaultSuite < Assert::Suite
+
+    # Test Handling
+
+    def ordered_tests
+      self.tests
+    end
+
+    def ordered_tests_by_run_time
+      self.ordered_tests.sort{ |a, b| a.run_time <=> b.run_time }
+    end
+
+    def test_count
+      self.tests.count
+    end
+
+    # Result Handling
+
+    def ordered_results
+      self.ordered_tests.inject([]){ |results, test| results += test.results }
+    end
+
+    def result_count(type = nil)
+      self.tests.inject(0){ |count, test| count += test.result_count(type) }
+    end
+
+  end
+
+end

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -21,7 +21,7 @@ module Assert
       view.on_start
 
       begin
-        suite.setup
+        suite.setups.each(&:call)
 
         suite.start_time = Time.now
         tests_to_run(suite).each do |test|
@@ -31,7 +31,7 @@ module Assert
         end
         suite.end_time = Time.now
 
-        suite.teardown
+        suite.teardowns.each(&:call)
       rescue Interrupt => err
         view.on_interrupt(err)
         raise(err)

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -1,45 +1,50 @@
+require 'assert/config_helpers'
 require 'assert/test'
 
 module Assert
-  class Suite
 
-    TEST_METHOD_REGEX = /^test./
+  class Suite
+    include Assert::ConfigHelpers
+
+    TEST_METHOD_REGEX = /^test./.freeze
 
     # A suite is a set of tests to run.  When a test class subclasses
     # the Context class, that test class is pushed to the suite.
 
-    attr_accessor :config, :tests, :test_methods, :start_time, :end_time
+    attr_reader :config, :tests, :test_methods, :setups, :teardowns
+    attr_accessor :start_time, :end_time
 
     def initialize(config)
-      @config = config
-      @tests = []
+      @config       = config
+      @tests        = []
       @test_methods = []
-      @start_time = Time.now
-      @end_time = @start_time
+      @setups       = []
+      @teardowns    = []
+      @start_time   = Time.now
+      @end_time     = @start_time
     end
+
+    def setup(&block)
+      self.setups << (block || proc{})
+    end
+    alias_method :startup, :setup
+
+    def teardown(&block)
+      self.teardowns << (block || proc{})
+    end
+    alias_method :shutdown, :teardown
 
     def run_time
       @end_time - @start_time
     end
 
     def test_rate
-      get_rate(self.tests.size, self.run_time)
+      get_rate(self.test_count, self.run_time)
     end
 
     def result_rate
-      get_rate(self.results.size, self.run_time)
+      get_rate(self.result_count, self.run_time)
     end
-
-    alias_method :ordered_tests, :tests
-
-    def ordered_tests_by_run_time
-      self.ordered_tests.sort{ |a, b| a.run_time <=> b.run_time }
-    end
-
-    def results
-      tests.inject([]){ |results, test| results += test.results }
-    end
-    alias_method :ordered_results, :results
 
     def count(thing)
       case thing
@@ -62,37 +67,33 @@ module Assert
       end
     end
 
-    def test_count
-      self.tests.size
-    end
+    # Test Handling
 
-    def result_count(type = nil)
-      if type
-        self.tests.inject(0) do |count, test|
-          count += test.result_count(type)
-        end
-      else
-        self.results.size
-      end
-    end
+    def ordered_tests;                      end
+    def reversed_ordered_tests;             end
+    def ordered_tests_by_run_time;          end
+    def reversed_ordered_tests_by_run_time; end
+    def test_count;                         end
 
-    def setup(&block)
-      if block_given?
-        self.setups << block
-      else
-        self.setups.each{ |setup| setup.call }
-      end
-    end
-    alias_method :startup, :setup
+    # Result Handling
 
-    def teardown(&block)
-      if block_given?
-        self.teardowns << block
-      else
-        self.teardowns.reverse.each{ |teardown| teardown.call }
-      end
-    end
-    alias_method :shutdown, :teardown
+    def ordered_results;          end
+    def reversed_ordered_results; end
+    def result_count(type = nil); end
+
+    # Callbacks
+
+    # define callback handlers to do special behavior during the test run.  These
+    # will be called by the test runner
+
+    def before_load(test_files); end
+    def after_load;              end
+    def on_start;                end
+    def before_test(test);       end
+    def on_result(result);       end
+    def after_test(test);        end
+    def on_finish;               end
+    def on_interrupt(err);       end
 
     def inspect
       "#<#{self.class}:#{'0x0%x' % (object_id << 1)}"\
@@ -100,53 +101,10 @@ module Assert
       " result_count=#{self.result_count.inspect}>"
     end
 
-    protected
-
-    def setups
-      @setups ||= []
-    end
-
-    def teardowns
-      @teardowns ||= []
-    end
-
-    def local_public_test_methods(klass)
-      # start with all public meths, store off the local ones
-      methods = klass.public_instance_methods
-      local_methods = klass.public_instance_methods(false)
-
-      # remove any from the superclass
-      while (klass.superclass)
-        methods -= (klass = klass.superclass).public_instance_methods
-      end
-
-      # add back in the local ones (to work around super having the same methods)
-      methods += local_methods
-
-      # uniq and remove any that don't start with 'test'
-      methods.uniq.delete_if {|method_name| method_name !~ TEST_METHOD_REGEX }
-    end
-
     private
 
     def get_rate(count, time)
       time == 0 ? 0.0 : (count.to_f / time.to_f)
-    end
-
-    class ContextInfo
-
-      attr_reader :called_from, :klass, :file
-
-      def initialize(klass, called_from = nil, first_caller = nil)
-        @called_from = called_from || first_caller
-        @klass = klass
-        @file = @called_from.gsub(/\:[0-9]+.*$/, '') if @called_from
-      end
-
-      def test_name(name)
-        [klass.description.to_s, name.to_s].compact.reject(&:empty?).join(' ')
-      end
-
     end
 
   end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,7 +1,7 @@
 require 'assert/config'
+require 'assert/default_suite'
 require 'assert/factory'
 require 'assert/result'
-require 'assert/suite'
 require 'assert/test'
 
 module Factory
@@ -12,7 +12,7 @@ module Factory
   end
 
   def self.context_info(context_klass = nil)
-    Assert::Suite::ContextInfo.new(context_klass || self.context_class, context_info_called_from)
+    Assert::ContextInfo.new(context_klass || self.context_class, context_info_called_from)
   end
 
   # Generate an anonymous `Context` inherited from `Assert::Context` by default.
@@ -34,7 +34,7 @@ module Factory
   def self.test(*args, &block)
     config, context_info, name = [
       args.last.kind_of?(Assert::Config) ? args.pop : self.modes_off_config,
-      args.last.kind_of?(Assert::Suite::ContextInfo) ? args.pop : self.context_info,
+      args.last.kind_of?(Assert::ContextInfo) ? args.pop : self.context_info,
       args.last.kind_of?(::String) ? args.pop : 'a test'
     ]
     Assert::Test.for_block(name, context_info, config, &block)
@@ -75,7 +75,7 @@ module Factory
   end
 
   def self.modes_off_suite
-    Assert::Suite.new(self.modes_off_config)
+    Assert::DefaultSuite.new(self.modes_off_config)
   end
 
   def self.modes_off_context_class(*args, &block)

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -1,9 +1,9 @@
 require 'assert'
 require 'assert/config'
 
+require 'assert/default_suite'
 require 'assert/default_view'
 require 'assert/runner'
-require 'assert/suite'
 
 class Assert::Config
 
@@ -22,14 +22,14 @@ class Assert::Config
     should have_imeths :debug, :apply
 
     should "default the view, suite, and runner" do
-      assert_kind_of Assert::DefaultView, subject.view
-      assert_kind_of Assert::Suite,  subject.suite
-      assert_kind_of Assert::Runner, subject.runner
+      assert_kind_of Assert::DefaultView,  subject.view
+      assert_kind_of Assert::DefaultSuite, subject.suite
+      assert_kind_of Assert::Runner,       subject.runner
     end
 
     should "default the test dir/helper/suffixes" do
-      assert_equal 'test', subject.test_dir
-      assert_equal 'helper.rb', subject.test_helper
+      assert_equal 'test',                    subject.test_dir
+      assert_equal 'helper.rb',               subject.test_helper
       assert_equal ['_tests.rb', "_test.rb"], subject.test_file_suffixes
     end
 

--- a/test/unit/context_info_tests.rb
+++ b/test/unit/context_info_tests.rb
@@ -1,0 +1,55 @@
+require 'assert'
+require 'assert/context_info'
+
+require 'assert/context'
+
+class Assert::ContextInfo
+
+  class UnitTests < Assert::Context
+    desc "Assert::ContextInfo"
+    setup do
+      @caller = caller
+      @klass  = Assert::Context
+      @info   = Assert::ContextInfo.new(@klass, nil, @caller.first)
+    end
+    subject{ @info }
+
+    should have_readers :called_from, :klass, :file
+    should have_imeths :test_name
+
+    should "set its klass on init" do
+      assert_equal @klass, subject.klass
+    end
+
+    should "set its called_from to the called_from or first caller on init" do
+      info = Assert::ContextInfo.new(@klass, @caller.first, nil)
+      assert_equal @caller.first, info.called_from
+
+      info = Assert::ContextInfo.new(@klass, nil, @caller.first)
+      assert_equal @caller.first, info.called_from
+    end
+
+    should "set its file from caller info on init" do
+      assert_equal @caller.first.gsub(/\:[0-9]+.*$/, ''), subject.file
+    end
+
+    should "not have any file info if no caller is given" do
+      info = Assert::ContextInfo.new(@klass)
+      assert_nil info.file
+    end
+
+    should "know how to build the contextual test name for a given name" do
+      desc = Factory.string
+      name = Factory.string
+
+      assert_equal name, subject.test_name(name)
+      assert_equal '',   subject.test_name('')
+      assert_equal '',   subject.test_name(nil)
+
+      Assert.stub(subject.klass, :description){ desc }
+      assert_equal "#{desc} #{name}", subject.test_name(name)
+    end
+
+  end
+
+end

--- a/test/unit/default_suite_tests.rb
+++ b/test/unit/default_suite_tests.rb
@@ -1,0 +1,74 @@
+require 'assert'
+require 'assert/default_suite'
+
+require 'assert/suite'
+
+class Assert::DefaultSuite
+
+  class UnitTests < Assert::Context
+    desc "Assert::DefaultSuite"
+    setup do
+      @config = Factory.modes_off_config
+      @suite  = Assert::DefaultSuite.new(@config)
+
+      ci = Factory.context_info(Factory.modes_off_context_class)
+      [ Factory.test("should nothing", ci){ },
+        Factory.test("should pass",    ci){ assert(1==1); refute(1==0) },
+        Factory.test("should fail",    ci){ ignore; assert(1==0); refute(1==1) },
+        Factory.test("should ignored", ci){ ignore },
+        Factory.test("should skip",    ci){ skip; ignore; assert(1==1) },
+        Factory.test("should error",   ci){ raise Exception; ignore; assert(1==1) }
+      ].each{ |test| @suite.tests << test }
+      @suite.tests.each(&:run)
+    end
+    subject{ @suite }
+
+    should "be a Suite" do
+      assert_kind_of Assert::Suite, subject
+    end
+
+    should "know its test and result attrs" do
+      assert_equal 6, subject.tests.count
+      assert_kind_of Assert::Test, subject.tests.first
+
+      assert_equal subject.tests.count, subject.test_count
+      assert_equal subject.tests,       subject.ordered_tests
+
+      exp = subject.ordered_tests.sort{ |a, b| a.run_time <=> b.run_time }
+      assert_equal exp, subject.ordered_tests_by_run_time
+
+      assert_equal 8, subject.result_count
+
+      exp = subject.ordered_tests.inject([]){ |results, t| results += t.results }
+      assert_equal exp, subject.ordered_results
+
+      assert_equal 2, subject.result_count(:pass)
+      assert_equal 2, subject.result_count(:fail)
+      assert_equal 2, subject.result_count(:ignore)
+      assert_equal 1, subject.result_count(:skip)
+      assert_equal 1, subject.result_count(:error)
+    end
+
+    should "count its tests and results" do
+      assert_equal subject.test_count,   subject.count(:tests)
+      assert_equal subject.result_count, subject.count(:results)
+
+      assert_equal subject.result_count(:pass), subject.count(:passed)
+      assert_equal subject.result_count(:pass), subject.count(:pass)
+
+      assert_equal subject.result_count(:fail), subject.count(:failed)
+      assert_equal subject.result_count(:fail), subject.count(:fail)
+
+      assert_equal subject.result_count(:ignore), subject.count(:ignored)
+      assert_equal subject.result_count(:ignore), subject.count(:ignore)
+
+      assert_equal subject.result_count(:skip), subject.count(:skipped)
+      assert_equal subject.result_count(:skip), subject.count(:skip)
+
+      assert_equal subject.result_count(:error), subject.count(:errored)
+      assert_equal subject.result_count(:error), subject.count(:error)
+    end
+
+  end
+
+end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -22,7 +22,7 @@ class Assert::Runner
     desc "when init"
     setup do
       @config = Factory.modes_off_config
-      @config.suite Assert::Suite.new(@config)
+      @config.suite Assert::DefaultSuite.new(@config)
       @config.view  Assert::View::Base.new(@config, StringIO.new("", "w+"))
 
       @runner = Assert::Runner.new(@config)

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -1,5 +1,7 @@
 require 'assert'
 require 'assert/suite'
+
+require 'assert/config_helpers'
 require 'assert/test'
 require 'test/support/inherited_stuff'
 
@@ -7,217 +9,94 @@ class Assert::Suite
 
   class UnitTests < Assert::Context
     desc "Assert::Suite"
+    subject{ Assert::Suite }
+
+    should "include the config helpers" do
+      assert_includes Assert::ConfigHelpers, subject
+    end
+
+    should "know its test method regex" do
+      assert_match     "test#{Factory.string}", subject::TEST_METHOD_REGEX
+      assert_not_match "#{Factory.string}test", subject::TEST_METHOD_REGEX
+    end
+
+  end
+
+  class InitTests < Assert::Context
+    desc "when init"
     setup do
       @config = Factory.modes_off_config
-      @suite = Assert::Suite.new(@config)
+      @suite  = Assert::Suite.new(@config)
     end
     subject{ @suite }
 
-    should have_accessors :config, :tests, :test_methods, :start_time, :end_time
-    should have_imeths :ordered_tests, :ordered_tests_by_run_time
-    should have_imeths :results, :ordered_results
-    should have_imeths :run_time, :test_rate, :result_rate
-    should have_imeths :count, :test_count, :result_count
+    should have_readers :config, :tests, :test_methods
+    should have_accessors :start_time, :end_time
     should have_imeths :setup, :startup, :teardown, :shutdown
+    should have_imeths :run_time, :test_rate, :result_rate, :count
+    should have_imeths :ordered_tests, :reversed_ordered_tests, :test_count
+    should have_imeths :ordered_results, :reversed_ordered_results, :result_count
+    should have_imeths :before_load, :after_load
+    should have_imeths :on_start, :on_finish, :on_interrupt
+    should have_imeths :before_test, :after_test, :on_result
 
-    should "determine a klass' local public test methods" do
-      exp = ["test_subclass_stuff", "test_mixin_stuff", "test_repeated"].sort
-      act = subject.send(:local_public_test_methods, SubStuff).sort.map(&:to_s)
-      assert_equal(exp, act)
+    should "know its config" do
+      assert_equal @config, subject.config
     end
 
-    should "have a zero run time, test rate and result rate by default" do
+    should "default its attrs" do
+      assert_equal [], subject.tests
+      assert_equal [], subject.test_methods
+      assert_equal [], subject.setups
+      assert_equal [], subject.teardowns
+
+      assert_equal subject.start_time, subject.end_time
+    end
+
+    should "know its run time and rates" do
       assert_equal 0, subject.run_time
       assert_equal 0, subject.test_rate
       assert_equal 0, subject.result_rate
+
+      time = Factory.integer(3).to_f
+      subject.end_time = subject.start_time + time
+      count = Factory.integer(10)
+      Assert.stub(subject, :test_count){ count }
+      Assert.stub(subject, :result_count){ count }
+
+      assert_equal time, subject.run_time
+      assert_equal (subject.test_count / subject.run_time),   subject.test_rate
+      assert_equal (subject.result_count / subject.run_time), subject.result_rate
     end
 
-  end
+    should "not provide any test or result attrs" do
+      assert_nil subject.ordered_tests
+      assert_nil subject.reversed_ordered_tests
+      assert_nil subject.test_count
 
-  class WithTestsTests < UnitTests
-    desc "a suite with tests"
-    setup do
-      ci = Factory.context_info(Factory.modes_off_context_class)
-      @suite.tests = [
-        Factory.test("should nothing", ci){ },
-        Factory.test("should pass",    ci){ assert(1==1); refute(1==0) },
-        Factory.test("should fail",    ci){ ignore; assert(1==0); refute(1==1) },
-        Factory.test("should ignored", ci){ ignore },
-        Factory.test("should skip",    ci){ skip; ignore; assert(1==1) },
-        Factory.test("should error",   ci){ raise Exception; ignore; assert(1==1) }
-      ]
-      @suite.tests.each(&:run)
+      assert_nil subject.ordered_results
+      assert_nil subject.reversed_ordered_results
+      assert_nil subject.result_count
     end
 
-    should "build test instances to run" do
-      assert_kind_of Assert::Test, subject.tests.first
+    should "add setup procs" do
+      status = nil
+      @suite.setup{ status = "setups" }
+      @suite.startup{ status += " have been run" }
+
+      assert_equal 2, subject.setups.count
+      subject.setups.each(&:call)
+      assert_equal "setups have been run", status
     end
 
-    should "know how many tests it has" do
-      assert_equal 6, subject.test_count
-    end
+    should "add teardown procs" do
+      status = nil
+      @suite.teardown{ status = "teardowns" }
+      @suite.shutdown{ status += " have been run" }
 
-    should "know its ordered tests" do
-      assert_equal subject.tests, subject.ordered_tests
-    end
-
-    should "know its tests ordered by run time" do
-      exp = subject.ordered_tests.sort{ |a, b| a.run_time <=> b.run_time }
-      assert_equal exp, subject.ordered_tests_by_run_time
-    end
-
-    should "know how many results it has" do
-      assert_equal 8, subject.result_count
-    end
-
-    should "know its ordered results" do
-      assert_equal subject.results, subject.ordered_results
-    end
-
-    should "know how many pass results it has" do
-      assert_equal 2, subject.result_count(:pass)
-    end
-
-    should "know how many fail results it has" do
-      assert_equal 2, subject.result_count(:fail)
-    end
-
-    should "know how many ignore results it has" do
-      assert_equal 2, subject.result_count(:ignore)
-    end
-
-    should "know how many skip results it has" do
-      assert_equal 1, subject.result_count(:skip)
-    end
-
-    should "know how many error results it has" do
-      assert_equal 1, subject.result_count(:error)
-    end
-
-    should "count its tests" do
-      assert_equal subject.test_count, subject.count(:tests)
-    end
-
-    should "count its results" do
-      assert_equal subject.result_count, subject.count(:results)
-    end
-
-    should "count its passed results" do
-      assert_equal subject.result_count(:pass), subject.count(:passed)
-      assert_equal subject.result_count(:pass), subject.count(:pass)
-    end
-
-    should "count its failed results" do
-      assert_equal subject.result_count(:fail), subject.count(:failed)
-      assert_equal subject.result_count(:fail), subject.count(:fail)
-    end
-
-    should "count its ignored results" do
-      assert_equal subject.result_count(:ignore), subject.count(:ignored)
-      assert_equal subject.result_count(:ignore), subject.count(:ignore)
-    end
-
-    should "count its skipped results" do
-      assert_equal subject.result_count(:skip), subject.count(:skipped)
-      assert_equal subject.result_count(:skip), subject.count(:skip)
-    end
-
-    should "count its errored results" do
-      assert_equal subject.result_count(:error), subject.count(:errored)
-      assert_equal subject.result_count(:error), subject.count(:error)
-    end
-
-  end
-
-  class SetupTests < UnitTests
-    desc "a suite with a setup block"
-    setup do
-      @setup_status = nil
-      @setup_blocks = []
-      @setup_blocks << ::Proc.new{ @setup_status = "setup" }
-      @setup_blocks << ::Proc.new{ @setup_status += " has been run" }
-      @setup_blocks.each{ |setup_block| @suite.setup(&setup_block) }
-    end
-
-    should "set the setup status to the correct message" do
-      subject.setup
-      assert_equal "setup has been run", @setup_status
-    end
-
-    should "return the setup blocks with the #setups method" do
-      @setup_blocks.each do |setup_block|
-        assert_includes setup_block, subject.send(:setups)
-      end
-    end
-
-  end
-
-  class TeardownTests < UnitTests
-    desc "a suite with a teardown"
-    setup do
-      @teardown_status = nil
-      @teardown_blocks = []
-      @teardown_blocks << ::Proc.new{ @teardown_status += " has been run" }
-      @teardown_blocks << ::Proc.new{ @teardown_status = "teardown" }
-      @teardown_blocks.each{ |teardown_block| @suite.teardown(&teardown_block) }
-    end
-
-    should "set the teardown status to the correct message" do
-      subject.teardown
-      assert_equal "teardown has been run", @teardown_status
-    end
-
-    should "return the teardown blocks with the #teardowns method" do
-      @teardown_blocks.each do |setup_block|
-        assert_includes setup_block, subject.send(:teardowns)
-      end
-    end
-
-  end
-
-  class ContextInfoTests < UnitTests
-    desc "ContextInfo"
-    setup do
-      @caller = caller
-      @klass  = Assert::Context
-      @info   = Assert::Suite::ContextInfo.new(@klass, nil, @caller.first)
-    end
-    subject{ @info }
-
-    should have_readers :called_from, :klass, :file
-    should have_imeths :test_name
-
-    should "set its klass on init" do
-      assert_equal @klass, subject.klass
-    end
-
-    should "set its called_from to the called_from or first caller on init" do
-      info = Assert::Suite::ContextInfo.new(@klass, @caller.first, nil)
-      assert_equal @caller.first, info.called_from
-
-      info = Assert::Suite::ContextInfo.new(@klass, nil, @caller.first)
-      assert_equal @caller.first, info.called_from
-    end
-
-    should "set its file from caller info on init" do
-      assert_equal @caller.first.gsub(/\:[0-9]+.*$/, ''), subject.file
-    end
-
-    should "not have any file info if no caller is given" do
-      info = Assert::Suite::ContextInfo.new(@klass)
-      assert_nil info.file
-    end
-
-    should "know how to build the contextual test name for a given name" do
-      desc = Factory.string
-      name = Factory.string
-
-      assert_equal name, subject.test_name(name)
-      assert_equal '',   subject.test_name('')
-      assert_equal '',   subject.test_name(nil)
-
-      Assert.stub(subject.klass, :description){ desc }
-      assert_equal "#{desc} #{name}", subject.test_name(name)
+      assert_equal 2, subject.teardowns.count
+      subject.teardowns.each(&:call)
+      assert_equal "teardowns have been run", status
     end
 
   end


### PR DESCRIPTION
This reworks the suite object to make it more flexible to extend.
This follows the pattern of the view object where the base suite
provides the core logic/behavior and the default suite provides
the default assert behavior.  The goal here is to enable extending
the suite for use in AssertSqlite (and Parassert).

The suite is responsible for accumulating tests for the runner to
run and for providing the run data and test result data.  The default
suite stores run data and results in memory.

Note: this begins the work of formalizing the test/result data api.
In a coming effort, I'll rework the default view to fully use this
api and implement the full api in the default suite.

There are a few other smaller changes here:

* I broke out the context info class into its own top-level object.
  This is purely an organizational change as it has nothing to do
  with the suite object.
* I simplified how the setups/teardowns are added and accessed.  This
  removes the unecessary complexity of the previous implementation.
* I added a callback setup similar to that of the view.  The goal
  here is to allow custom suites to inject special behavior during
  test runs (much like the views can).  This is just to make suites
  as extendable as possible and provide the same flexibility as the
  views.

@jcredding ready for review.