### PR TITLE
update view to no longer use a base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ end
 However, the view handler you use is itself configurable.  Define you own view handler class and specify it in your user/local settings:
 
 ```ruby
-class MyCustomView < Assert::View::Base
+class MyCustomView < Assert::View
   # define your view here...
 end
 
@@ -467,7 +467,7 @@ end
 
 ### Anatomy of a View
 
-A view class handles the logic and templating of test result output.  A view class should inherit from `Assert::View::Base`.  This defines default callback handlers for the test runner and gives access to a bunch of common helpers for reading test result data.
+A view class handles the logic and templating of test result output.  A view class should inherit from `Assert::View`.  This defines default callback handlers for the test runner and gives access to a bunch of common helpers for reading test result data.
 
 Each view should implement the callback handler methods to output information at different points during the running of a test suite.  Callbacks have access to any view methods and should output information using `puts` and `prints`.  See the `DefaultView` template for a usage example.
 
@@ -534,7 +534,7 @@ Tests produce results as they are executed.  Every `assert` statement produces a
 
 ### View
 
-A `View` object is responsible for rendering test result output.  Assert provides a `Assert::View::Base` object to provide common helpers and default runner callback handlers for building views.  Assert also provides an `Assert::DefaultView` that it renders its output with.  See the "Viewing Test Results" section below for more details.
+A `View` object is responsible for rendering test result output.  Assert provides a `Assert::View` object to provide common helpers and default runner callback handlers for building views.  Assert also provides an `Assert::DefaultView` that it renders its output with.  See the "Viewing Test Results" section below for more details.
 
 ### Macro
 

--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -5,7 +5,7 @@ module Assert
   # This is the default view used by assert.  It renders ansi test output
   # designed for terminal viewing.
 
-  class DefaultView < Assert::View::Base
+  class DefaultView < Assert::View
 
     # setup options and their default values
 

--- a/lib/assert/view.rb
+++ b/lib/assert/view.rb
@@ -4,7 +4,8 @@ require 'assert/view_helpers'
 
 module Assert
 
-  module View
+  class View
+    include Assert::ViewHelpers
 
     # this method is used to bring in custom user-specific views
     # require views by passing either a full path to the view ruby file
@@ -26,81 +27,76 @@ module Assert
       end
     end
 
-    class Base
-      include Assert::ViewHelpers
+    # setup options and their default values
 
-      # setup options and their default values
+    option 'styled',        false
+    option 'pass_styles'    # none
+    option 'fail_styles'    # none
+    option 'error_styles'   # none
+    option 'skip_styles'    # none
+    option 'ignore_styles'  # none
 
-      option 'styled',        false
-      option 'pass_styles'    # none
-      option 'fail_styles'    # none
-      option 'error_styles'   # none
-      option 'skip_styles'    # none
-      option 'ignore_styles'  # none
+    option 'pass_abbrev',   '.'
+    option 'fail_abbrev',   'F'
+    option 'ignore_abbrev', 'I'
+    option 'skip_abbrev',   'S'
+    option 'error_abbrev',  'E'
 
-      option 'pass_abbrev',   '.'
-      option 'fail_abbrev',   'F'
-      option 'ignore_abbrev', 'I'
-      option 'skip_abbrev',   'S'
-      option 'error_abbrev',  'E'
+    attr_reader :config
 
-      attr_reader :config
-
-      def initialize(config, output_io)
-        @config , @output_io, = config, output_io
-        @output_io.sync = true if @output_io.respond_to?(:sync=)
-      end
-
-      def view
-        self
-      end
-
-      def is_tty?
-        !!@output_io.isatty
-      end
-
-      def ansi_styled_msg(msg, result_or_sym)
-        return msg if !self.is_tty? || !self.styled
-        code = Assert::ViewHelpers::Ansi.code_for(*self.send("#{result_or_sym.to_sym}_styles"))
-        return msg if code.empty?
-        code + msg + Assert::ViewHelpers::Ansi.code_for(:reset)
-      end
-
-      # Callbacks
-
-      # define callback handlers to output information.  These will be called
-      # by the test runner.
-
-      # available callbacks from the runner:
-      # * `before_load`:  called at the beginning, before the suite is loaded
-      # * `after_load`:   called after the suite is loaded, just before `on_start`
-      #                   functionally equivalent to `on_start`
-      # * `on_start`:     called when a loaded test suite starts running
-      # * `before_test`:  called before a test starts running
-      #                   the test is passed as an arg
-      # * `on_result`:    called when a running tests generates a result
-      #                   the result is passed as an arg
-      # * `after_test`:   called after a test finishes running
-      #                   the test is passed as an arg
-      # * `on_finish`:    called when the test suite is finished running
-      # * `on_interrupt`: called when the test suite is interrupted while running
-      #                   the interrupt exception is passed as an arg
-
-      def before_load(test_files); end
-      def after_load;              end
-      def on_start;                end
-      def before_test(test);       end
-      def on_result(result);       end
-      def after_test(test);        end
-      def on_finish;               end
-      def on_interrupt(err);       end
-
-      # IO capture
-
-      def puts(*args); @output_io.puts(*args); end
-      def print(*args); @output_io.print(*args); end
-
+    def initialize(config, output_io)
+      @config , @output_io, = config, output_io
+      @output_io.sync = true if @output_io.respond_to?(:sync=)
     end
+
+    def view
+      self
+    end
+
+    def is_tty?
+      !!@output_io.isatty
+    end
+
+    def ansi_styled_msg(msg, result_or_sym)
+      return msg if !self.is_tty? || !self.styled
+      code = Assert::ViewHelpers::Ansi.code_for(*self.send("#{result_or_sym.to_sym}_styles"))
+      return msg if code.empty?
+      code + msg + Assert::ViewHelpers::Ansi.code_for(:reset)
+    end
+
+    # Callbacks
+
+    # define callback handlers to output information.  These will be called
+    # by the test runner.
+
+    # available callbacks from the runner:
+    # * `before_load`:  called at the beginning, before the suite is loaded
+    # * `after_load`:   called after the suite is loaded, just before `on_start`
+    #                   functionally equivalent to `on_start`
+    # * `on_start`:     called when a loaded test suite starts running
+    # * `before_test`:  called before a test starts running
+    #                   the test is passed as an arg
+    # * `on_result`:    called when a running tests generates a result
+    #                   the result is passed as an arg
+    # * `after_test`:   called after a test finishes running
+    #                   the test is passed as an arg
+    # * `on_finish`:    called when the test suite is finished running
+    # * `on_interrupt`: called when the test suite is interrupted while running
+    #                   the interrupt exception is passed as an arg
+
+    def before_load(test_files); end
+    def after_load;              end
+    def on_start;                end
+    def before_test(test);       end
+    def on_result(result);       end
+    def after_test(test);        end
+    def on_finish;               end
+    def on_interrupt(err);       end
+
+    # IO capture
+
+    def puts(*args); @output_io.puts(*args); end
+    def print(*args); @output_io.print(*args); end
 
   end
 

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -23,7 +23,7 @@ class Assert::Runner
     setup do
       @config = Factory.modes_off_config
       @config.suite Assert::DefaultSuite.new(@config)
-      @config.view  Assert::View::Base.new(@config, StringIO.new("", "w+"))
+      @config.view  Assert::View.new(@config, StringIO.new("", "w+"))
 
       @runner = Assert::Runner.new(@config)
     end

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -5,7 +5,7 @@ require 'stringio'
 require 'assert/suite'
 require 'assert/view_helpers'
 
-module Assert::View
+class Assert::View
 
   class UnitTests < Assert::Context
     desc "Assert::View"
@@ -13,15 +13,19 @@ module Assert::View
 
     should have_instance_method :require_user_view
 
+    should "include the view helpers" do
+      assert_includes Assert::ViewHelpers, subject
+    end
+
   end
 
-  class BaseTests < UnitTests
-    desc "Base"
+  class InitTests < UnitTests
+    desc "when init"
     setup do
       @io     = StringIO.new("", "w+")
       @config = Factory.modes_off_config
 
-      @view = Assert::View::Base.new(@config, @io)
+      @view = Assert::View.new(@config, @io)
     end
     subject{ @view }
 
@@ -30,10 +34,6 @@ module Assert::View
     should have_imeths :before_load, :after_load
     should have_imeths :on_start, :on_finish, :on_interrupt
     should have_imeths :before_test, :after_test, :on_result
-
-    should "include the view helpers" do
-      assert_includes Assert::ViewHelpers, subject.class
-    end
 
     should "default its style options" do
       assert_false subject.styled


### PR DESCRIPTION
This is a purely organizational change.  The goal here is to make
the view implementation more closely match the new suite implementation
and to remove some legacy ceremony/complexity with view handling.

The diff is rugged b/c there was a tab indention change - there are
no behavior changes here.

@jcredding ready for review.