### PR TITLE
update view to get all test/result data from the suite

### DIFF
--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -34,7 +34,7 @@ module Assert
 
       # load the test files
       self.config.view.before_load(test_files)
-      Assert::CLI.bench("Require #{test_files.count} test files") do
+      Assert::CLI.bench("Require #{test_files.size} test files") do
         test_files.each{ |p| require p }
       end
       if self.config.debug

--- a/lib/assert/config_helpers.rb
+++ b/lib/assert/config_helpers.rb
@@ -33,28 +33,6 @@ module Assert
       format % self.config.suite.result_rate
     end
 
-    # get a uniq list of contexts for the test suite
-    def suite_contexts
-      @suite_contexts ||= self.config.suite.tests.inject([]) do |contexts, test|
-        contexts << test.context_info.klass
-      end.uniq
-    end
-
-    def ordered_suite_contexts
-      self.suite_contexts.sort{ |a,b| a.to_s <=> b.to_s }
-    end
-
-    # get a uniq list of files containing contexts for the test suite
-    def suite_files
-      @suite_files ||= self.config.suite.tests.inject([]) do |files, test|
-        files << test.context_info.file
-      end.uniq
-    end
-
-    def ordered_suite_files
-      self.suite_files.sort{ |a,b| a.to_s <=> b.to_s }
-    end
-
     def show_test_profile_info?
       !!self.config.profile
     end

--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -117,13 +117,13 @@ module Assert
     # alter the backtraces of fail results generated in the given block
     def with_backtrace(bt, &block)
       bt ||= []
-      current_results.count.tap do |count|
+      current_results.size.tap do |size|
         begin
           instance_eval(&block)
         rescue Result::TestSkipped, Result::TestFailure => e
           e.set_backtrace(bt); raise(e)
         ensure
-          current_results[count..-1].each{ |r| r.set_backtrace(bt) }
+          current_results[size..-1].each{ |r| r.set_backtrace(bt) }
         end
       end
     end

--- a/lib/assert/default_suite.rb
+++ b/lib/assert/default_suite.rb
@@ -6,29 +6,58 @@ module Assert
 
   class DefaultSuite < Assert::Suite
 
-    # Test Handling
+    # Test data
 
     def ordered_tests
       self.tests
+    end
+
+    def reversed_tests
+      self.tests.reverse
     end
 
     def ordered_tests_by_run_time
       self.ordered_tests.sort{ |a, b| a.run_time <=> b.run_time }
     end
 
-    def test_count
-      self.tests.count
+    def reversed_tests_by_run_time
+      self.ordered_tests_by_run_time.reverse
     end
 
-    # Result Handling
+    def test_count
+      self.tests.size
+    end
+
+    # Result data
 
     def ordered_results
       self.ordered_tests.inject([]){ |results, test| results += test.results }
     end
 
+    def reversed_results
+      self.ordered_results.reverse
+    end
+
+    # dump failed or errored results,
+    # dump skipped or ignored results if they have a message
+    def ordered_results_for_dump
+      self.ordered_results.select do |result|
+        [:fail, :error].include?(result.to_sym) ||
+        !!([:skip, :ignore].include?(result.to_sym) && result.message)
+      end
+    end
+
+    def reversed_results_for_dump
+      self.ordered_results_for_dump.reverse
+    end
+
     def result_count(type = nil)
       self.tests.inject(0){ |count, test| count += test.result_count(type) }
     end
+
+    # Callbacks
+
+    # no custom callbacks
 
   end
 

--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -82,22 +82,17 @@ module Assert
       print "\n"
       puts
 
-      # output detailed results for the tests in reverse test/result order
-      tests = config.suite.ordered_tests.reverse
-      result_details_for(tests, :reversed).each do |details|
-        if show_result_details?(details.result)
-          # output the styled result details
-          result = details.result
-          puts ansi_styled_msg(result.to_s, result)
+      config.suite.reversed_results_for_dump.each do |result|
+        # output the styled result details
+        puts ansi_styled_msg(result.to_s, result)
 
-          # output any captured stdout
-          output = details.output
-          puts captured_output(output) if output && !output.empty?
+        # output any captured stdout
+        puts captured_output(result.output) if result.output && !result.output.empty?
 
-          # add an empty line between each result detail
-          puts
-        end
+        # add an empty line between each result detail
+        puts
       end
+
     end
 
   end

--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -32,6 +32,7 @@ module Assert::Result
       self.new({
         :test_name => test.name,
         :message   => message,
+        :output    => test.output,
         :backtrace => Backtrace.new(bt)
       })
     end
@@ -44,6 +45,7 @@ module Assert::Result
     def name;      @name      ||= (@build_data[:name]      || self.class.name.to_s);        end
     def test_name; @test_name ||= (@build_data[:test_name] || '');                          end
     def message;   @message   ||= (@build_data[:message]   || '');                          end
+    def output;    @output    ||= (@build_data[:output]    || '');                          end
     def backtrace; @backtrace ||= (@build_data[:backtrace] || Backtrace.new([]));           end
     def trace;     @trace     ||= (@build_data[:trace]     || build_trace(self.backtrace)); end
 
@@ -63,6 +65,7 @@ module Assert::Result
         :name      => self.name,
         :test_name => self.test_name,
         :message   => self.message,
+        :output    => self.output,
         :backtrace => self.backtrace,
         :trace     => self.trace,
       }

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -66,19 +66,21 @@ module Assert
       end
     end
 
-    # Test Handling
+    # Test data
 
-    def ordered_tests;                      end
-    def reversed_ordered_tests;             end
-    def ordered_tests_by_run_time;          end
-    def reversed_ordered_tests_by_run_time; end
-    def test_count;                         end
+    def ordered_tests;              end
+    def reversed_tests;             end
+    def ordered_tests_by_run_time;  end
+    def reversed_tests_by_run_time; end
+    def test_count;                 end
 
-    # Result Handling
+    # Result data
 
-    def ordered_results;          end
-    def reversed_ordered_results; end
-    def result_count(type = nil); end
+    def ordered_results;           end
+    def reversed_results;          end
+    def ordered_results_for_dump;  end
+    def reversed_results_for_dump; end
+    def result_count(type = nil);  end
 
     # Callbacks
 

--- a/lib/assert/view_helpers.rb
+++ b/lib/assert/view_helpers.rb
@@ -38,43 +38,6 @@ module Assert
         format % test.result_rate
       end
 
-      # get all the result details for a set of tests
-      def result_details_for(tests, result_order = :normal)
-        test_index = 0
-        tests.collect do |test|
-          test_index += 1
-
-          details = test.results.collect do |result|
-            ResultDetails.new(result, test, test_index)
-          end
-          details.reverse! if result_order == :reversed
-          details
-        end.compact.flatten
-      end
-
-      # get all the result details for a set of tests matching a file or context
-      def matched_result_details_for(match, tests, result_order = :normal)
-        context_match = match.kind_of?(Class) && match.ancestors.include?(Assert::Context)
-        file_match = match.kind_of?(String)
-
-        matching_tests = if context_match
-          tests.select {|test| test.context_info.klass == match}
-        elsif file_match
-          tests.select {|test| test.context_info.file == match}
-        else
-          tests
-        end
-
-        result_details_for(matching_tests, result_order)
-      end
-
-      # only show result details for failed or errored results
-      # show result details if a skip or passed result was issues w/ a message
-      def show_result_details?(result)
-        [:fail, :error].include?(result.to_sym) ||
-        !!([:skip, :ignore].include?(result.to_sym) && result.message)
-      end
-
       # show any captured output
       def captured_output(output)
         "--- stdout ---\n"\
@@ -216,19 +179,6 @@ module Assert
 
       def self.code_for(*style_names)
         style_names.map{ |n| "\e[#{CODES[n]}m" if CODES.key?(n) }.compact.join('')
-      end
-
-    end
-
-    class ResultDetails
-
-      attr_reader :result, :test_index, :test, :output
-
-      def initialize(result, test, test_index)
-        @result     = result
-        @test       = test
-        @test_index = test_index
-        @output     = test.output
       end
 
     end

--- a/test/unit/config_helpers_tests.rb
+++ b/test/unit/config_helpers_tests.rb
@@ -23,8 +23,6 @@ module Assert::ConfigHelpers
 
     should have_imeths :runner_seed, :count, :tests?, :all_pass?
     should have_imeths :run_time, :test_rate, :result_rate
-    should have_imeths :suite_contexts, :ordered_suite_contexts
-    should have_imeths :suite_files, :ordered_suite_files
     should have_imeths :show_test_profile_info?, :show_test_verbose_info?
     should have_imeths :ocurring_result_types
 
@@ -53,26 +51,6 @@ module Assert::ConfigHelpers
 
       exp = format % subject.config.suite.result_rate
       assert_equal exp, subject.result_rate(format)
-    end
-
-    should "know its suite contexts and ordered suite contexts" do
-      exp = subject.config.suite.tests.inject([]) do |contexts, test|
-        contexts << test.context_info.klass
-      end.uniq
-      assert_equal exp, subject.suite_contexts
-
-      exp = subject.suite_contexts.sort{ |a,b| a.to_s <=> b.to_s }
-      assert_equal exp, subject.ordered_suite_contexts
-    end
-
-    should "know its suite files and ordered suite files" do
-      exp = subject.config.suite.tests.inject([]) do |files, test|
-        files << test.context_info.file
-      end.uniq
-      assert_equal exp, subject.suite_files
-
-      exp = subject.suite_files.sort{ |a,b| a.to_s <=> b.to_s }
-      assert_equal exp, subject.ordered_suite_files
     end
 
     should "know whether to show test profile info" do

--- a/test/unit/context/suite_dsl_tests.rb
+++ b/test/unit/context/suite_dsl_tests.rb
@@ -32,7 +32,7 @@ module Assert::Context::SuiteDSL
       @context_class = Factory.context_class(@parent_class)
     end
 
-    should "default to it's parents subject block" do
+    should "default to it's parent's suite" do
       assert_equal @custom_suite, subject.suite
     end
 

--- a/test/unit/default_suite_tests.rb
+++ b/test/unit/default_suite_tests.rb
@@ -28,11 +28,11 @@ class Assert::DefaultSuite
     end
 
     should "know its test and result attrs" do
-      assert_equal 6, subject.tests.count
+      assert_equal 6, subject.tests.size
       assert_kind_of Assert::Test, subject.tests.first
 
-      assert_equal subject.tests.count, subject.test_count
-      assert_equal subject.tests,       subject.ordered_tests
+      assert_equal subject.tests.size, subject.test_count
+      assert_equal subject.tests,      subject.ordered_tests
 
       exp = subject.ordered_tests.sort{ |a, b| a.run_time <=> b.run_time }
       assert_equal exp, subject.ordered_tests_by_run_time

--- a/test/unit/result_tests.rb
+++ b/test/unit/result_tests.rb
@@ -42,6 +42,7 @@ module Assert::Result
         :name      => Factory.string,
         :test_name => Factory.string,
         :message   => Factory.string,
+        :output    => Factory.text,
         :backtrace => Backtrace.new(caller),
         :trace     => Factory.string
       }
@@ -50,7 +51,7 @@ module Assert::Result
     subject{ @result }
 
     should have_cmeths :type, :name, :for_test
-    should have_imeths :type, :name, :test_name, :message, :backtrace, :trace
+    should have_imeths :type, :name, :test_name, :message, :output, :backtrace, :trace
     should have_imeths *Assert::Result.types.keys.map{ |k| "#{k}?" }
     should have_imeths :set_backtrace, :data, :to_sym, :to_s
 
@@ -78,6 +79,7 @@ module Assert::Result
       assert_equal @given_data[:name],        subject.name
       assert_equal @given_data[:test_name],   subject.test_name
       assert_equal @given_data[:message],     subject.message
+      assert_equal @given_data[:output],      subject.output
       assert_equal @given_data[:backtrace],   subject.backtrace
       assert_equal @given_data[:trace],       subject.trace
     end
@@ -89,6 +91,7 @@ module Assert::Result
       assert_equal '',                result.name
       assert_equal '',                result.test_name
       assert_equal '',                result.message
+      assert_equal '',                result.output
       assert_equal Backtrace.new([]), result.backtrace
       assert_equal '',                result.trace
     end
@@ -118,6 +121,7 @@ module Assert::Result
         :name      => subject.name,
         :test_name => subject.test_name,
         :message   => subject.message,
+        :output    => subject.output,
         :backtrace => subject.backtrace,
         :trace     => subject.trace,
       }

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -34,8 +34,12 @@ class Assert::Suite
     should have_accessors :start_time, :end_time
     should have_imeths :setup, :startup, :teardown, :shutdown
     should have_imeths :run_time, :test_rate, :result_rate, :count
-    should have_imeths :ordered_tests, :reversed_ordered_tests, :test_count
-    should have_imeths :ordered_results, :reversed_ordered_results, :result_count
+    should have_imeths :ordered_tests, :reversed_tests
+    should have_imeths :ordered_tests_by_run_time, :reversed_tests_by_run_time
+    should have_imeths :test_count
+    should have_imeths :ordered_results, :reversed_results
+    should have_imeths :ordered_results_for_dump, :reversed_results_for_dump
+    should have_imeths :result_count
     should have_imeths :before_load, :after_load
     should have_imeths :on_start, :on_finish, :on_interrupt
     should have_imeths :before_test, :after_test, :on_result
@@ -71,11 +75,15 @@ class Assert::Suite
 
     should "not provide any test or result attrs" do
       assert_nil subject.ordered_tests
-      assert_nil subject.reversed_ordered_tests
+      assert_nil subject.reversed_tests
+      assert_nil subject.ordered_tests_by_run_time
+      assert_nil subject.reversed_tests_by_run_time
       assert_nil subject.test_count
 
       assert_nil subject.ordered_results
-      assert_nil subject.reversed_ordered_results
+      assert_nil subject.reversed_results
+      assert_nil subject.ordered_results_for_dump
+      assert_nil subject.reversed_results_for_dump
       assert_nil subject.result_count
     end
 

--- a/test/unit/view_helpers_tests.rb
+++ b/test/unit/view_helpers_tests.rb
@@ -54,8 +54,7 @@ module Assert::ViewHelpers
     subject{ @helpers }
 
     should have_imeths :test_run_time, :test_result_rate
-    should have_imeths :result_details_for, :matched_result_details_for
-    should have_imeths :show_result_details?, :captured_output
+    should have_imeths :captured_output
     should have_imeths :test_count_statement, :result_count_statement
     should have_imeths :to_sentence
     should have_imeths :all_pass_result_summary_msg, :result_summary_msg
@@ -72,25 +71,6 @@ module Assert::ViewHelpers
       exp = format % test.result_rate
       assert_equal exp, subject.test_result_rate(test, format)
       assert_equal exp, subject.test_result_rate(test)
-    end
-
-    # note: not formally testing the result details for methods as the views
-    # will break if these are broken.
-
-    should "know whether to show result details" do
-      assert_false subject.show_result_details?(Factory.pass_result)
-
-      assert_true subject.show_result_details?(Factory.fail_result)
-      assert_true subject.show_result_details?(Factory.error_result)
-
-      skip_res, ignore_res = Factory.skip_result, Factory.ignore_result
-      assert_true subject.show_result_details?(skip_res)
-      assert_true subject.show_result_details?(ignore_res)
-
-      Assert.stub(skip_res,   :message){ nil}
-      Assert.stub(ignore_res, :message){ nil}
-      assert_false subject.show_result_details?(skip_res)
-      assert_false subject.show_result_details?(ignore_res)
     end
 
     should "know how to build captured output" do
@@ -181,28 +161,6 @@ module Assert::ViewHelpers
 
       styles = []
       assert_equal '', subject.code_for(*styles)
-    end
-
-  end
-
-  class ResultDetailsTests < UnitTests
-    desc "ResultDetails"
-    setup do
-      @result = Factory.string
-      @test   = Factory.test
-      @index  = Factory.integer
-
-      @details = ResultDetails.new(@result, @test, @index)
-    end
-    subject{ @details }
-
-    should have_readers :result, :test_index, :test, :output
-
-    should "know its attrs" do
-      assert_equal @result,      subject.result
-      assert_equal @test,        subject.test
-      assert_equal @index,       subject.test_index
-      assert_equal @test.output, subject.output
     end
 
   end


### PR DESCRIPTION
Before the view gathered its data partially from the suite and
partially processed it on its own.  This would break if the suite
implements custom ways of storing and making data available.

This reworks the views and view helpers to get all data from the
suite and updates the default suite to implement all suite behavior
by storing data in memory and processing it in memory.

This is prep for assert-sqlite where its suite will not store data
in memory but will instead store it in the db and query the db for
data processing.

There are a few other tweaks I've added here:

* added `output` to the result api and handling - it is needed by
  the views and should have been added originally
* switched from array `count` to array `size` - supposedly it is
  faster: https://github.com/JuanitoFatas/fast-ruby#arraylength-vs-arraysize-vs-arraycount-code
* removed a bunch of view helpers that are seemingly not used.  They
  may have been for kellyredding/assert-view-leftright and
  kellyredding/assert-view-testunit - both of which are deprecated.
* shortened the "reverse_*" api methods for less typing

@jcredding ready for review.