### PR TITLE
add DefaultRunner

### DIFF
--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -33,7 +33,10 @@ module Assert
       end
 
       # load the test files
-      self.config.view.before_load(test_files)
+      runner, suite, view = self.config.runner, self.config.suite, self.config.view
+      runner.before_load(test_files)
+      suite.before_load(test_files)
+      view.before_load(test_files)
       Assert::CLI.bench("Require #{test_files.size} test files") do
         test_files.each{ |p| require p }
       end
@@ -41,7 +44,9 @@ module Assert
         puts Assert::CLI.debug_msg("Test files:")
         test_files.each{ |f| puts Assert::CLI.debug_msg("  #{f}") }
       end
-      self.config.view.after_load
+      runner.after_load
+      suite.after_load
+      view.after_load
     end
 
     def run

--- a/lib/assert/config.rb
+++ b/lib/assert/config.rb
@@ -1,6 +1,6 @@
+require 'assert/default_runner'
 require 'assert/default_suite'
 require 'assert/default_view'
-require 'assert/runner'
 require 'assert/utils'
 
 module Assert
@@ -25,9 +25,9 @@ module Assert
     settings :capture_output, :halt_on_fail, :profile, :verbose, :list, :debug
 
     def initialize(settings = nil)
-      @suite  = Assert::DefaultSuite.new(self)
       @view   = Assert::DefaultView.new(self, $stdout)
-      @runner = Assert::Runner.new(self)
+      @suite  = Assert::DefaultSuite.new(self)
+      @runner = Assert::DefaultRunner.new(self)
 
       @test_dir    = "test"
       @test_helper = "helper.rb"

--- a/lib/assert/default_runner.rb
+++ b/lib/assert/default_runner.rb
@@ -1,0 +1,23 @@
+require 'assert/runner'
+
+module Assert
+
+  # This is the default runner used by assert.  It runs the tests one at a time
+  # in random order
+
+  class DefaultRunner < Assert::Runner
+
+    def on_start
+      if self.tests?
+        self.view.puts "Running tests in random order, seeded with \"#{self.runner_seed}\""
+      end
+    end
+
+    def run!(&block)
+      srand self.runner_seed
+      self.suite.tests.sort.sort_by{ rand self.suite.tests.size }.each(&block)
+    end
+
+  end
+
+end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -14,7 +14,7 @@ class Assert::Config
     end
     subject{ @config }
 
-    should have_imeths :suite, :view, :runner
+    should have_imeths :view, :suite, :runner
     should have_imeths :test_dir, :test_helper, :test_file_suffixes
     should have_imeths :changed_proc, :pp_proc, :use_diff_proc, :run_diff_proc
     should have_imeths :runner_seed, :changed_only, :changed_ref, :pp_objects
@@ -22,9 +22,9 @@ class Assert::Config
     should have_imeths :debug, :apply
 
     should "default the view, suite, and runner" do
-      assert_kind_of Assert::DefaultView,  subject.view
-      assert_kind_of Assert::DefaultSuite, subject.suite
-      assert_kind_of Assert::Runner,       subject.runner
+      assert_kind_of Assert::DefaultView,   subject.view
+      assert_kind_of Assert::DefaultSuite,  subject.suite
+      assert_kind_of Assert::DefaultRunner, subject.runner
     end
 
     should "default the test dir/helper/suffixes" do

--- a/test/unit/default_runner_tests.rb
+++ b/test/unit/default_runner_tests.rb
@@ -1,0 +1,36 @@
+require 'assert'
+require 'assert/default_runner'
+
+require 'assert/runner'
+
+class Assert::DefaultRunner
+
+  class UnitTests < Assert::Context
+    desc "Assert::DefaultRunner"
+    setup do
+      @config = Factory.modes_off_config
+      @runner = Assert::DefaultRunner.new(@config)
+    end
+    subject{ @runner }
+
+    should have_imeths :on_start, :run!
+
+    should "descibe the run on start" do
+      output = ""
+      view   = Assert::View.new(@config, StringIO.new(output, "w+"))
+      Assert.stub(subject, :view){ view }
+
+      subject.on_start
+      assert_empty output
+
+      ci = Factory.context_info(Factory.modes_off_context_class)
+      @config.suite.tests << Factory.test("should pass", ci){ assert(1==1) }
+      subject.on_start
+
+      exp = "Running tests in random order, seeded with \"#{subject.runner_seed}\"\n"
+      assert_equal exp, output
+    end
+
+  end
+
+end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -3,7 +3,8 @@ require 'assert/runner'
 
 require 'stringio'
 require 'assert/config_helpers'
-require 'assert/suite'
+require 'assert/default_suite'
+require 'assert/result'
 require 'assert/view'
 
 class Assert::Runner
@@ -29,17 +30,93 @@ class Assert::Runner
     end
     subject { @runner }
 
-    should have_readers :config
-    should have_imeths :run
+    should have_readers :config, :suite, :view
+    should have_imeths :run, :run!
+    should have_imeths :before_load, :after_load
+    should have_imeths :on_start, :on_finish, :on_interrupt
+    should have_imeths :before_test, :after_test, :on_result
 
     should "know its config" do
       assert_equal @config, subject.config
     end
 
-    should "return an integer exit code" do
-      assert_equal 0, subject.run
+    should "not have set its suite and view" do
+      assert_nil subject.suite
+      assert_nil subject.view
     end
 
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      callback_mixin = Module.new
+      runner_class = Class.new(Assert::Runner) do
+        include CallbackMixin
+
+        def run!(&block)
+          self.suite.tests.each(&block)
+        end
+      end
+      suite_class  = Class.new(Assert::DefaultSuite){ include CallbackMixin }
+      view_class   = Class.new(Assert::View){ include CallbackMixin }
+
+      @config.suite suite_class.new(@config)
+      @config.view  view_class.new(@config, StringIO.new("", "w+"))
+
+      ci = Factory.context_info(Factory.modes_off_context_class)
+      @test = Factory.test("should pass", ci){ assert(1==1) }
+      @config.suite.tests << @test
+
+      @runner = runner_class.new(@config)
+      @result = @runner.run
+    end
+
+    should "return an integer exit code" do
+      assert_equal 0, @result
+    end
+
+    should "have set its suite and view" do
+      assert_equal @config.suite, subject.suite
+      assert_equal @config.view,  subject.view
+    end
+
+    should "run all callback on itself, the suite and the view" do
+      # itself
+      assert_true subject.on_start_called
+      assert_equal @test, subject.before_test_called
+      assert_instance_of Assert::Result::Pass, subject.on_result_called
+      assert_equal @test, subject.after_test_called
+      assert_true subject.on_finish_called
+
+      # suite
+      suite = @config.suite
+      assert_true suite.on_start_called
+      assert_equal @test, suite.before_test_called
+      assert_instance_of Assert::Result::Pass, suite.on_result_called
+      assert_equal @test, suite.after_test_called
+      assert_true suite.on_finish_called
+
+      # view
+      view = @config.view
+      assert_true view.on_start_called
+      assert_equal @test, view.before_test_called
+      assert_instance_of Assert::Result::Pass, view.on_result_called
+      assert_equal @test, view.after_test_called
+      assert_true view.on_finish_called
+    end
+
+  end
+
+  module CallbackMixin
+    attr_reader :on_start_called, :on_finish_called
+    attr_reader :before_test_called, :after_test_called, :on_result_called
+
+    def on_start;          @on_start_called     = true;   end
+    def before_test(test); @before_test_called  = test;   end
+    def on_result(result); @on_result_called    = result; end
+    def after_test(test);  @after_test_called   = test;   end
+    def on_finish;         @on_finish_called    = true;   end
   end
 
 end


### PR DESCRIPTION
This updates the runner logic so that it can be intentionally
subclassed with extra behavior, much like the suite and view.  This
also adds a default runner implementation.  This is prep work for
doing Parassert - it will define a custom runner that will run
tests in parallel.

The base runner has all the structured run procedures and handling.
Custom runners must define a `run!` method which should yield tests
to run to the given block.  They can also define callbacks for extra
custom behavior.

This also updates the runner to call all of its own callbacks and
all of the suite's callbacks in addition to the view callbacks. This
fully implements the callback system between all of the objects.

@jcredding ready for review.