### PR TITLE
Ruby changed Array#choice to Array#sample

### DIFF
--- a/test/unit/config_helpers_tests.rb
+++ b/test/unit/config_helpers_tests.rb
@@ -14,7 +14,7 @@ module Assert::ConfigHelpers
         def config
           # use the assert config since it has tests, contexts, etc
           # also maybe use a fresh config that is empty
-          @config ||= [Assert.config, Assert::Config.new].choice
+          @config ||= [Assert.config, Assert::Config.new].sample
         end
       end
       @helpers = @helpers_class.new
@@ -31,7 +31,7 @@ module Assert::ConfigHelpers
     end
 
     should "know how to count things on the suite" do
-      thing = [:pass, :fail, :results, :tests].choice
+      thing = [:pass, :fail, :results, :tests].sample
       assert_equal subject.config.suite.count(thing), subject.count(thing)
     end
 

--- a/test/unit/result_tests.rb
+++ b/test/unit/result_tests.rb
@@ -26,7 +26,7 @@ module Assert::Result
     end
 
     should "create results from data hashes" do
-      type   = Assert::Result.types.keys.choice
+      type   = Assert::Result.types.keys.sample
       exp    = Assert::Result.types[type].new(:type => type)
 
       assert_equal exp, Assert::Result.new(:type => type)
@@ -152,7 +152,7 @@ module Assert::Result
       other = Assert::Result::Base.new(@given_data)
       assert_equal other, subject
 
-      Assert.stub(other, [:type, :message].choice){ Factory.string }
+      Assert.stub(other, [:type, :message].sample){ Factory.string }
       assert_not_equal other, subject
     end
 

--- a/test/unit/view_helpers_tests.rb
+++ b/test/unit/view_helpers_tests.rb
@@ -19,7 +19,7 @@ module Assert::ViewHelpers
         def config
           # use the assert config since it has tests, contexts, etc
           # also maybe use a fresh config that is empty
-          @config ||= [Assert.config, Assert::Config.new].choice
+          @config ||= [Assert.config, Assert::Config.new].sample
         end
       end
     end
@@ -119,7 +119,7 @@ module Assert::ViewHelpers
       assert_equal exp, subject.result_summary_msg(res_type)
 
       Assert.stub(subject, :all_pass?){ false }
-      res_type = [:pass, :ignore, :fail, :skip, :error].choice
+      res_type = [:pass, :ignore, :fail, :skip, :error].sample
       exp = "#{subject.count(res_type)} #{res_type.to_s}"
       assert_equal exp, subject.result_summary_msg(res_type)
     end
@@ -152,7 +152,7 @@ module Assert::ViewHelpers
     end
 
     should "map its code style names to ansi code strings" do
-      styles = Factory.integer(3).times.map{ subject::CODES.keys.choice }
+      styles = Factory.integer(3).times.map{ subject::CODES.keys.sample }
       exp = styles.map{ |n| "\e[#{subject::CODES[n]}m" }.join('')
       assert_equal exp, subject.code_for(*styles)
 

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -67,7 +67,7 @@ class Assert::View
 
     should "know how to build ansi styled messages" do
       msg = Factory.string
-      result = [:pass, :fail, :error, :skip, :ignore].choice
+      result = [:pass, :fail, :error, :skip, :ignore].sample
 
       Assert.stub(subject, :is_tty?){ false }
       Assert.stub(subject, :styled){ false }
@@ -86,7 +86,7 @@ class Assert::View
       Assert.stub(subject, "#{result}_styles"){ [] }
       assert_equal msg, subject.ansi_styled_msg(msg, result)
 
-      styles = Factory.integer(3).times.map{ Assert::ViewHelpers::Ansi::CODES.keys.choice }
+      styles = Factory.integer(3).times.map{ Assert::ViewHelpers::Ansi::CODES.keys.sample }
       Assert.stub(subject, "#{result}_styles"){ styles }
       exp_code = Assert::ViewHelpers::Ansi.code_for(*styles)
       exp = exp_code + msg + Assert::ViewHelpers::Ansi.code_for(:reset)


### PR DESCRIPTION
Looks like Matz renamed this in ruby commit 9295fd4b5, almost exactly 8 years ago.
Running assert on itself, with a current ruby (tested with 2.2.3p147), shows 16 errors
resulting from the lack of a 'choice' method on Array.