### PR TITLE
backfill Array#sample so tests pass in ruby 1.8.7

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,3 +8,12 @@ $LOAD_PATH.unshift(ROOT_PATH)
 # require pry for debugging (`binding.pry`)
 require 'pry'
 require 'test/support/factory'
+
+# 1.8.7 backfills
+
+# Array#sample
+if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
+  class Array
+    alias_method :sample, :choice
+  end
+end


### PR DESCRIPTION
The test suite was updated to use `Array#sample` instead of
`Array#choice` in 239 so that the test suite would pass in modern
ruby versions.  However, I would prefer that the test suite continues
to pass in ruby 1.8.7 as well.

This backfills the `sample` method so that tests will pass in 1.8.7.

See #239 for reference.

@jcredding ready for review.  You good with this backfill implementation?