### PR TITLE
include one-time suite setups/teardowns in total test run time

### DIFF
--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -21,8 +21,8 @@ module Assert
       self.view.on_start
 
       begin
-        self.suite.setups.each(&:call)
         self.suite.start_time = Time.now
+        self.suite.setups.each(&:call)
         self.run! do |test|
           self.before_test(test)
           self.suite.before_test(test)
@@ -36,8 +36,8 @@ module Assert
           self.suite.after_test(test)
           self.view.after_test(test)
         end
-        self.suite.end_time = Time.now
         self.suite.teardowns.each(&:call)
+        self.suite.end_time = Time.now
       rescue Interrupt => err
         self.on_interrupt(err)
         self.suite.on_interrupt(err)


### PR DESCRIPTION
Not including it has been around since the beginning (see e4a019a).
I don't see a good reason to not include it though.  We include
the setup/teardown of each test.  Plus not including it makes the
reported test suite run times shorter than the actual perceived
run time.

I say let's include the in the total run time so it is more honest
and better matches perceived run times.

@jcredding ready for review.  You OK with this man?  Any concerns I'm missing in changing this?