### PR TITLE
formalize the runner, suite and view in the config helpers

### DIFF
--- a/lib/assert/config_helpers.rb
+++ b/lib/assert/config_helpers.rb
@@ -2,6 +2,10 @@ module Assert
 
   module ConfigHelpers
 
+    def runner; self.config.runner; end
+    def suite;  self.config.suite;  end
+    def view;   self.config.view;   end
+
     def runner_seed
       self.config.runner_seed
     end
@@ -18,18 +22,15 @@ module Assert
       self.count(:pass) == self.count(:results)
     end
 
-    # get the formatted suite run time
-    def run_time(format = '%.6f')
+    def formatted_run_time(format = '%.6f')
       format % self.config.suite.run_time
     end
 
-    # get the formatted suite test rate
-    def test_rate(format = '%.6f')
+    def formatted_test_rate(format = '%.6f')
       format % self.config.suite.test_rate
     end
 
-    # get the formatted suite result rate
-    def result_rate(format = '%.6f')
+    def formatted_result_rate(format = '%.6f')
       format % self.config.suite.result_rate
     end
 

--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -69,7 +69,9 @@ module Assert
 
       puts "#{result_count_statement}: #{styled_results_sentence}"
       puts
-      puts "(#{run_time} seconds, #{test_rate} tests/s, #{result_rate} results/s)"
+      puts "(#{formatted_run_time} seconds, " \
+           "#{formatted_test_rate} tests/s, " \
+           "#{formatted_result_rate} results/s)"
     end
 
     def on_interrupt(err)

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -7,15 +7,15 @@ module Assert
   class Runner
     include Assert::ConfigHelpers
 
-    attr_reader :config, :suite, :view
+    attr_reader :config
 
     def initialize(config)
       @config = config
     end
 
-    def run
-      @suite, @view = @config.suite, @config.view
+    def runner; self; end
 
+    def run
       self.on_start
       self.suite.on_start
       self.view.on_start

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -24,6 +24,8 @@ module Assert
       @end_time     = @start_time
     end
 
+    def suite; self; end
+
     def setup(&block)
       self.setups << (block || proc{})
     end

--- a/lib/assert/view.rb
+++ b/lib/assert/view.rb
@@ -1,10 +1,12 @@
 require 'assert/config'
+require 'assert/config_helpers'
 require 'assert/suite'
 require 'assert/view_helpers'
 
 module Assert
 
   class View
+    include Assert::ConfigHelpers
     include Assert::ViewHelpers
 
     # this method is used to bring in custom user-specific views
@@ -49,9 +51,7 @@ module Assert
       @output_io.sync = true if @output_io.respond_to?(:sync=)
     end
 
-    def view
-      self
-    end
+    def view; self; end
 
     def is_tty?
       !!@output_io.isatty

--- a/test/unit/config_helpers_tests.rb
+++ b/test/unit/config_helpers_tests.rb
@@ -21,10 +21,18 @@ module Assert::ConfigHelpers
     end
     subject{ @helpers }
 
+    should have_imeths :runner, :suite, :view
     should have_imeths :runner_seed, :count, :tests?, :all_pass?
-    should have_imeths :run_time, :test_rate, :result_rate
+    should have_imeths :formatted_run_time
+    should have_imeths :formatted_test_rate, :formatted_result_rate
     should have_imeths :show_test_profile_info?, :show_test_verbose_info?
     should have_imeths :ocurring_result_types
+
+    should "know the config's runner, suite and view" do
+      assert_equal subject.config.runner, subject.runner
+      assert_equal subject.config.suite,  subject.suite
+      assert_equal subject.config.view,   subject.view
+    end
 
     should "know its runner seed" do
       assert_equal subject.config.runner_seed, subject.runner_seed
@@ -44,13 +52,13 @@ module Assert::ConfigHelpers
       format = '%.6f'
 
       exp = format % subject.config.suite.run_time
-      assert_equal exp, subject.run_time(format)
+      assert_equal exp, subject.formatted_run_time(format)
 
       exp = format % subject.config.suite.test_rate
-      assert_equal exp, subject.test_rate(format)
+      assert_equal exp, subject.formatted_test_rate(format)
 
       exp = format % subject.config.suite.result_rate
-      assert_equal exp, subject.result_rate(format)
+      assert_equal exp, subject.formatted_result_rate(format)
     end
 
     should "know whether to show test profile info" do

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -30,8 +30,8 @@ class Assert::Runner
     end
     subject { @runner }
 
-    should have_readers :config, :suite, :view
-    should have_imeths :run, :run!
+    should have_readers :config
+    should have_imeths :runner, :run, :run!
     should have_imeths :before_load, :after_load
     should have_imeths :on_start, :on_finish, :on_interrupt
     should have_imeths :before_test, :after_test, :on_result
@@ -40,9 +40,8 @@ class Assert::Runner
       assert_equal @config, subject.config
     end
 
-    should "not have set its suite and view" do
-      assert_nil subject.suite
-      assert_nil subject.view
+    should "override the config helper's runner value with itself" do
+      assert_equal subject, subject.runner
     end
 
   end
@@ -74,11 +73,6 @@ class Assert::Runner
 
     should "return an integer exit code" do
       assert_equal 0, @result
-    end
-
-    should "have set its suite and view" do
-      assert_equal @config.suite, subject.suite
-      assert_equal @config.view,  subject.view
     end
 
     should "run all callback on itself, the suite and the view" do

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -32,7 +32,7 @@ class Assert::Suite
 
     should have_readers :config, :tests, :test_methods
     should have_accessors :start_time, :end_time
-    should have_imeths :setup, :startup, :teardown, :shutdown
+    should have_imeths :suite, :setup, :startup, :teardown, :shutdown
     should have_imeths :run_time, :test_rate, :result_rate, :count
     should have_imeths :ordered_tests, :reversed_tests
     should have_imeths :ordered_tests_by_run_time, :reversed_tests_by_run_time
@@ -46,6 +46,10 @@ class Assert::Suite
 
     should "know its config" do
       assert_equal @config, subject.config
+    end
+
+    should "override the config helper's suite value with itself" do
+      assert_equal subject, subject.suite
     end
 
     should "default its attrs" do

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'assert/view'
 
 require 'stringio'
+require 'assert/config_helpers'
 require 'assert/suite'
 require 'assert/view_helpers'
 
@@ -12,6 +13,10 @@ class Assert::View
     subject { Assert::View }
 
     should have_instance_method :require_user_view
+
+    should "include the config helpers" do
+      assert_includes Assert::ConfigHelpers, subject
+    end
 
     should "include the view helpers" do
       assert_includes Assert::ViewHelpers, subject
@@ -57,7 +62,7 @@ class Assert::View
       assert_equal @config, subject.config
     end
 
-    should "expose itself as `view`" do
+    should "override the config helper's view value with itself" do
       assert_equal subject, subject.view
     end
 


### PR DESCRIPTION
This cleans up some usage of the config helpers in the runner, suite
and view.  The config helpers now formally define each object so
the things mixing in the config helpers don't have to.

Now the runner no longer manually has to define the objects it needs.
I also had each object override the config helpers that define
themselves.  Finally, this renames the run time and rates to include
`formatted_` in the name.  The previous name collided with with
the corresponding names on the suite.  It wasn't causing problems, it
was just bad form.

This is more prep for switching to have the tests accumulate result
data rather than store it as objects in memory.

@jcredding ready for review.