### PR TITLE
move the `ansi_styled_msg` helper method out of the base view

### DIFF
--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -1,4 +1,5 @@
 require 'assert/view'
+require 'assert/view_helpers'
 
 module Assert
 
@@ -6,6 +7,7 @@ module Assert
   # designed for terminal viewing.
 
   class DefaultView < Assert::View
+    include Assert::ViewHelpers::Ansi
 
     # setup options and their default values
 

--- a/lib/assert/view.rb
+++ b/lib/assert/view.rb
@@ -57,13 +57,6 @@ module Assert
       !!@output_io.isatty
     end
 
-    def ansi_styled_msg(msg, result_or_sym)
-      return msg if !self.is_tty? || !self.styled
-      code = Assert::ViewHelpers::Ansi.code_for(*self.send("#{result_or_sym.to_sym}_styles"))
-      return msg if code.empty?
-      code + msg + Assert::ViewHelpers::Ansi.code_for(:reset)
-    end
-
     # Callbacks
 
     # define callback handlers to output information.  These will be called

--- a/lib/assert/view_helpers.rb
+++ b/lib/assert/view_helpers.rb
@@ -181,6 +181,13 @@ module Assert
         style_names.map{ |n| "\e[#{CODES[n]}m" if CODES.key?(n) }.compact.join('')
       end
 
+      def ansi_styled_msg(msg, result_or_sym)
+        return msg if !self.is_tty? || !self.styled
+        code = Assert::ViewHelpers::Ansi.code_for(*self.send("#{result_or_sym.to_sym}_styles"))
+        return msg if code.empty?
+        code + msg + Assert::ViewHelpers::Ansi.code_for(:reset)
+      end
+
     end
 
   end

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -35,7 +35,7 @@ class Assert::View
     subject{ @view }
 
     should have_readers :config
-    should have_imeths :view, :is_tty?, :ansi_styled_msg
+    should have_imeths :view, :is_tty?
     should have_imeths :before_load, :after_load
     should have_imeths :on_start, :on_finish, :on_interrupt
     should have_imeths :before_test, :after_test, :on_result
@@ -68,34 +68,6 @@ class Assert::View
 
     should "know if it is a tty" do
       assert_equal !!@io.isatty, subject.is_tty?
-    end
-
-    should "know how to build ansi styled messages" do
-      msg = Factory.string
-      result = [:pass, :fail, :error, :skip, :ignore].sample
-
-      Assert.stub(subject, :is_tty?){ false }
-      Assert.stub(subject, :styled){ false }
-      assert_equal msg, subject.ansi_styled_msg(msg, result)
-
-      Assert.stub(subject, :is_tty?){ false }
-      Assert.stub(subject, :styled){ true }
-      assert_equal msg, subject.ansi_styled_msg(msg, result)
-
-      Assert.stub(subject, :is_tty?){ true }
-      Assert.stub(subject, :styled){ false }
-      assert_equal msg, subject.ansi_styled_msg(msg, result)
-
-      Assert.stub(subject, :is_tty?){ true }
-      Assert.stub(subject, :styled){ true }
-      Assert.stub(subject, "#{result}_styles"){ [] }
-      assert_equal msg, subject.ansi_styled_msg(msg, result)
-
-      styles = Factory.integer(3).times.map{ Assert::ViewHelpers::Ansi::CODES.keys.sample }
-      Assert.stub(subject, "#{result}_styles"){ styles }
-      exp_code = Assert::ViewHelpers::Ansi.code_for(*styles)
-      exp = exp_code + msg + Assert::ViewHelpers::Ansi.code_for(:reset)
-      assert_equal exp, subject.ansi_styled_msg(msg, result)
     end
 
   end


### PR DESCRIPTION
This method really only applies if you are using ansi stuff in your
view.  There is no need to have this in the base view.  This moves
the method to the Ansi view helper module and updates the default
view to mixin that module as it needs the helper.  This will help
reduce bloat when building non-ansi views.

This is a cleanup to prep for reworking/simplifying the views when
we switch to accumulating test result data.

@jcredding ready for review.