### PR TITLE
runner: move test randomization to the base runner

### DIFF
--- a/lib/assert/default_runner.rb
+++ b/lib/assert/default_runner.rb
@@ -2,21 +2,10 @@ require 'assert/runner'
 
 module Assert
 
-  # This is the default runner used by assert.  It runs the tests one at a time
-  # in random order
+  # This is the default runner used by assert.  It adds no special behavior on
+  # top of the base runner's behavior
 
   class DefaultRunner < Assert::Runner
-
-    def on_start
-      if self.tests?
-        self.view.puts "Running tests in random order, seeded with \"#{self.runner_seed}\""
-      end
-    end
-
-    def run!(&block)
-      srand self.runner_seed
-      self.suite.tests.sort.sort_by{ rand self.suite.tests.size }.each(&block)
-    end
 
   end
 

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -20,10 +20,15 @@ module Assert
       self.suite.on_start
       self.view.on_start
 
+      if self.tests?
+        self.view.puts "Running tests in random order, " \
+                       "seeded with \"#{self.runner_seed}\""
+      end
+
       begin
         self.suite.start_time = Time.now
         self.suite.setups.each(&:call)
-        self.run! do |test|
+        tests_to_run.each do |test|
           self.before_test(test)
           self.suite.before_test(test)
           self.view.before_test(test)
@@ -52,13 +57,9 @@ module Assert
       end
     end
 
-    def run!
-      # runners should override as needed and yeild tests to the given block
-    end
-
     # Callbacks
 
-    # define callback handlers to do special behavior during the test run.  These
+    # define callback handlers to do special behavior during the test run. These
     # will be called by the test runner
 
     def before_load(test_files); end
@@ -69,6 +70,13 @@ module Assert
     def after_test(test);        end
     def on_finish;               end
     def on_interrupt(err);       end
+
+    private
+
+    def tests_to_run
+      srand self.runner_seed
+      self.suite.tests.sort.sort_by{ rand self.suite.tests.size }
+    end
 
   end
 

--- a/test/unit/default_runner_tests.rb
+++ b/test/unit/default_runner_tests.rb
@@ -13,24 +13,6 @@ class Assert::DefaultRunner
     end
     subject{ @runner }
 
-    should have_imeths :on_start, :run!
-
-    should "descibe the run on start" do
-      output = ""
-      view   = Assert::View.new(@config, StringIO.new(output, "w+"))
-      Assert.stub(subject, :view){ view }
-
-      subject.on_start
-      assert_empty output
-
-      ci = Factory.context_info(Factory.modes_off_context_class)
-      @config.suite.tests << Factory.test("should pass", ci){ assert(1==1) }
-      subject.on_start
-
-      exp = "Running tests in random order, seeded with \"#{subject.runner_seed}\"\n"
-      assert_equal exp, output
-    end
-
   end
 
 end


### PR DESCRIPTION
This moves the logic/handling for randomizing the test run order
out of the default runner and into the base runner.  I'm essentially
saying this is not something that is intended to be overridden.

This is prep for adding logic to just run just single tests.  I want
to centralize the "baseline" features into the the base runner so
they are always available, no matter what runner is in use.  This
is also prep for adding a custom runner that runs tests in parallel.
It shouldn't have to re-implement this kind of basline behavior.

@jcredding ready for review.