### PR TITLE
runner: add `-t` option to run only a single test

### DIFF
--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -17,7 +17,8 @@ module Assert
         apply_env_settings
       end
 
-      files = test_files(test_paths.empty? ? [*self.config.test_dir] : test_paths)
+      paths = test_paths.empty? ? [*self.config.test_dir] : test_paths
+      files = lookup_test_files(paths)
       init(files, path_of(self.config.test_dir, files.first))
     end
 
@@ -75,9 +76,11 @@ module Assert
       self.config.runner_seed ENV['ASSERT_RUNNER_SEED'].to_i if ENV['ASSERT_RUNNER_SEED']
     end
 
-    def test_files(test_paths)
+    def lookup_test_files(test_paths)
       file_paths = if self.config.changed_only
         changed_test_files(test_paths)
+      elsif self.config.single_test?
+        globbed_test_files(self.config.single_test_file_path)
       else
         globbed_test_files(test_paths)
       end
@@ -106,9 +109,8 @@ module Assert
       require settings_file if File.exists?(settings_file)
     end
 
-    # this method inspects a test path and finds the test dir path.
-
     def path_of(segment, a_path)
+      # this method inspects a test path and finds the test dir path.
       full_path = File.expand_path(a_path || '.', Dir.pwd)
       seg_pos = full_path.index(segment_regex(segment))
       File.join(seg_pos && (seg_pos > 0) ? full_path[0..(seg_pos-1)] : full_path, segment)

--- a/lib/assert/cli.rb
+++ b/lib/assert/cli.rb
@@ -36,6 +36,9 @@ module Assert
         option 'changed_ref', 'reference for changes, use with `-c` opt', {
           :abbrev => 'r', :value => ''
         }
+        option 'single_test', 'only run the test on the given file/line', {
+          :abbrev => 't', :value => ''
+        }
         option 'pp_objects', 'pretty-print objects in fail messages', {
           :abbrev => 'p'
         }

--- a/lib/assert/config.rb
+++ b/lib/assert/config.rb
@@ -1,6 +1,7 @@
 require 'assert/default_runner'
 require 'assert/default_suite'
 require 'assert/default_view'
+require 'assert/file_line'
 require 'assert/utils'
 
 module Assert
@@ -21,8 +22,9 @@ module Assert
     settings :view, :suite, :runner
     settings :test_dir, :test_helper, :test_file_suffixes
     settings :changed_proc, :pp_proc, :use_diff_proc, :run_diff_proc
-    settings :runner_seed, :changed_only, :changed_ref, :pp_objects
-    settings :capture_output, :halt_on_fail, :profile, :verbose, :list, :debug
+    settings :runner_seed, :changed_only, :changed_ref, :single_test
+    settings :pp_objects, :capture_output, :halt_on_fail, :profile
+    settings :verbose, :list, :debug
 
     def initialize(settings = nil)
       @view   = Assert::DefaultView.new(self, $stdout)
@@ -42,6 +44,7 @@ module Assert
       @runner_seed    = begin; srand; srand % 0xFFFF; end.to_i
       @changed_only   = false
       @changed_ref    = ''
+      @single_test    = ''
       @pp_objects     = false
       @capture_output = false
       @halt_on_fail   = true
@@ -59,6 +62,21 @@ module Assert
           self.send(name.to_s, settings[name])
         end
       end
+      @single_test_file_line = nil
+    end
+
+    def single_test?
+      !self.single_test.empty?
+    end
+
+    def single_test_file_line
+      @single_test_file_line ||= Assert::FileLine.parse(
+        File.expand_path(self.single_test, Dir.pwd)
+      )
+    end
+
+    def single_test_file_path
+      self.single_test_file_line.file if self.single_test_file_line
     end
 
   end

--- a/lib/assert/config_helpers.rb
+++ b/lib/assert/config_helpers.rb
@@ -10,6 +10,14 @@ module Assert
       self.config.runner_seed
     end
 
+    def single_test?
+      self.config.single_test?
+    end
+
+    def single_test_file_line
+      self.config.single_test_file_line
+    end
+
     def count(type)
       self.config.suite.count(type)
     end

--- a/lib/assert/file_line.rb
+++ b/lib/assert/file_line.rb
@@ -3,7 +3,7 @@ module Assert
   class FileLine
 
     def self.parse(file_line_path)
-      self.new(*(file_line_path.to_s.match(/(.+)\:(.+)/) || [])[1..2])
+      self.new(*(file_line_path.to_s.match(/(^[^\:]*)\:*(\d*)$/) || [])[1..2])
     end
 
     attr_reader :file, :line
@@ -18,7 +18,8 @@ module Assert
 
     def ==(other_file_line)
       if other_file_line.kind_of?(FileLine)
-        self.file == other_file_line.file && self.line == other_file_line.line
+        self.file == other_file_line.file &&
+        self.line == other_file_line.line
       else
         super
       end

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -20,7 +20,9 @@ module Assert
       self.suite.on_start
       self.view.on_start
 
-      if self.tests?
+      if self.single_test?
+        self.view.puts "Running test: #{self.single_test_file_line}"
+      elsif self.tests?
         self.view.puts "Running tests in random order, " \
                        "seeded with \"#{self.runner_seed}\""
       end
@@ -74,8 +76,13 @@ module Assert
     private
 
     def tests_to_run
-      srand self.runner_seed
-      self.suite.tests.sort.sort_by{ rand self.suite.tests.size }
+      if self.single_test?
+        [ self.suite.tests.find{ |t| t.file_line == self.single_test_file_line }
+        ].compact
+      else
+        srand self.runner_seed
+        self.suite.tests.sort.sort_by{ rand self.suite.tests.size }
+      end
     end
 
   end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -8,7 +8,7 @@ module Factory
   extend Assert::Factory
 
   def self.context_info_called_from
-    "#{Factory.path}_tests.rb:#{Factory.integer}"
+    File.expand_path("#{Factory.path}_tests.rb:#{Factory.integer}", Dir.pwd)
   end
 
   def self.context_info(context_klass = nil)

--- a/test/unit/config_helpers_tests.rb
+++ b/test/unit/config_helpers_tests.rb
@@ -22,7 +22,8 @@ module Assert::ConfigHelpers
     subject{ @helpers }
 
     should have_imeths :runner, :suite, :view
-    should have_imeths :runner_seed, :count, :tests?, :all_pass?
+    should have_imeths :runner_seed, :single_test?, :single_test_file_line
+    should have_imeths :count, :tests?, :all_pass?
     should have_imeths :formatted_run_time
     should have_imeths :formatted_test_rate, :formatted_result_rate
     should have_imeths :show_test_profile_info?, :show_test_verbose_info?
@@ -36,6 +37,19 @@ module Assert::ConfigHelpers
 
     should "know its runner seed" do
       assert_equal subject.config.runner_seed, subject.runner_seed
+    end
+
+    should "know if it is in single test mode" do
+      Assert.stub(subject.config, :single_test?){ true }
+      assert_true subject.single_test?
+
+      Assert.stub(subject.config, :single_test?){ false }
+      assert_false subject.single_test?
+    end
+
+    should "know its single test file line" do
+      exp = subject.config.single_test_file_line
+      assert_equal exp, subject.single_test_file_line
     end
 
     should "know how to count things on the suite" do

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -1,8 +1,10 @@
 require 'assert'
 require 'assert/config'
 
+require 'assert/default_runner'
 require 'assert/default_suite'
 require 'assert/default_view'
+require 'assert/file_line'
 require 'assert/runner'
 
 class Assert::Config
@@ -17,9 +19,11 @@ class Assert::Config
     should have_imeths :view, :suite, :runner
     should have_imeths :test_dir, :test_helper, :test_file_suffixes
     should have_imeths :changed_proc, :pp_proc, :use_diff_proc, :run_diff_proc
-    should have_imeths :runner_seed, :changed_only, :changed_ref, :pp_objects
-    should have_imeths :capture_output, :halt_on_fail, :profile, :verbose, :list
-    should have_imeths :debug, :apply
+    should have_imeths :runner_seed, :changed_only, :changed_ref, :single_test
+    should have_imeths :pp_objects, :capture_output, :halt_on_fail, :profile
+    should have_imeths :verbose, :list, :debug
+    should have_imeths :apply, :single_test?
+    should have_imeths :single_test_file_line, :single_test_file_path
 
     should "default the view, suite, and runner" do
       assert_kind_of Assert::DefaultView,   subject.view
@@ -44,6 +48,7 @@ class Assert::Config
       assert_not_nil subject.runner_seed
       assert_not     subject.changed_only
       assert_empty   subject.changed_ref
+      assert_empty   subject.single_test
       assert_not     subject.pp_objects
       assert_not     subject.capture_output
       assert         subject.halt_on_fail
@@ -60,6 +65,34 @@ class Assert::Config
 
       assert Assert::Config.new.halt_on_fail
       assert_not Assert::Config.new(:halt_on_fail => false).halt_on_fail
+    end
+
+    should "know if it is in single test mode" do
+      assert_false subject.single_test?
+
+      subject.apply(:single_test => Factory.string)
+      assert_true subject.single_test?
+    end
+
+    should "know its single test file line" do
+      exp = Assert::FileLine.parse(File.expand_path('', Dir.pwd))
+      assert_equal exp, subject.single_test_file_line
+
+      file_line_path = "#{Factory.path}_tests.rb:#{Factory.integer}"
+      subject.apply(:single_test => file_line_path)
+
+      exp = Assert::FileLine.parse(File.expand_path(file_line_path, Dir.pwd))
+      assert_equal exp, subject.single_test_file_line
+    end
+
+    should "know its single test file path" do
+      exp = Assert::FileLine.parse(File.expand_path('', Dir.pwd)).file
+      assert_equal exp, subject.single_test_file_path
+
+      path = "#{Factory.path}_tests.rb"
+      file_line_path = "#{path}:#{Factory.integer}"
+      subject.apply(:single_test => file_line_path)
+      assert_equal File.expand_path(path, Dir.pwd), subject.single_test_file_path
     end
 
   end

--- a/test/unit/file_line_tests.rb
+++ b/test/unit/file_line_tests.rb
@@ -23,8 +23,12 @@ class Assert::FileLine
 
     should "handle parsing bad data gracefully" do
       file_line = subject.parse(@file)
-      assert_equal '', file_line.file
-      assert_equal '', file_line.line
+      assert_equal @file, file_line.file
+      assert_equal '',    file_line.line
+
+      file_line = subject.parse(@line)
+      assert_equal @line, file_line.file
+      assert_equal '',    file_line.line
 
       file_line = subject.parse('')
       assert_equal '', file_line.file

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -50,7 +50,7 @@ class Assert::Runner
     desc "and run"
     setup do
       callback_mixin = Module.new
-      runner_class = Class.new(Assert::Runner) do
+      @runner_class = Class.new(Assert::Runner) do
         include CallbackMixin
 
         def run!(&block)
@@ -65,11 +65,11 @@ class Assert::Runner
       @config.suite suite_class.new(@config)
       @config.view  view_class.new(@config, StringIO.new(@view_output, "w+"))
 
-      ci = Factory.context_info(Factory.modes_off_context_class)
-      @test = Factory.test("should pass", ci){ assert(1==1) }
+      @ci = Factory.context_info(Factory.modes_off_context_class)
+      @test = Factory.test("should pass", @ci){ assert(1==1) }
       @config.suite.tests << @test
 
-      @runner = runner_class.new(@config)
+      @runner = @runner_class.new(@config)
       @result = @runner.run
     end
 
@@ -80,25 +80,25 @@ class Assert::Runner
     should "run all callbacks on itself, the suite and the view" do
       # itself
       assert_true subject.on_start_called
-      assert_equal @test, subject.before_test_called
-      assert_instance_of Assert::Result::Pass, subject.on_result_called
-      assert_equal @test, subject.after_test_called
+      assert_equal [@test], subject.before_test_called
+      assert_instance_of Assert::Result::Pass, subject.on_result_called.last
+      assert_equal [@test], subject.after_test_called
       assert_true subject.on_finish_called
 
       # suite
       suite = @config.suite
       assert_true suite.on_start_called
-      assert_equal @test, suite.before_test_called
-      assert_instance_of Assert::Result::Pass, suite.on_result_called
-      assert_equal @test, suite.after_test_called
+      assert_equal [@test], suite.before_test_called
+      assert_instance_of Assert::Result::Pass, suite.on_result_called.last
+      assert_equal [@test], suite.after_test_called
       assert_true suite.on_finish_called
 
       # view
       view = @config.view
       assert_true view.on_start_called
-      assert_equal @test, view.before_test_called
-      assert_instance_of Assert::Result::Pass, view.on_result_called
-      assert_equal @test, view.after_test_called
+      assert_equal [@test], view.before_test_called
+      assert_instance_of Assert::Result::Pass, view.on_result_called.last
+      assert_equal [@test], view.after_test_called
       assert_true view.on_finish_called
     end
 
@@ -113,17 +113,55 @@ class Assert::Runner
       assert_not_includes exp, @view_output
     end
 
+    should "run only a single test if a single test is configured" do
+      other_test = Factory.test("should also pass", @ci){ assert(1==1) }
+      @config.suite.tests << other_test
+
+      @config.single_test @test.file_line.to_s
+
+      runner = @runner_class.new(@config)
+      runner.run
+      assert_equal [@test], runner.before_test_called
+    end
+
+    should "descibe running only a single test if a single test is configured" do
+      @config.single_test @test.file_line.to_s
+      @view_output.gsub!(/./, '')
+      subject.run
+
+      exp = "Running test: #{subject.single_test_file_line}\n"
+      assert_includes exp, @view_output
+    end
+
   end
 
   module CallbackMixin
     attr_reader :on_start_called, :on_finish_called
     attr_reader :before_test_called, :after_test_called, :on_result_called
 
-    def on_start;          @on_start_called     = true;   end
-    def before_test(test); @before_test_called  = test;   end
-    def on_result(result); @on_result_called    = result; end
-    def after_test(test);  @after_test_called   = test;   end
-    def on_finish;         @on_finish_called    = true;   end
+    def on_start
+      @on_start_called = true
+    end
+
+    def before_test(test)
+      @before_test_called ||= []
+      @before_test_called << test
+    end
+
+    def on_result(result)
+      @on_result_called ||= []
+      @on_result_called << result
+    end
+
+    def after_test(test)
+      @after_test_called ||= []
+      @after_test_called << test
+    end
+
+    def on_finish
+      @on_finish_called = true
+    end
+
   end
 
 end


### PR DESCRIPTION
This updates assert's base runner to allow running only a single
test.  The idea is to not only be able to isolate failing tests
and work on just them but also to print out assert CLI commands
in fail/error messages to allow you to easily re-run only a single
failing test for quick iterations.

To accomplish this I've added a new cli opt, `-t`, that takes the
file/line of the single test to run.  For example:

```
$ assert -t test/unit/config_tests.rb:61
```

This option configures the file line for the single test and puts
assert in "single test" mode.  Only the test file for this test
will be loaded and only that single test will be run.  If an invalid
file/line is specified, no tests are run.

Some addtional notes:

* `-t` was used b/c you are calling out a test - t for test
* the file line parse logic was updated to be a bit more flexible -
  it not parses even if the file or line parts are omitted

Closes #120.

@jcredding ready for review.