### PR TITLE
output the cmd to re-run a result's test in result details

### DIFF
--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -93,6 +93,9 @@ module Assert
         # output any captured stdout
         puts captured_output(result.output) if result.output && !result.output.empty?
 
+        # output re-run CLI cmd
+        puts re_run_test_cmd(result.test_id)
+
         # add an empty line between each result detail
         puts
       end

--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -31,6 +31,7 @@ module Assert::Result
     def self.for_test(test, message, bt)
       self.new({
         :test_name => test.name,
+        :test_id   => test.file_line.to_s,
         :message   => message,
         :output    => test.output,
         :backtrace => Backtrace.new(bt)
@@ -44,6 +45,7 @@ module Assert::Result
     def type;      @type      ||= (@build_data[:type]      || self.class.type).to_sym;      end
     def name;      @name      ||= (@build_data[:name]      || self.class.name.to_s);        end
     def test_name; @test_name ||= (@build_data[:test_name] || '');                          end
+    def test_id;   @test_id   ||= (@build_data[:test_id]   || '');                          end
     def message;   @message   ||= (@build_data[:message]   || '');                          end
     def output;    @output    ||= (@build_data[:output]    || '');                          end
     def backtrace; @backtrace ||= (@build_data[:backtrace] || Backtrace.new([]));           end
@@ -64,6 +66,7 @@ module Assert::Result
       { :type      => self.type,
         :name      => self.name,
         :test_name => self.test_name,
+        :test_id   => self.test_id,
         :message   => self.message,
         :output    => self.output,
         :backtrace => self.backtrace,

--- a/lib/assert/view_helpers.rb
+++ b/lib/assert/view_helpers.rb
@@ -45,6 +45,11 @@ module Assert
         "--------------"
       end
 
+      # show any captured output
+      def re_run_test_cmd(test_id)
+        "assert -t #{test_id.gsub(Dir.pwd, '.')}"
+      end
+
       def test_count_statement
         "#{self.count(:tests)} test#{'s' if self.count(:tests) != 1}"
       end

--- a/test/unit/result_tests.rb
+++ b/test/unit/result_tests.rb
@@ -41,6 +41,7 @@ module Assert::Result
         :type      => Factory.string,
         :name      => Factory.string,
         :test_name => Factory.string,
+        :test_id   => Factory.string,
         :message   => Factory.string,
         :output    => Factory.text,
         :backtrace => Backtrace.new(caller),
@@ -51,7 +52,8 @@ module Assert::Result
     subject{ @result }
 
     should have_cmeths :type, :name, :for_test
-    should have_imeths :type, :name, :test_name, :message, :output, :backtrace, :trace
+    should have_imeths :type, :name, :test_name, :test_id
+    should have_imeths :message, :output, :backtrace, :trace
     should have_imeths *Assert::Result.types.keys.map{ |k| "#{k}?" }
     should have_imeths :set_backtrace, :data, :to_sym, :to_s
 
@@ -68,7 +70,9 @@ module Assert::Result
       exp_backtrace = Backtrace.new(bt)
       exp_trace     = exp_backtrace.filtered.first.to_s
 
-      assert_equal @test.name,    result.test_name
+      assert_equal @test.name,           result.test_name
+      assert_equal @test.file_line.to_s, result.test_id
+
       assert_equal message,       result.message
       assert_equal exp_backtrace, result.backtrace
       assert_equal exp_trace,     result.trace
@@ -78,6 +82,7 @@ module Assert::Result
       assert_equal @given_data[:type].to_sym, subject.type
       assert_equal @given_data[:name],        subject.name
       assert_equal @given_data[:test_name],   subject.test_name
+      assert_equal @given_data[:test_id],     subject.test_id
       assert_equal @given_data[:message],     subject.message
       assert_equal @given_data[:output],      subject.output
       assert_equal @given_data[:backtrace],   subject.backtrace
@@ -90,6 +95,7 @@ module Assert::Result
       assert_equal :unknown,          result.type
       assert_equal '',                result.name
       assert_equal '',                result.test_name
+      assert_equal '',                result.test_id
       assert_equal '',                result.message
       assert_equal '',                result.output
       assert_equal Backtrace.new([]), result.backtrace
@@ -120,6 +126,7 @@ module Assert::Result
         :type      => subject.type,
         :name      => subject.name,
         :test_name => subject.test_name,
+        :test_id   => subject.test_id,
         :message   => subject.message,
         :output    => subject.output,
         :backtrace => subject.backtrace,

--- a/test/unit/view_helpers_tests.rb
+++ b/test/unit/view_helpers_tests.rb
@@ -56,7 +56,7 @@ module Assert::ViewHelpers
     subject{ @helpers }
 
     should have_imeths :test_run_time, :test_result_rate
-    should have_imeths :captured_output
+    should have_imeths :captured_output, :re_run_test_cmd
     should have_imeths :test_count_statement, :result_count_statement
     should have_imeths :to_sentence
     should have_imeths :all_pass_result_summary_msg, :result_summary_msg
@@ -81,6 +81,12 @@ module Assert::ViewHelpers
             "#{output}"\
             "--------------"
       assert_equal exp, subject.captured_output(output)
+    end
+
+    should "know how to build the re-run test cmd" do
+      test_id = "#{Dir.pwd}/#{Factory.string}_tests.rb:#{Factory.integer}"
+      exp = "assert -t #{test_id.gsub(Dir.pwd, '.')}"
+      assert_equal exp, subject.re_run_test_cmd(test_id)
     end
 
     should "know its test count and result count statements" do


### PR DESCRIPTION
Now that we can run individual tests using the new `-t` option,
a common need is to re-run just a single test that is failing and
we want to focus on.  This updates the result details that are dumped
by the default view to build and include an assert cmd for re-running
just that result's test.

To make this happen, I first needed to track the `test_id` on each
result.  The test id is just the file/line string for the result's
test.

I chose to print the command with no empty lines between it and the
rest of the result details b/c we currently don't put any empty lines
in the result details.  I chose to not ansi color it to help make it
stand out from the rest of the details.  This is similar to how we
output captured output for each result.

![assert](https://cloud.githubusercontent.com/assets/82110/14114505/d2841c40-f59c-11e5-8d8e-d0dc6fe3dec7.gif)

@jcredding ready for review.
