### PR TITLE
switch to applying CLI options last

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,25 +202,25 @@ Assert.configure do |config|
 end
 ```
 
-Assert uses a config pattern for specifying settings.  Using this pattern, you can configure settings, extensions, custom views, etc.  Settings can be configured in 4 different scopes and are applied in this order: User, Local, CLI, ENV.
+Assert uses a config pattern for specifying settings.  Using this pattern, you can configure settings, extensions, custom views, etc.  Settings can be configured in 4 different scopes and are applied in this order: User, Local, ENV, CLI.
 
 ### User settings
 
-Assert will look for and require the file `$HOME/.assert/init.rb`.  Use this file to specify user settings.  User settings can be overridden by Local, CLI, and ENV settings.
+Assert will look for and require the file `$HOME/.assert/init.rb`.  Use this file to specify user settings.  User settings can be overridden by Local, ENV, and CLI settings.
 
 ### Local settings
 
-Assert will look for and require the file `./.assert.rb`.  Use this file to specify project settings.  Local settings can be overridden by CLI, and ENV settings.
+Assert will look for and require the file `./.assert.rb`.  Use this file to specify project settings.  Local settings can be overridden by ENV, and CLI settings.
 
 To specify a custom local settings file path, use the `ASSERT_LOCALFILE` env var.
 
-### CLI settings
-
-Assert accepts options from its CLI.  Use these options to specify runtime settings.  CLI settings can be overridden by ENV settings.
-
 ### ENV settings
 
-Assert uses ENV vars to drive certain settings.  Use these vars to specify absolute runtime settings.  ENV settings are always applied last and cannot be overridden.
+Assert uses ENV vars to drive certain settings.  Use these vars to specify specific environment settings.  ENV settings can be overridden by CLI settings.
+
+### CLI settings
+
+Assert accepts options from its CLI.  Use these options to specify absolute runtime settings.  CLI settings are always applied last and cannot be overridden.
 
 ## Running Tests
 
@@ -266,16 +266,16 @@ Assert.configure do |config|
 end
 ```
 
-Using the CLI:
-
-```sh
-$ assert [-s|--runner-seed] 1234
-```
-
 Using an ENV var:
 
 ```sh
 $ ASSERT_RUNNER_SEED=1234 assert
+```
+
+Using the CLI:
+
+```sh
+$ assert [-s|--runner-seed] 1234
 ```
 
 ### Run a single test

--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -13,8 +13,8 @@ module Assert
       Assert::CLI.bench('Apply settings') do
         apply_user_settings
         apply_local_settings
-        apply_option_settings(test_options)
         apply_env_settings
+        apply_option_settings(test_options)
       end
 
       paths = test_paths.empty? ? [*self.config.test_dir] : test_paths
@@ -68,12 +68,12 @@ module Assert
       safe_require(ENV['ASSERT_LOCALFILE'] || path_of(LOCAL_SETTINGS_FILE, Dir.pwd))
     end
 
-    def apply_option_settings(options)
-      self.config.apply(options)
-    end
-
     def apply_env_settings
       self.config.runner_seed ENV['ASSERT_RUNNER_SEED'].to_i if ENV['ASSERT_RUNNER_SEED']
+    end
+
+    def apply_option_settings(options)
+      self.config.apply(options)
     end
 
     def lookup_test_files(test_paths)


### PR DESCRIPTION
Previously, ENV settings would be applied last and could therefore
override CLI settings.  It seems strange in hindsight to ever override
something that has been specified at the CLI.  It leads to confusing
and unpredictable behavior as you may not realize and ENV var is
even set.

This switches to always applying CLI settings last so that they
are never overridden.  I also chose to reorder some of the implementation
to match the order b/c that is what was done previously.  I also
updated the README to keep it relevent and matching the implementation.

@jcredding ready for review.