### PR TITLE
have `assert_raises` return any raised exception instance

### DIFF
--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -179,6 +179,7 @@ module Assert
       desc = exceptions.last.kind_of?(String) ? exceptions.pop : nil
       err = RaisedException.new(exceptions, &block)
       assert(err.raised?, desc){ err.msg }
+      err.exception
     end
     alias_method :assert_raise, :assert_raises
 

--- a/test/unit/assertions/assert_raises_tests.rb
+++ b/test/unit/assertions/assert_raises_tests.rb
@@ -35,6 +35,19 @@ module Assert::Assertions
       messages.each_with_index{ |msg, n| assert_match /^#{exp[n]}/, msg }
     end
 
+    should "return any raised exception instance" do
+      error     = nil
+      error_msg = Factory.string
+      test = Factory.test do
+        error = assert_raises(RuntimeError){ raise(RuntimeError, error_msg) }
+      end
+      test.run
+
+      assert_not_nil error
+      assert_kind_of RuntimeError, error
+      assert_equal error_msg, error.message
+    end
+
   end
 
   class AssertNothingRaisedTests < Assert::Context


### PR DESCRIPTION
The goal here is to be able to do further assertions against any
raised exception while still explicitly asserting a specific kind
of exception was raised.

@jcredding ready for review