### PR TITLE
debug mode: bench showing debug msg immediately; show timing on finish

### DIFF
--- a/lib/assert/assert_runner.rb
+++ b/lib/assert/assert_runner.rb
@@ -10,7 +10,7 @@ module Assert
 
     def initialize(config, test_paths, test_options)
       @config = config
-      Assert::CLI.bench('Apply settings') do
+      Assert::CLI.bench('Applying settings') do
         apply_user_settings
         apply_local_settings
         apply_env_settings
@@ -25,7 +25,7 @@ module Assert
     def init(test_files, test_dir)
       # load any test helper file
       if test_dir && (h = File.join(test_dir, self.config.test_helper)) && File.exists?(h)
-        Assert::CLI.bench('Require test helper'){ require h }
+        Assert::CLI.bench('Requiring test helper'){ require h }
       end
 
       if self.config.list
@@ -38,7 +38,7 @@ module Assert
       runner.before_load(test_files)
       suite.before_load(test_files)
       view.before_load(test_files)
-      Assert::CLI.bench("Require #{test_files.size} test files") do
+      Assert::CLI.bench("Requiring #{test_files.size} test files") do
         test_files.each{ |p| require p }
       end
       if self.config.debug

--- a/lib/assert/cli.rb
+++ b/lib/assert/cli.rb
@@ -11,16 +11,25 @@ module Assert
       args.include?('-d') || args.include?('--debug')
     end
 
-    def self.debug_msg(msg, time_in_ms = nil)
-      "[DEBUG] #{msg}#{" (#{time_in_ms} ms)" if time_in_ms}"
+    def self.debug_msg(msg)
+      "[DEBUG] #{msg}"
     end
 
-    def self.bench(msg, &block)
+    def self.debug_start_msg(msg)
+      debug_msg("#{msg}...".ljust(30))
+    end
+
+    def self.debug_finish_msg(time_in_ms)
+      " (#{time_in_ms} ms)"
+    end
+
+    def self.bench(start_msg, &block)
       if !Assert.config.debug
         block.call; return
       end
+      print debug_start_msg(start_msg)
       RoundedMillisecondTime.new(Benchmark.measure(&block).real).tap do |time_in_ms|
-        puts debug_msg(msg, time_in_ms)
+        puts debug_finish_msg(time_in_ms)
       end
     end
 


### PR DESCRIPTION
This addresses issue 256.  On test suites that are large (many test
files to require or complicated env setup in the test helper), debug
mode is only somewhat helpful.  On the longer init steps (ie requiring
the test helper and requiring the test files) assert would just stare
blankly at you while stuff was happening but you didn't know what
it was doing.  Only once the step was complete did you know what it
was doing.  This is not great UX.

This updates the bench logic to pring the debug msg immediately to
show that this step has begun and we are waiting on it.  Then
when the step is done the timing info is displayed as before.  This
lets the developer see that something is going on and start mentally
estimating how long it has taken so far.

This also justifies the output so the timing info is easier to read.
Again, just trying to improve the UX a bit.

Closes #256 

@jcredding ready for review.  This was driving me insane on our big app.  I was wondering why the test suite was taking so long to start so I reran in debug mode.  Then assert just stared at me while something was going on (but I didn't know what) (spoiler: it was taking over 30s to require all the test files).