### PR TITLE
stubs: call to original method using `Assert.stub_send`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ myobj.mymeth(123)
   # => StubError: arity mismatch
 Assert.stub(myobj, :mymeth).with(123){ 'stub-meth' }
   # => StubError: arity mismatch
+Assert.stub_send(myobj, :mymeth) # call to the original method post-stub
+  # => 'meth'
 
 Assert.stub(myobj, :myval){ 'stub-meth' }
   # => StubError: arity mismatch
@@ -99,6 +101,10 @@ myobj.myval(123)
   # => '123'
 myobj.myval(456)
   # => StubError: `myval(456)` not stubbed.
+Assert.stub_send(myobj, :myval, 123) # call to the original method post-stub
+  # => 123
+Assert.stub_send(myobj, :myval, 456)
+  # => 456
 
 Assert.unstub(myobj, :mymeth)
 Assert.unstub(myobj, :myval)

--- a/lib/assert/stub.rb
+++ b/lib/assert/stub.rb
@@ -18,6 +18,10 @@ module Assert
     self.stubs.keys.each{ |key| self.stubs.delete(key).teardown }
   end
 
+  def self.stub_send(object, method_name, *args, &block)
+    self.stubs[Assert::Stub.key(object, method_name)].call_method(*args, &block)
+  end
+
   StubError = Class.new(ArgumentError)
   NotStubbedError = Class.new(StubError)
   StubArityError = Class.new(StubError)
@@ -53,6 +57,14 @@ module Assert
       @lookup = Hash.new{ |hash, key| self.do }
     end
 
+    def do=(block)
+      @do = block || @do
+    end
+
+    def call_method(*args, &block)
+      @method.call(*args, &block)
+    end
+
     def call(*args, &block)
       unless arity_matches?(args)
         message = "arity mismatch on `#{@method_name}`: " \
@@ -74,10 +86,6 @@ module Assert
         raise StubArityError, message
       end
       @lookup[args] = block
-    end
-
-    def do=(block)
-      @do = block || @do
     end
 
     def teardown

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -10,7 +10,7 @@ module Assert
     subject { Assert }
 
     should have_imeths :config, :configure, :view, :suite, :runner
-    should have_imeths :stubs, :stub, :unstub, :unstub!
+    should have_imeths :stubs, :stub, :unstub, :unstub!, :stub_send
 
     should "know its config instance" do
       assert_kind_of Assert::Config, subject.config
@@ -29,10 +29,14 @@ module Assert
 
   class StubTests < UnitTests
     setup do
+      @orig_value = Factory.string
+      @stub_value = Factory.string
+
       @myclass = Class.new do
-        def mymeth; 'meth'; end
+        def initialize(value); @value = value; end
+        def mymeth; @value; end
       end
-      @myobj = @myclass.new
+      @myobj = @myclass.new(@orig_value)
     end
 
     should "build a stub" do
@@ -49,31 +53,31 @@ module Assert
     should "set the stub's do block if given a block" do
       Assert.stub(@myobj, :mymeth)
       assert_raises(NotStubbedError){ @myobj.mymeth }
-      Assert.stub(@myobj, :mymeth){ 'mymeth' }
-      assert_equal 'mymeth', @myobj.mymeth
+      Assert.stub(@myobj, :mymeth){ @stub_value }
+      assert_equal @stub_value, @myobj.mymeth
     end
 
     should "teardown stubs" do
-      assert_equal 'meth', @myobj.mymeth
+      assert_equal @orig_value, @myobj.mymeth
       Assert.unstub(@myobj, :mymeth)
-      assert_equal 'meth', @myobj.mymeth
+      assert_equal @orig_value, @myobj.mymeth
 
-      assert_equal 'meth', @myobj.mymeth
-      Assert.stub(@myobj, :mymeth){ 'mymeth' }
-      assert_equal 'mymeth', @myobj.mymeth
+      assert_equal @orig_value, @myobj.mymeth
+      Assert.stub(@myobj, :mymeth){ @stub_value }
+      assert_equal @stub_value, @myobj.mymeth
       Assert.unstub(@myobj, :mymeth)
-      assert_equal 'meth', @myobj.mymeth
+      assert_equal @orig_value, @myobj.mymeth
     end
 
     should "know and teardown all stubs" do
-      assert_equal 'meth', @myobj.mymeth
+      assert_equal @orig_value, @myobj.mymeth
 
-      Assert.stub(@myobj, :mymeth){ 'mymeth' }
-      assert_equal 'mymeth', @myobj.mymeth
+      Assert.stub(@myobj, :mymeth){ @stub_value }
+      assert_equal @stub_value, @myobj.mymeth
       assert_equal 1, Assert.stubs.size
 
       Assert.unstub!
-      assert_equal 'meth', @myobj.mymeth
+      assert_equal @orig_value, @myobj.mymeth
       assert_empty Assert.stubs
     end
 
@@ -89,6 +93,13 @@ module Assert
 
       context_class.run_teardowns('scope')
       assert_empty Assert.stubs
+    end
+
+    should "be able to call a stub's original method" do
+      Assert.stub(@myobj, :mymeth){ @stub_value }
+
+      assert_equal @stub_value, @myobj.mymeth
+      assert_equal @orig_value, Assert.stub_send(@myobj, :mymeth)
     end
 
   end


### PR DESCRIPTION
One shortcoming of using stubs was that it was difficult to call
the original method you were stubbing within your stub.

For example, say you wanted to stub a method just to spy on what it was
being called with.  In this case, you don't want to change what the
method returns, you just want to capture the args it was called with.
You would setup a stub like:

```ruby
meth_called_with = []
Assert.stub(myobj, :meth) do |*args|
  meth_called_with = args
  # err, what to return??
end
```

The problem is what do you return from this stub?  Some fake value?
It is even worse when stubbing the `:new` method:

```ruby
obj_init_with = []
Assert.stub(myobj, :new) do |*args|
  obj_init_with = args
  # err, what to return??  can't call myobj.new b/c of the stub.
end
```

To address this problem, there is a new singleton method: `Asset.stub_send`
to allow calling the original stubbed method from inside a stub.  Using this,
our stub of the `:new` method is now possible:

```ruby
obj_init_with = []
Assert.stub(myobj, :new) do |*args|
  obj_init_with = args
  # calls the non-stubbed `new` method w/ given args
  Assert.stub_send(myobj, :new, *args)
end
```

This gives you the best of both worlds: you get to spy on the args
your object was initialized with but don't have to create some
janky test double to return so you stub won't break your code.
You can return what would normally be returned if there was no
stub.

Note: I chose to name the method `stub_send` b/c its signature feels
like calling the normal `send` method.  I originally considered
calling it `stub_super` b/c it felt like I wanted to "super" to the
original method in my stub but we decided to keep that name available
for specialized stubbing where you can stub `super` calls within
methods.

Note also: this does a few minor cleanups to the related tests to
make things clearer and to add some missing regression method tests.

@jcredding ready for review.  I know this has plagued us some in testing our big app.  What do you think?  You cool with the naming and UX on this?  For reference, I ran into stubbing the new method this morning on some app tests and decided to rage-address this issue. :smile: 