### PR TITLE
stubs: have stub errors use the backtrace of the original caller

### DIFF
--- a/lib/assert/stub.rb
+++ b/lib/assert/stub.rb
@@ -4,22 +4,28 @@ module Assert
     @stubs ||= {}
   end
 
-  def self.stub(*args, &block)
-    (self.stubs[Assert::Stub.key(*args)] ||= Assert::Stub.new(*args)).tap do |s|
-      s.do = block
-    end
+  def self.stub(obj, meth, &block)
+    (self.stubs[Assert::Stub.key(obj, meth)] ||= begin
+      orig_caller = caller
+      Assert::Stub.new(obj, meth, orig_caller)
+    end).tap{ |s| s.do = block }
   end
 
-  def self.unstub(*args)
-    (self.stubs.delete(Assert::Stub.key(*args)) || Assert::Stub::NullStub.new).teardown
+  def self.unstub(obj, meth)
+    (self.stubs.delete(Assert::Stub.key(obj, meth)) || Assert::Stub::NullStub.new).teardown
   end
 
   def self.unstub!
     self.stubs.keys.each{ |key| self.stubs.delete(key).teardown }
   end
 
-  def self.stub_send(object, method_name, *args, &block)
-    self.stubs[Assert::Stub.key(object, method_name)].call_method(*args, &block)
+  def self.stub_send(obj, meth, *args, &block)
+    orig_caller = caller
+    stub = self.stubs.fetch(Assert::Stub.key(obj, meth)) do
+      msg = "`#{meth}` not stubbed"
+      raise NotStubbedError.new(msg).tap{ |e| e.set_backtrace(orig_caller) }
+    end
+    stub.call_method(args, &block)
   end
 
   StubError = Class.new(ArgumentError)
@@ -38,52 +44,49 @@ module Assert
 
     attr_reader :method_name, :name, :ivar_name, :do
 
-    def initialize(object, method_name, &block)
+    def initialize(object, method_name, orig_caller = nil, &block)
+      orig_caller ||= caller
       @metaclass = class << object; self; end
       @method_name = method_name.to_s
       @name = "__assert_stub__#{object.object_id}_#{@method_name}"
       @ivar_name = "@__assert_stub_#{object.object_id}_" \
                    "#{@method_name.to_sym.object_id}"
 
-      setup(object)
+      setup(object, orig_caller)
 
-      @do = block || Proc.new do |*args, &block|
-        err_msg = "#{inspect_call(args)} not stubbed."
-        inspect_lookup_stubs.tap do |stubs|
-          err_msg += "\nStubs:\n#{stubs}" if !stubs.empty?
-        end
-        raise NotStubbedError, err_msg
-      end
-      @lookup = Hash.new{ |hash, key| self.do }
+      @do     = block
+      @lookup = {}
     end
 
     def do=(block)
       @do = block || @do
     end
 
-    def call_method(*args, &block)
+    def call_method(args, &block)
       @method.call(*args, &block)
     end
 
-    def call(*args, &block)
+    def call(args, orig_caller = nil, &block)
+      orig_caller ||= caller
       unless arity_matches?(args)
-        message = "arity mismatch on `#{@method_name}`: " \
-                  "expected #{number_of_args(@method.arity)}, " \
-                  "called with #{args.size}"
-        raise StubArityError, message
+        msg = "arity mismatch on `#{@method_name}`: " \
+              "expected #{number_of_args(@method.arity)}, " \
+              "called with #{args.size}"
+        raise StubArityError.new(msg).tap{ |e| e.set_backtrace(orig_caller) }
       end
-      @lookup[args].call(*args, &block)
+      lookup(args, orig_caller).call(*args, &block)
     rescue NotStubbedError => exception
       @lookup.rehash
-      @lookup[args].call(*args, &block)
+      lookup(args, orig_caller).call(*args, &block)
     end
 
     def with(*args, &block)
+      orig_caller = caller
       unless arity_matches?(args)
-        message = "arity mismatch on `#{@method_name}`: " \
-                  "expected #{number_of_args(@method.arity)}, " \
-                  "stubbed with #{args.size}"
-        raise StubArityError, message
+        msg = "arity mismatch on `#{@method_name}`: " \
+              "expected #{number_of_args(@method.arity)}, " \
+              "stubbed with #{args.size}"
+        raise StubArityError.new(msg).tap{ |e| e.set_backtrace(orig_caller) }
       end
       @lookup[args] = block
     end
@@ -103,9 +106,10 @@ module Assert
 
     protected
 
-    def setup(object)
+    def setup(object, orig_caller)
       unless object.respond_to?(@method_name)
-        raise StubError, "#{object.inspect} does not respond to `#{@method_name}`"
+        msg = "#{object.inspect} does not respond to `#{@method_name}`"
+        raise StubError.new(msg).tap{ |e| e.set_backtrace(orig_caller) }
       end
       is_constant = object.kind_of?(Module)
       local_object_methods = object.methods(false).map(&:to_s)
@@ -126,12 +130,24 @@ module Assert
       Assert.instance_variable_set(@ivar_name, self)
       @metaclass.class_eval <<-stub_method
         def #{@method_name}(*args, &block)
-          Assert.instance_variable_get("#{@ivar_name}").call(*args, &block)
+          Assert.instance_variable_get("#{@ivar_name}").call(args, caller, &block)
         end
       stub_method
     end
 
     private
+
+    def lookup(args, orig_caller)
+      @lookup.fetch(args) do
+        self.do || begin
+          msg = "#{inspect_call(args)} not stubbed."
+          inspect_lookup_stubs.tap do |stubs|
+            msg += "\nStubs:\n#{stubs}" if !stubs.empty?
+          end
+          raise NotStubbedError.new(msg).tap{ |e| e.set_backtrace(orig_caller) }
+        end
+      end
+    end
 
     def arity_matches?(args)
       return true if @method.arity == args.size # mandatory args

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -96,6 +96,8 @@ module Assert
     end
 
     should "be able to call a stub's original method" do
+      assert_raises(NotStubbedError){ Assert.stub_send(@myobj, :mymeth) }
+
       Assert.stub(@myobj, :mymeth){ @stub_value }
 
       assert_equal @stub_value, @myobj.mymeth

--- a/test/unit/stub_tests.rb
+++ b/test/unit/stub_tests.rb
@@ -42,9 +42,7 @@ class Assert::Stub
     end
 
     should "complain when called if no do block was given" do
-      assert_raises Assert::NotStubbedError do
-        @myobj.mymeth
-      end
+      assert_raises(Assert::NotStubbedError){ @myobj.mymeth }
 
       subject.do = proc{ 'mymeth' }
       assert_nothing_raised do
@@ -57,9 +55,7 @@ class Assert::Stub
     end
 
     should "complain if stubbing a method that the object doesn't respond to" do
-      assert_raises Assert::StubError do
-        Assert::Stub.new(@myobj, :some_other_meth)
-      end
+      assert_raises(Assert::StubError){ Assert::Stub.new(@myobj, :some_other_meth) }
     end
 
     should "complain if stubbed and called with no `do` proc given" do
@@ -193,46 +189,46 @@ class Assert::Stub
 
       # no args
       stub = Assert::Stub.new(@myobj, :mymeth){ 'mymeth' }
-      assert_equal 'mymeth', stub.call
-      assert_equal 'meth',   stub.call_method
+      assert_equal 'mymeth', stub.call([])
+      assert_equal 'meth',   stub.call_method([])
 
       # static args
       stub = Assert::Stub.new(@myobj, :myval){ |val| val.to_s }
-      assert_equal '1', stub.call(1)
-      assert_equal 1,   stub.call_method(1)
-      assert_equal '2', stub.call(2)
-      assert_equal 2,   stub.call_method(2)
+      assert_equal '1', stub.call([1])
+      assert_equal 1,   stub.call_method([1])
+      assert_equal '2', stub.call([2])
+      assert_equal 2,   stub.call_method([2])
       stub.with(2){ 'two' }
-      assert_equal 'two', stub.call(2)
-      assert_equal 2,     stub.call_method(2)
+      assert_equal 'two', stub.call([2])
+      assert_equal 2,     stub.call_method([2])
 
       # dynamic args
       stub = Assert::Stub.new(@myobj, :myargs){ |*args| args.join(',') }
-      assert_equal '1,2',   stub.call(1,2)
-      assert_equal [1,2],   stub.call_method(1,2)
-      assert_equal '3,4,5', stub.call(3,4,5)
-      assert_equal [3,4,5], stub.call_method(3,4,5)
+      assert_equal '1,2',   stub.call([1,2])
+      assert_equal [1,2],   stub.call_method([1,2])
+      assert_equal '3,4,5', stub.call([3,4,5])
+      assert_equal [3,4,5], stub.call_method([3,4,5])
       stub.with(3,4,5){ 'three-four-five' }
-      assert_equal 'three-four-five', stub.call(3,4,5)
-      assert_equal [3,4,5],           stub.call_method(3,4,5)
+      assert_equal 'three-four-five', stub.call([3,4,5])
+      assert_equal [3,4,5],           stub.call_method([3,4,5])
 
       # mixed static/dynamic args
       stub = Assert::Stub.new(@myobj, :myvalargs){ |*args| args.join(',') }
-      assert_equal '1,2,3',    stub.call(1,2,3)
-      assert_equal [1,2, [3]], stub.call_method(1,2,3)
-      assert_equal '3,4,5',    stub.call(3,4,5)
-      assert_equal [3,4,[5]],  stub.call_method(3,4,5)
+      assert_equal '1,2,3',    stub.call([1,2,3])
+      assert_equal [1,2, [3]], stub.call_method([1,2,3])
+      assert_equal '3,4,5',    stub.call([3,4,5])
+      assert_equal [3,4,[5]],  stub.call_method([3,4,5])
       stub.with(3,4,5){ 'three-four-five' }
-      assert_equal 'three-four-five', stub.call(3,4,5)
-      assert_equal [3,4,[5]],         stub.call_method(3,4,5)
+      assert_equal 'three-four-five', stub.call([3,4,5])
+      assert_equal [3,4,[5]],         stub.call_method([3,4,5])
 
       # blocks
       blkcalled = false
       blk = proc{ blkcalled = true }
       stub = Assert::Stub.new(@myobj, :myblk){ blkcalled = 'true' }
-      stub.call(&blk)
+      stub.call([], &blk)
       assert_equal 'true', blkcalled
-      stub.call_method(&blk)
+      stub.call_method([], &blk)
       assert_equal true, blkcalled
     end
 
@@ -271,7 +267,7 @@ class Assert::Stub
     subject{ @stub }
 
     should "not raise a stub error when called" do
-      assert_nothing_raised{ @stub.call(@arg) }
+      assert_nothing_raised{ @stub.call([@arg]) }
     end
 
   end


### PR DESCRIPTION
Previously, the backtraces of the stub errors would be nested in
the internals of the stubbing implementation.  This is really
confusing b/c you really want the backtrace to point to where the
problem originated so that the user is shown what they need to change.

This updates the stubbing internals to capture the original caller
for any calls that may raise stubbing errors.  This original caller
is then used as the backtrace for all stub errors.

Note: this also makes the newly added `stub_send` raise a `NotStubbedError`
when trying to call the original method on something that hasn't
been stubbed.  This is consistent with the other stub methods and
should have been done in PR 258 where this method was originally
added but was missed.

See #258 for reference.

@jcredding ready for review.  I noticed this annoyance when working on the `stub_send` method.