### PR TITLE
apply runner seed whether running single or multiple tests

### DIFF
--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -21,11 +21,11 @@ module Assert
       self.view.on_start
 
       if self.single_test?
-        self.view.puts "Running test: #{self.single_test_file_line}"
+        self.view.print "Running test: #{self.single_test_file_line}"
       elsif self.tests?
-        self.view.puts "Running tests in random order, " \
-                       "seeded with \"#{self.runner_seed}\""
+        self.view.print "Running tests in random order"
       end
+      self.view.puts ", seeded with \"#{self.runner_seed}\""
 
       begin
         self.suite.start_time = Time.now
@@ -76,11 +76,11 @@ module Assert
     private
 
     def tests_to_run
+      srand self.runner_seed
       if self.single_test?
         [ self.suite.tests.find{ |t| t.file_line == self.single_test_file_line }
         ].compact
       else
-        srand self.runner_seed
         self.suite.tests.sort.sort_by{ rand self.suite.tests.size }
       end
     end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -129,7 +129,8 @@ class Assert::Runner
       @view_output.gsub!(/./, '')
       subject.run
 
-      exp = "Running test: #{subject.single_test_file_line}\n"
+      exp = "Running test: #{subject.single_test_file_line}, " \
+            "seeded with \"#{subject.runner_seed}\"\n"
       assert_includes exp, @view_output
     end
 


### PR DESCRIPTION
When adding the single test mode back in PR 250, I ended up only
applying the runner seed if you were running in non-single test mode
(ie not using the `-t` option flag).  On the surface this kinda sense
b/c the seed drives the test order randomization. If you are only
running one test you don't need test randomization.

However, the intent is that this seed also drives the pseudo random
generator (`srand`). This impacts the values that are generated by
Assert's factories. We need to always apply the seed info so that you
can re-run a single test and get the same factory values out.  This
update ensures that whether running in single or multi test mode, the
seed value is always applied.

![image-4t7q0](https://cloud.githubusercontent.com/assets/82110/14930746/f61912ee-0e2b-11e6-8091-6cd91bb6661e.jpg)

See #250 for reference.
Closes #262.

@jcredding ready for review
@nweathersbee FYI.
