### PR TITLE
accumulate: prep notes for accumulating test results

### DIFF
--- a/lib/assert/config_helpers.rb
+++ b/lib/assert/config_helpers.rb
@@ -18,15 +18,18 @@ module Assert
       self.config.single_test_file_line
     end
 
+    # TODO: remove the count method
     def count(type)
       self.config.suite.count(type)
     end
 
     def tests?
+      # TODO: remove `count` method: `self.suite.test_count`
       self.count(:tests) > 0
     end
 
     def all_pass?
+      # TODO: remove `count` method: `self.suite.pass_result_count` ...
       self.count(:pass) == self.count(:results)
     end
 
@@ -53,6 +56,7 @@ module Assert
     # return a list of result symbols that have actually occurred
     def ocurring_result_types
       @result_types ||= [:pass, :fail, :ignore, :skip, :error].select do |sym|
+        # TODO: remove `count` method: `self.suite.send("#{sym}_result_count")`
         self.count(sym) > 0
       end
     end

--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -9,6 +9,8 @@ module Assert
   class DefaultView < Assert::View
     include Assert::ViewHelpers::Ansi
 
+    # TODO: mixin the ansi view helper mixin
+
     # setup options and their default values
 
     option 'styled',        true

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -17,8 +17,8 @@ module Assert
 
     def run
       self.on_start
-      self.suite.on_start
-      self.view.on_start
+      self.suite.on_start # TODO: reset test/result counts
+      self.view.on_start  # TODO: reset display result list
 
       if self.single_test?
         self.view.print "Running test: #{self.single_test_file_line}"
@@ -32,14 +32,14 @@ module Assert
         self.suite.setups.each(&:call)
         tests_to_run.each do |test|
           self.before_test(test)
-          self.suite.before_test(test)
+          self.suite.before_test(test) # TODO: increment test count; optionally store test run
           self.view.before_test(test)
           test.run do |result|
             self.on_result(result)
-            self.suite.on_result(result)
-            self.view.on_result(result)
+            self.suite.on_result(result) # TODO: increment result count
+            self.view.on_result(result)  # TODO: optionally store result data for display
           end
-          self.after_test(test)
+          self.after_test(test) # TODO: delete suite test; optionally store test run
           self.suite.after_test(test)
           self.view.after_test(test)
         end
@@ -52,6 +52,7 @@ module Assert
         raise(err)
       end
 
+      # TODO: remove `count` method: `self.suite.fail_result_count`
       (self.suite.count(:fail) + self.suite.count(:error)).tap do
         self.view.on_finish
         self.suite.on_finish

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -11,6 +11,10 @@ module Assert
     # A suite is a set of tests to run.  When a test class subclasses
     # the Context class, that test class is pushed to the suite.
 
+    # TODO: just store "suite tests" and "suite results"
+    # both will be "structs" of just the data needed for presentation
+    # don't store all of the tests and all results on the tests
+    # unshift tests as they are run (for later garbage collection)
     attr_reader :config, :tests, :test_methods, :setups, :teardowns
     attr_accessor :start_time, :end_time
 
@@ -48,6 +52,7 @@ module Assert
       get_rate(self.result_count, self.run_time)
     end
 
+    # TODO: replace this count method with explict count methods for each type
     def count(thing)
       if thing == :tests
         test_count

--- a/lib/assert/test.rb
+++ b/lib/assert/test.rb
@@ -48,9 +48,11 @@ module Assert
     def run_time;  @run_time  ||= (@build_data[:run_time]                 || 0);        end
 
     def total_result_count
+    # TODO: won't be needed b/c we won't be storing this state on the test
       @total_result_count ||= (@build_data[:total_result_count] || 0)
     end
 
+    # TODO: won't be needed b/c we won't be storing this state on the test
     Assert::Result.types.keys.each do |type|
       n = result_count_meth(type)
       define_method(n) do
@@ -63,6 +65,7 @@ module Assert
     def code;         @code         ||= @build_data[:code];         end
 
     def data
+      # TODO: don't merge result count data, that state will be stored on the suite
       { :file_line => self.file_line.to_s,
         :name      => self.name.to_s,
         :output    => self.output.to_s,
@@ -74,10 +77,12 @@ module Assert
     def file;          self.file_line.file;     end
     def line_number;   self.file_line.line;     end
 
+    # TODO: should be able to remove this once this state is on the suite
     def result_rate
       get_rate(self.result_count, self.run_time)
     end
 
+    # TODO: remove once this state is stored on the suite
     def result_count(type = nil)
       if Assert::Result.types.keys.include?(type)
         self.send(result_count_meth(type))
@@ -87,10 +92,14 @@ module Assert
     end
 
     def capture_result(result, callback)
+      # TODO: don't store state on run, just call the callback
+      # let the suite accumulate the test/result data
       self.results << result
       self.total_result_count += 1
       n = result_count_meth(result.to_sym)
       instance_variable_set("@#{n}", (instance_variable_get("@#{n}") || 0) + 1)
+
+      # TODO: this should be all we need to do in the end
       callback.call(result)
     end
 
@@ -107,6 +116,7 @@ module Assert
       @results
     end
 
+    # TODO: don't store results on the test class, result data will be stored on the suite
     Assert::Result.types.each do |name, klass|
       define_method "#{name}_results" do
         self.results.select{|r| r.kind_of?(klass) }
@@ -118,6 +128,7 @@ module Assert
     end
 
     def inspect
+      # TODO: remove :results from this
       attributes_string = ([ :name, :context_info, :results ].collect do |attr|
         "@#{attr}=#{self.send(attr).inspect}"
       end).join(" ")
@@ -175,6 +186,7 @@ module Assert
       StringIO.new(self.output, "a+")
     end
 
+    # TODO: should be able to remove this once this state is on the suite
     def result_count_data(seed)
       Assert::Result.types.keys.inject(seed) do |d, t|
         d[result_count_meth(t)] = self.send(result_count_meth(t))
@@ -182,10 +194,12 @@ module Assert
       end
     end
 
+    # TODO: should be able to remove this once this state is on the suite
     def result_count_meth(type)
       self.class.result_count_meth(type)
     end
 
+    # TODO: should be able to remove this once this state is on the suite
     def get_rate(count, time)
       time == 0 ? 0.0 : (count.to_f / time.to_f)
     end

--- a/lib/assert/view_helpers.rb
+++ b/lib/assert/view_helpers.rb
@@ -28,11 +28,13 @@ module Assert
 
     module InstanceMethods
 
+      # TODO: get from the suite as test won't store this data
       # get the formatted run time for an idividual test
       def test_run_time(test, format = '%.6f')
         format % test.run_time
       end
 
+      # TODO: get from the suite as test won't store this data
       # get the formatted result rate for an individual test
       def test_result_rate(test, format = '%.6f')
         format % test.result_rate
@@ -50,10 +52,12 @@ module Assert
         "assert -t #{test_id.gsub(Dir.pwd, '.')}"
       end
 
+      # TODO: remove `count` method
       def test_count_statement
         "#{self.count(:tests)} test#{'s' if self.count(:tests) != 1}"
       end
 
+      # TODO: remove `count` method
       def result_count_statement
         "#{self.count(:results)} result#{'s' if self.count(:results) != 1}"
       end
@@ -99,6 +103,7 @@ module Assert
 
     end
 
+    # TODO: move to an ansi view helper mixin
     module Ansi
 
       # Table of supported styles/codes (http://en.wikipedia.org/wiki/ANSI_escape_code)


### PR DESCRIPTION
I made a bunch of notes of things to change when switching to
accumulating test results.  Currently we store every test object
and every result generated by every test.  This is inefficient
for calculating summary info at the end of the test run and is
unnecessary as we don't need to store all of this data.  Plus
the overhead on large test suites is significant.

In this overall effort, I plan on switching to not storing every
test.  Instead, tests will be shifted off as they are run and
only result data needed for presentation will be accumulated.
This should save memory not storing as many objects and should
make rendering summary presentation data more efficient.

@jcredding copy of #264 made against a feature branch - FYI.