### PR TITLE
accumulate: rework suite to abstract the tests to run

### DIFF
--- a/lib/assert/config_helpers.rb
+++ b/lib/assert/config_helpers.rb
@@ -18,6 +18,9 @@ module Assert
       self.config.single_test_file_line
     end
 
+    def tests_to_run?;      self.config.suite.tests_to_run?;      end
+    def tests_to_run_count; self.config.suite.tests_to_run_count; end
+
     # TODO: remove the count method
     def count(type)
       self.config.suite.count(type)

--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -39,11 +39,11 @@ module Assert
           self.suite.test_methods << klass_method_name
         end
 
-        self.suite.tests << Test.for_method(
+        self.suite.on_test(Test.for_method(
           method_name.to_s,
           ContextInfo.new(self, nil, caller.first),
           self.suite.config
-        )
+        ))
       end
     end
 

--- a/lib/assert/context/test_dsl.rb
+++ b/lib/assert/context/test_dsl.rb
@@ -13,12 +13,12 @@ class Assert::Context
         instance_eval(&desc_or_macro)
       elsif block_given?
         # create a test from the given code block
-        self.suite.tests << Assert::Test.for_block(
+        self.suite.on_test(Assert::Test.for_block(
           desc_or_macro.kind_of?(Assert::Macro) ? desc_or_macro.name : desc_or_macro,
           Assert::ContextInfo.new(self, called_from, first_caller || caller.first),
           self.suite.config,
           &block
-        )
+        ))
       else
         test_eventually(desc_or_macro, called_from, first_caller || caller.first, &block)
       end
@@ -27,12 +27,12 @@ class Assert::Context
     def test_eventually(desc_or_macro, called_from = nil, first_caller = nil, &block)
       # create a test from a proc that just skips
       ci = Assert::ContextInfo.new(self, called_from, first_caller || caller.first)
-      self.suite.tests << Assert::Test.for_block(
+      self.suite.on_test(Assert::Test.for_block(
         desc_or_macro.kind_of?(Assert::Macro) ? desc_or_macro.name : desc_or_macro,
         ci,
         self.suite.config,
         &proc { skip('TODO', ci.called_from) }
-      )
+      ))
     end
     alias_method :test_skip, :test_eventually
 

--- a/lib/assert/default_suite.rb
+++ b/lib/assert/default_suite.rb
@@ -2,9 +2,22 @@ require 'assert/suite'
 
 module Assert
 
+  # TODO: make this comment/description more accurate once accumulation work done
   # This is the default suite used by assert.  It stores test/result data in-memory.
 
   class DefaultSuite < Assert::Suite
+
+    attr_reader :tests
+
+    def initialize(config)
+      super
+      @tests = []
+    end
+
+    def tests_to_run;       @tests;          end
+    def tests_to_run?;      @tests.size > 0; end
+    def tests_to_run_count; @tests.size;     end
+    def clear_tests_to_run; @tests.clear;    end
 
     # Test data
 
@@ -57,7 +70,9 @@ module Assert
 
     # Callbacks
 
-    # no custom callbacks
+    def on_test(test)
+      @tests << test
+    end
 
   end
 

--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -9,8 +9,6 @@ module Assert
   class DefaultView < Assert::View
     include Assert::ViewHelpers::Ansi
 
-    # TODO: mixin the ansi view helper mixin
-
     # setup options and their default values
 
     option 'styled',        true
@@ -24,7 +22,7 @@ module Assert
     end
 
     def after_load
-      puts "Loaded suite (#{test_count_statement})"
+      puts "Loaded suite (#{tests_to_run_count_statement})"
     end
 
     def on_start

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -22,14 +22,18 @@ module Assert
 
       if self.single_test?
         self.view.print "Running test: #{self.single_test_file_line}"
-      elsif self.tests?
+      elsif self.tests_to_run?
         self.view.print "Running tests in random order"
       end
-      self.view.puts ", seeded with \"#{self.runner_seed}\""
+      if self.tests_to_run?
+        self.view.puts ", seeded with \"#{self.runner_seed}\""
+      end
 
       begin
         self.suite.start_time = Time.now
         self.suite.setups.each(&:call)
+        # TODO: tests_to_run.tap{ self.suite.clear_tests_to_run }.each
+        # TODO: maybe while/pop off tests_to_run so tests get gc'd
         tests_to_run.each do |test|
           self.before_test(test)
           self.suite.before_test(test) # TODO: increment test count; optionally store test run
@@ -79,10 +83,10 @@ module Assert
     def tests_to_run
       srand self.runner_seed
       if self.single_test?
-        [ self.suite.tests.find{ |t| t.file_line == self.single_test_file_line }
+        [ self.suite.tests_to_run.find{ |t| t.file_line == self.single_test_file_line }
         ].compact
       else
-        self.suite.tests.sort.sort_by{ rand self.suite.tests.size }
+        self.suite.tests_to_run.sort.sort_by{ rand self.suite.tests_to_run_count }
       end
     end
 

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -11,16 +11,11 @@ module Assert
     # A suite is a set of tests to run.  When a test class subclasses
     # the Context class, that test class is pushed to the suite.
 
-    # TODO: just store "suite tests" and "suite results"
-    # both will be "structs" of just the data needed for presentation
-    # don't store all of the tests and all results on the tests
-    # unshift tests as they are run (for later garbage collection)
-    attr_reader :config, :tests, :test_methods, :setups, :teardowns
+    attr_reader :config, :test_methods, :setups, :teardowns
     attr_accessor :start_time, :end_time
 
     def initialize(config)
       @config       = config
-      @tests        = []
       @test_methods = []
       @setups       = []
       @teardowns    = []
@@ -39,6 +34,11 @@ module Assert
       self.teardowns << (block || proc{})
     end
     alias_method :shutdown, :teardown
+
+    def tests_to_run;       end
+    def tests_to_run?;      end
+    def tests_to_run_count; end
+    def clear_tests_to_run; end
 
     def run_time
       @end_time - @start_time
@@ -95,6 +95,7 @@ module Assert
     # will be called by the test runner
 
     def before_load(test_files); end
+    def on_test(test);           end
     def after_load;              end
     def on_start;                end
     def before_test(test);       end

--- a/lib/assert/view_helpers.rb
+++ b/lib/assert/view_helpers.rb
@@ -52,9 +52,8 @@ module Assert
         "assert -t #{test_id.gsub(Dir.pwd, '.')}"
       end
 
-      # TODO: remove `count` method
-      def test_count_statement
-        "#{self.count(:tests)} test#{'s' if self.count(:tests) != 1}"
+      def tests_to_run_count_statement
+        "#{self.tests_to_run_count} test#{'s' if self.tests_to_run_count != 1}"
       end
 
       # TODO: remove `count` method
@@ -103,7 +102,6 @@ module Assert
 
     end
 
-    # TODO: move to an ansi view helper mixin
     module Ansi
 
       # Table of supported styles/codes (http://en.wikipedia.org/wiki/ANSI_escape_code)

--- a/test/unit/config_helpers_tests.rb
+++ b/test/unit/config_helpers_tests.rb
@@ -23,6 +23,7 @@ module Assert::ConfigHelpers
 
     should have_imeths :runner, :suite, :view
     should have_imeths :runner_seed, :single_test?, :single_test_file_line
+    should have_imeths :tests_to_run?, :tests_to_run_count
     should have_imeths :count, :tests?, :all_pass?
     should have_imeths :formatted_run_time
     should have_imeths :formatted_test_rate, :formatted_result_rate
@@ -50,6 +51,14 @@ module Assert::ConfigHelpers
     should "know its single test file line" do
       exp = subject.config.single_test_file_line
       assert_equal exp, subject.single_test_file_line
+    end
+
+    should "know its tests-to-run attrs" do
+      exp = subject.config.suite.tests_to_run?
+      assert_equal exp, subject.tests_to_run?
+
+      exp = subject.config.suite.tests_to_run_count
+      assert_equal exp, subject.tests_to_run_count
     end
 
     should "know how to count things on the suite" do

--- a/test/unit/default_suite_tests.rb
+++ b/test/unit/default_suite_tests.rb
@@ -18,13 +18,28 @@ class Assert::DefaultSuite
         Factory.test("should ignored", ci){ ignore },
         Factory.test("should skip",    ci){ skip; ignore; assert(1==1) },
         Factory.test("should error",   ci){ raise Exception; ignore; assert(1==1) }
-      ].each{ |test| @suite.tests << test }
+      ].each{ |test| @suite.on_test(test) }
       @suite.tests.each(&:run)
     end
     subject{ @suite }
 
+    should have_readers :tests
+
     should "be a Suite" do
       assert_kind_of Assert::Suite, subject
+    end
+
+    should "know its tests-to-run atts" do
+      assert_equal 6, subject.tests_to_run.size
+      assert_equal 6, subject.tests_to_run_count
+      assert_kind_of Assert::Test, subject.tests.first
+      assert_true subject.tests_to_run?
+
+      subject.clear_tests_to_run
+
+      assert_equal 0, subject.tests_to_run.size
+      assert_equal 0, subject.tests_to_run_count
+      assert_false subject.tests_to_run?
     end
 
     should "know its test and result attrs" do

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -67,7 +67,7 @@ class Assert::Runner
 
       @ci = Factory.context_info(Factory.modes_off_context_class)
       @test = Factory.test("should pass", @ci){ assert(1==1) }
-      @config.suite.tests << @test
+      @config.suite.on_test(@test)
 
       @runner = @runner_class.new(@config)
       @result = @runner.run
@@ -115,7 +115,7 @@ class Assert::Runner
 
     should "run only a single test if a single test is configured" do
       other_test = Factory.test("should also pass", @ci){ assert(1==1) }
-      @config.suite.tests << other_test
+      @config.suite.on_test(other_test)
 
       @config.single_test @test.file_line.to_s
 

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -30,7 +30,7 @@ class Assert::Suite
     end
     subject{ @suite }
 
-    should have_readers :config, :tests, :test_methods
+    should have_readers :config, :test_methods, :setups, :teardowns
     should have_accessors :start_time, :end_time
     should have_imeths :suite, :setup, :startup, :teardown, :shutdown
     should have_imeths :run_time, :test_rate, :result_rate, :count
@@ -40,7 +40,7 @@ class Assert::Suite
     should have_imeths :ordered_results, :reversed_results
     should have_imeths :ordered_results_for_dump, :reversed_results_for_dump
     should have_imeths :result_count
-    should have_imeths :before_load, :after_load
+    should have_imeths :before_load, :on_test, :after_load
     should have_imeths :on_start, :on_finish, :on_interrupt
     should have_imeths :before_test, :after_test, :on_result
 
@@ -48,17 +48,23 @@ class Assert::Suite
       assert_equal @config, subject.config
     end
 
-    should "override the config helper's suite value with itself" do
-      assert_equal subject, subject.suite
-    end
-
     should "default its attrs" do
-      assert_equal [], subject.tests
       assert_equal [], subject.test_methods
       assert_equal [], subject.setups
       assert_equal [], subject.teardowns
 
       assert_equal subject.start_time, subject.end_time
+    end
+
+    should "override the config helper's suite value with itself" do
+      assert_equal subject, subject.suite
+    end
+
+    should "not provide any tests-to-run implementations" do
+      assert_nil subject.tests_to_run
+      assert_nil subject.tests_to_run?
+      assert_nil subject.tests_to_run_count
+      assert_nil subject.clear_tests_to_run
     end
 
     should "know its run time and rates" do

--- a/test/unit/view_helpers_tests.rb
+++ b/test/unit/view_helpers_tests.rb
@@ -57,7 +57,7 @@ module Assert::ViewHelpers
 
     should have_imeths :test_run_time, :test_result_rate
     should have_imeths :captured_output, :re_run_test_cmd
-    should have_imeths :test_count_statement, :result_count_statement
+    should have_imeths :tests_to_run_count_statement, :result_count_statement
     should have_imeths :to_sentence
     should have_imeths :all_pass_result_summary_msg, :result_summary_msg
     should have_imeths :results_summary_sentence
@@ -89,9 +89,9 @@ module Assert::ViewHelpers
       assert_equal exp, subject.re_run_test_cmd(test_id)
     end
 
-    should "know its test count and result count statements" do
-      exp = "#{subject.count(:tests)} test#{'s' if subject.count(:tests) != 1}"
-      assert_equal exp, subject.test_count_statement
+    should "know its tests-to-run count and result count statements" do
+      exp = "#{subject.tests_to_run_count} test#{'s' if subject.tests_to_run_count != 1}"
+      assert_equal exp, subject.tests_to_run_count_statement
 
       exp = "#{subject.count(:results)} result#{'s' if subject.count(:results) != 1}"
       assert_equal exp, subject.result_count_statement


### PR DESCRIPTION
This is part of switching to accumulating test run and result data.
This is specifically prep for removing the `tests` reader on the
suite.  Since we will be accumulating data, there will be no need
to keep a list of all the tests in memory.

I chose to move the storage of tests as an array into the default
suite as opposed to the base suite.  I don't want to force storing
tests in memory on all suites.  Some suites may choose to store
their tests to run some other way.

I chose to add an `on_test` callback for adding tests to the suite.
This follows the callback pattern used for other custom behavior
(ie `on_result`) and removes needing to access the raw list of
tests outside of the suite.

I chose to add a method to clear the tests to run.  This is prep
for clearing out the tests from memory once they have been run so
they can be garbage collected.

Some other really minor stuff:

* I removed the ansi-related comments.  I'm not sure what I originally
  intended with these but I don't want to do that anymore.
* I also added a check to make sure there are tests to run before
  printing the runner seed info - this fixes a bug I introduced
  in a previous effort.  The seed info would print even if there
  were no tests to run and this was unintended.

@jcredding ready for review.