### PR TITLE
accumulate: store/accumulate test/result counts on the suite

### DIFF
--- a/lib/assert/config_helpers.rb
+++ b/lib/assert/config_helpers.rb
@@ -21,19 +21,16 @@ module Assert
     def tests_to_run?;      self.config.suite.tests_to_run?;      end
     def tests_to_run_count; self.config.suite.tests_to_run_count; end
 
-    # TODO: remove the count method
-    def count(type)
-      self.config.suite.count(type)
-    end
-
-    def tests?
-      # TODO: remove `count` method: `self.suite.test_count`
-      self.count(:tests) > 0
-    end
+    def test_count;          self.config.suite.test_count;          end
+    def result_count;        self.config.suite.result_count;        end
+    def pass_result_count;   self.config.suite.pass_result_count;   end
+    def fail_result_count;   self.config.suite.fail_result_count;   end
+    def error_result_count;  self.config.suite.error_result_count;  end
+    def skip_result_count;   self.config.suite.skip_result_count;   end
+    def ignore_result_count; self.config.suite.ignore_result_count; end
 
     def all_pass?
-      # TODO: remove `count` method: `self.suite.pass_result_count` ...
-      self.count(:pass) == self.count(:results)
+      self.pass_result_count == self.result_count
     end
 
     def formatted_run_time(format = '%.6f')
@@ -56,11 +53,10 @@ module Assert
       !!self.config.verbose
     end
 
-    # return a list of result symbols that have actually occurred
+    # return a list of result type symbols that have actually occurred
     def ocurring_result_types
       @result_types ||= [:pass, :fail, :ignore, :skip, :error].select do |sym|
-        # TODO: remove `count` method: `self.suite.send("#{sym}_result_count")`
-        self.count(sym) > 0
+        self.send("#{sym}_result_count") > 0
       end
     end
 

--- a/lib/assert/default_suite.rb
+++ b/lib/assert/default_suite.rb
@@ -7,11 +7,13 @@ module Assert
 
   class DefaultSuite < Assert::Suite
 
+    # TODO: remove once ordered methods are moved to the view
     attr_reader :tests
 
     def initialize(config)
       super
       @tests = []
+      reset_run_data
     end
 
     def tests_to_run;       @tests;          end
@@ -19,7 +21,16 @@ module Assert
     def tests_to_run_count; @tests.size;     end
     def clear_tests_to_run; @tests.clear;    end
 
-    # Test data
+    def test_count;          @test_count;          end
+    def result_count;        @result_count;        end
+    def pass_result_count;   @pass_result_count;   end
+    def fail_result_count;   @fail_result_count;   end
+    def error_result_count;  @error_result_count;  end
+    def skip_result_count;   @skip_result_count;   end
+    def ignore_result_count; @ignore_result_count; end
+
+    # TODO: move all these ordered methods to the view as it is only needed by
+    # the view for presentation purposes
 
     def ordered_tests
       self.tests
@@ -36,12 +47,6 @@ module Assert
     def reversed_tests_by_run_time
       self.ordered_tests_by_run_time.reverse
     end
-
-    def test_count
-      self.tests.size
-    end
-
-    # Result data
 
     def ordered_results
       self.ordered_tests.inject([]){ |results, test| results += test.results }
@@ -64,14 +69,41 @@ module Assert
       self.ordered_results_for_dump.reverse
     end
 
-    def result_count(type = nil)
-      self.tests.inject(0){ |count, test| count += test.result_count(type) }
-    end
-
     # Callbacks
 
     def on_test(test)
       @tests << test
+    end
+
+    def on_start
+      reset_run_data
+    end
+
+    def before_test(test)
+      @test_count += 1
+    end
+
+    def on_result(result)
+      @result_count += 1
+      self.send("increment_#{result.type}_result_count")
+    end
+
+    private
+
+    def increment_pass_result_count;   @pass_result_count   += 1; end
+    def increment_fail_result_count;   @fail_result_count   += 1; end
+    def increment_error_result_count;  @error_result_count  += 1; end
+    def increment_skip_result_count;   @skip_result_count   += 1; end
+    def increment_ignore_result_count; @ignore_result_count += 1; end
+
+    def reset_run_data
+      @test_count          = 0
+      @result_count        = 0
+      @pass_result_count   = 0
+      @fail_result_count   = 0
+      @error_result_count  = 0
+      @skip_result_count   = 0
+      @ignore_result_count = 0
     end
 
   end

--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -49,7 +49,7 @@ module Assert
     end
 
     def on_finish
-      if tests?
+      if self.test_count > 0
         dump_test_results
       end
 

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -17,7 +17,7 @@ module Assert
 
     def run
       self.on_start
-      self.suite.on_start # TODO: reset test/result counts
+      self.suite.on_start
       self.view.on_start  # TODO: reset display result list
 
       if self.single_test?
@@ -36,16 +36,16 @@ module Assert
         # TODO: maybe while/pop off tests_to_run so tests get gc'd
         tests_to_run.each do |test|
           self.before_test(test)
-          self.suite.before_test(test) # TODO: increment test count; optionally store test run
-          self.view.before_test(test)
+          self.suite.before_test(test)
+          self.view.before_test(test) # TODO: optionally store test presentation info
           test.run do |result|
             self.on_result(result)
-            self.suite.on_result(result) # TODO: increment result count
-            self.view.on_result(result)  # TODO: optionally store result data for display
+            self.suite.on_result(result)
+            self.view.on_result(result) # TODO: optionally store result presentation info
           end
-          self.after_test(test) # TODO: delete suite test; optionally store test run
+          self.after_test(test)
           self.suite.after_test(test)
-          self.view.after_test(test)
+          self.view.after_test(test) # TODO: optionally store test presentation info
         end
         self.suite.teardowns.each(&:call)
         self.suite.end_time = Time.now
@@ -56,8 +56,7 @@ module Assert
         raise(err)
       end
 
-      # TODO: remove `count` method: `self.suite.fail_result_count`
-      (self.suite.count(:fail) + self.suite.count(:error)).tap do
+      (self.fail_result_count + self.error_result_count).tap do
         self.view.on_finish
         self.suite.on_finish
         self.on_finish

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -8,6 +8,7 @@ module Assert
 
     TEST_METHOD_REGEX = /^test./.freeze
 
+    # TODO: improve this comment
     # A suite is a set of tests to run.  When a test class subclasses
     # the Context class, that test class is pushed to the suite.
 
@@ -52,26 +53,13 @@ module Assert
       get_rate(self.result_count, self.run_time)
     end
 
-    # TODO: replace this count method with explict count methods for each type
-    def count(thing)
-      if thing == :tests
-        test_count
-      elsif thing == :results
-        result_count
-      elsif thing == :pass   || thing == :passed
-        result_count(:pass)
-      elsif thing == :fail   || thing == :failed
-        result_count(:fail)
-      elsif thing == :error  || thing == :errored
-        result_count(:error)
-      elsif thing == :skip   || thing == :skipped
-        result_count(:skip)
-      elsif thing == :ignore || thing == :ignored
-        result_count(:ignore)
-      else
-        0
-      end
-    end
+    def test_count;          end
+    def result_count;        end
+    def pass_result_count;   end
+    def fail_result_count;   end
+    def error_result_count;  end
+    def skip_result_count;   end
+    def ignore_result_count; end
 
     # Test data
 
@@ -79,7 +67,6 @@ module Assert
     def reversed_tests;             end
     def ordered_tests_by_run_time;  end
     def reversed_tests_by_run_time; end
-    def test_count;                 end
 
     # Result data
 
@@ -87,7 +74,6 @@ module Assert
     def reversed_results;          end
     def ordered_results_for_dump;  end
     def reversed_results_for_dump; end
-    def result_count(type = nil);  end
 
     # Callbacks
 

--- a/lib/assert/view_helpers.rb
+++ b/lib/assert/view_helpers.rb
@@ -56,9 +56,8 @@ module Assert
         "#{self.tests_to_run_count} test#{'s' if self.tests_to_run_count != 1}"
       end
 
-      # TODO: remove `count` method
       def result_count_statement
-        "#{self.count(:results)} result#{'s' if self.count(:results) != 1}"
+        "#{self.result_count} result#{'s' if self.result_count != 1}"
       end
 
       # generate a comma-seperated sentence fragment given a list of items
@@ -72,9 +71,9 @@ module Assert
 
       # generate an appropriate result summary msg for all tests passing
       def all_pass_result_summary_msg
-        if self.count(:results) < 1
+        if self.result_count < 1
           "uhh..."
-        elsif self.count(:results) == 1
+        elsif self.result_count == 1
           "pass"
         else
           "all pass"
@@ -86,7 +85,7 @@ module Assert
         if result_type == :pass && self.all_pass?
           self.all_pass_result_summary_msg
         else
-          "#{self.count(result_type)} #{result_type.to_s}"
+          "#{self.send("#{result_type}_result_count")} #{result_type}"
         end
       end
 

--- a/test/unit/default_suite_tests.rb
+++ b/test/unit/default_suite_tests.rb
@@ -12,17 +12,20 @@ class Assert::DefaultSuite
       @suite  = Assert::DefaultSuite.new(@config)
 
       ci = Factory.context_info(Factory.modes_off_context_class)
-      [ Factory.test("should nothing", ci){ },
+      @tests = [
+        Factory.test("should nothing", ci){ },
         Factory.test("should pass",    ci){ assert(1==1); refute(1==0) },
         Factory.test("should fail",    ci){ ignore; assert(1==0); refute(1==1) },
         Factory.test("should ignored", ci){ ignore },
         Factory.test("should skip",    ci){ skip; ignore; assert(1==1) },
         Factory.test("should error",   ci){ raise Exception; ignore; assert(1==1) }
-      ].each{ |test| @suite.on_test(test) }
+      ]
+      @tests.each{ |test| @suite.on_test(test) }
       @suite.tests.each(&:run)
     end
     subject{ @suite }
 
+    # TODO: remove once ordered methods are moved to the view
     should have_readers :tests
 
     should "be a Suite" do
@@ -42,46 +45,89 @@ class Assert::DefaultSuite
       assert_false subject.tests_to_run?
     end
 
+    should "default its test/result counts" do
+      assert_equal 0, subject.test_count
+      assert_equal 0, subject.result_count
+      assert_equal 0, subject.pass_result_count
+      assert_equal 0, subject.fail_result_count
+      assert_equal 0, subject.error_result_count
+      assert_equal 0, subject.skip_result_count
+      assert_equal 0, subject.ignore_result_count
+    end
+
+    should "increment its test count on `before_test`" do
+      subject.before_test(@tests.sample)
+      assert_equal 1, subject.test_count
+    end
+
+    should "increment its result counts on `on_result`" do
+      subject.on_result(Factory.pass_result)
+      assert_equal 1, subject.result_count
+      assert_equal 1, subject.pass_result_count
+      assert_equal 0, subject.fail_result_count
+      assert_equal 0, subject.error_result_count
+      assert_equal 0, subject.skip_result_count
+      assert_equal 0, subject.ignore_result_count
+
+      subject.on_result(Factory.fail_result)
+      assert_equal 2, subject.result_count
+      assert_equal 1, subject.pass_result_count
+      assert_equal 1, subject.fail_result_count
+      assert_equal 0, subject.error_result_count
+      assert_equal 0, subject.skip_result_count
+      assert_equal 0, subject.ignore_result_count
+
+      subject.on_result(Factory.error_result)
+      assert_equal 3, subject.result_count
+      assert_equal 1, subject.pass_result_count
+      assert_equal 1, subject.fail_result_count
+      assert_equal 1, subject.error_result_count
+      assert_equal 0, subject.skip_result_count
+      assert_equal 0, subject.ignore_result_count
+
+      subject.on_result(Factory.skip_result)
+      assert_equal 4, subject.result_count
+      assert_equal 1, subject.pass_result_count
+      assert_equal 1, subject.fail_result_count
+      assert_equal 1, subject.error_result_count
+      assert_equal 1, subject.skip_result_count
+      assert_equal 0, subject.ignore_result_count
+
+      subject.on_result(Factory.ignore_result)
+      assert_equal 5, subject.result_count
+      assert_equal 1, subject.pass_result_count
+      assert_equal 1, subject.fail_result_count
+      assert_equal 1, subject.error_result_count
+      assert_equal 1, subject.skip_result_count
+      assert_equal 1, subject.ignore_result_count
+    end
+
+    should "clear the run data on `on_start`" do
+      subject.before_test(@tests.sample)
+      subject.on_result(Factory.pass_result)
+
+      assert_equal 1, subject.test_count
+      assert_equal 1, subject.result_count
+      assert_equal 1, subject.pass_result_count
+
+      subject.on_start
+
+      assert_equal 0, subject.test_count
+      assert_equal 0, subject.result_count
+      assert_equal 0, subject.pass_result_count
+    end
+
+    # TODO: move to the view as only needed for view presentation purposes
     should "know its test and result attrs" do
       assert_equal 6, subject.tests.size
       assert_kind_of Assert::Test, subject.tests.first
 
-      assert_equal subject.tests.size, subject.test_count
-      assert_equal subject.tests,      subject.ordered_tests
-
+      assert_equal subject.tests, subject.ordered_tests
       exp = subject.ordered_tests.sort{ |a, b| a.run_time <=> b.run_time }
       assert_equal exp, subject.ordered_tests_by_run_time
 
-      assert_equal 8, subject.result_count
-
       exp = subject.ordered_tests.inject([]){ |results, t| results += t.results }
       assert_equal exp, subject.ordered_results
-
-      assert_equal 2, subject.result_count(:pass)
-      assert_equal 2, subject.result_count(:fail)
-      assert_equal 2, subject.result_count(:ignore)
-      assert_equal 1, subject.result_count(:skip)
-      assert_equal 1, subject.result_count(:error)
-    end
-
-    should "count its tests and results" do
-      assert_equal subject.test_count,   subject.count(:tests)
-      assert_equal subject.result_count, subject.count(:results)
-
-      assert_equal subject.result_count(:pass), subject.count(:passed)
-      assert_equal subject.result_count(:pass), subject.count(:pass)
-
-      assert_equal subject.result_count(:fail), subject.count(:failed)
-      assert_equal subject.result_count(:fail), subject.count(:fail)
-
-      assert_equal subject.result_count(:ignore), subject.count(:ignored)
-      assert_equal subject.result_count(:ignore), subject.count(:ignore)
-
-      assert_equal subject.result_count(:skip), subject.count(:skipped)
-      assert_equal subject.result_count(:skip), subject.count(:skip)
-
-      assert_equal subject.result_count(:error), subject.count(:errored)
-      assert_equal subject.result_count(:error), subject.count(:error)
     end
 
   end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -52,10 +52,6 @@ class Assert::Runner
       callback_mixin = Module.new
       @runner_class = Class.new(Assert::Runner) do
         include CallbackMixin
-
-        def run!(&block)
-          self.suite.tests.each(&block)
-        end
       end
       suite_class  = Class.new(Assert::DefaultSuite){ include CallbackMixin }
       view_class   = Class.new(Assert::View){ include CallbackMixin }
@@ -73,8 +69,18 @@ class Assert::Runner
       @result = @runner.run
     end
 
-    should "return an integer exit code" do
+    should "return the fail+error result count as an integer exit code" do
       assert_equal 0, @result
+
+      fail_count  = Factory.integer
+      error_count = Factory.integer
+      Assert.stub(subject, :fail_result_count){ fail_count }
+      Assert.stub(subject, :error_result_count){ error_count }
+      Assert.stub(@test, :run){ } # no-op
+      result = @runner.run
+
+      exp = fail_count + error_count
+      assert_equal exp, result
     end
 
     should "run all callbacks on itself, the suite and the view" do

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -33,13 +33,16 @@ class Assert::Suite
     should have_readers :config, :test_methods, :setups, :teardowns
     should have_accessors :start_time, :end_time
     should have_imeths :suite, :setup, :startup, :teardown, :shutdown
-    should have_imeths :run_time, :test_rate, :result_rate, :count
+    should have_imeths :tests_to_run, :tests_to_run?
+    should have_imeths :tests_to_run_count, :clear_tests_to_run
+    should have_imeths :run_time, :test_rate, :result_rate
+    should have_imeths :test_count, :result_count, :pass_result_count
+    should have_imeths :fail_result_count, :error_result_count
+    should have_imeths :skip_result_count, :ignore_result_count
     should have_imeths :ordered_tests, :reversed_tests
     should have_imeths :ordered_tests_by_run_time, :reversed_tests_by_run_time
-    should have_imeths :test_count
     should have_imeths :ordered_results, :reversed_results
     should have_imeths :ordered_results_for_dump, :reversed_results_for_dump
-    should have_imeths :result_count
     should have_imeths :before_load, :on_test, :after_load
     should have_imeths :on_start, :on_finish, :on_interrupt
     should have_imeths :before_test, :after_test, :on_result
@@ -83,18 +86,25 @@ class Assert::Suite
       assert_equal (subject.result_count / subject.run_time), subject.result_rate
     end
 
+    should "not provide any test/result count implementations" do
+      assert_nil subject.test_count
+      assert_nil subject.pass_result_count
+      assert_nil subject.fail_result_count
+      assert_nil subject.error_result_count
+      assert_nil subject.skip_result_count
+      assert_nil subject.ignore_result_count
+    end
+
     should "not provide any test or result attrs" do
       assert_nil subject.ordered_tests
       assert_nil subject.reversed_tests
       assert_nil subject.ordered_tests_by_run_time
       assert_nil subject.reversed_tests_by_run_time
-      assert_nil subject.test_count
 
       assert_nil subject.ordered_results
       assert_nil subject.reversed_results
       assert_nil subject.ordered_results_for_dump
       assert_nil subject.reversed_results_for_dump
-      assert_nil subject.result_count
     end
 
     should "add setup procs" do

--- a/test/unit/view_helpers_tests.rb
+++ b/test/unit/view_helpers_tests.rb
@@ -93,7 +93,7 @@ module Assert::ViewHelpers
       exp = "#{subject.tests_to_run_count} test#{'s' if subject.tests_to_run_count != 1}"
       assert_equal exp, subject.tests_to_run_count_statement
 
-      exp = "#{subject.count(:results)} result#{'s' if subject.count(:results) != 1}"
+      exp = "#{subject.result_count} result#{'s' if subject.result_count != 1}"
       assert_equal exp, subject.result_count_statement
     end
 
@@ -110,13 +110,13 @@ module Assert::ViewHelpers
     end
 
     should "know its all pass result summary message" do
-      Assert.stub(subject, :count).with(:results){ 0 }
+      Assert.stub(subject, :result_count){ 0 }
       assert_equal "uhh...", subject.all_pass_result_summary_msg
 
-      Assert.stub(subject, :count).with(:results){ 1 }
+      Assert.stub(subject, :result_count){ 1 }
       assert_equal "pass", subject.all_pass_result_summary_msg
 
-      Assert.stub(subject, :count).with(:results){ Factory.integer(10)+1 }
+      Assert.stub(subject, :result_count){ Factory.integer(10)+1 }
       assert_equal "all pass", subject.all_pass_result_summary_msg
     end
 
@@ -128,7 +128,7 @@ module Assert::ViewHelpers
 
       Assert.stub(subject, :all_pass?){ false }
       res_type = [:pass, :ignore, :fail, :skip, :error].sample
-      exp = "#{subject.count(res_type)} #{res_type.to_s}"
+      exp = "#{subject.send("#{res_type}_result_count")} #{res_type.to_s}"
       assert_equal exp, subject.result_summary_msg(res_type)
     end
 


### PR DESCRIPTION
This is part of switching to accumulating all test run data and not
storing unnecessary data like every test obj that was run and every
result obj that those tests produced.

This replaces the super-generic `count` method (that would count any
tests data) with data-specific count methods.  These count methods
pull from the counts accumulated on the suite rather than actually
counting up objects in memory.  Counts are accumulated by implementing
callbacks and incrementing counters appropriately.  I chose to use
specific increment private methods for incrementing the typed
result counts to avoid having to do some conditional or some
dynamic ivar get/set.

I also added some more notes for the coming steps like moving
presentation data accumulation/handling into the view, etc.

@jcredding ready for review.