### PR TITLE
accumulate: abstract suite `tests_to_run`

### DIFF
--- a/lib/assert/default_suite.rb
+++ b/lib/assert/default_suite.rb
@@ -16,10 +16,17 @@ module Assert
       reset_run_data
     end
 
-    def tests_to_run;       @tests;          end
     def tests_to_run?;      @tests.size > 0; end
     def tests_to_run_count; @tests.size;     end
     def clear_tests_to_run; @tests.clear;    end
+
+    def find_test_to_run(file_line)
+      @tests.find{ |t| t.file_line == file_line }
+    end
+
+    def sorted_tests_to_run(&sort_by_proc)
+      @tests.sort.sort_by(&sort_by_proc)
+    end
 
     def test_count;          @test_count;          end
     def result_count;        @result_count;        end

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -82,10 +82,11 @@ module Assert
     def tests_to_run
       srand self.runner_seed
       if self.single_test?
-        [ self.suite.tests_to_run.find{ |t| t.file_line == self.single_test_file_line }
-        ].compact
+        [self.suite.find_test_to_run(self.single_test_file_line)].compact
       else
-        self.suite.tests_to_run.sort.sort_by{ rand self.suite.tests_to_run_count }
+        # TODO: implies tests are always stored in memory?
+        # TODO: move this back to base suite definition?
+        self.suite.sorted_tests_to_run{ rand self.tests_to_run_count }
       end
     end
 

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -36,10 +36,11 @@ module Assert
     end
     alias_method :shutdown, :teardown
 
-    def tests_to_run;       end
-    def tests_to_run?;      end
-    def tests_to_run_count; end
-    def clear_tests_to_run; end
+    def tests_to_run?;                      end
+    def tests_to_run_count;                 end
+    def clear_tests_to_run;                 end
+    def find_test_to_run(file_line);        end
+    def sorted_tests_to_run(&sort_by_proc); end
 
     def run_time
       @end_time - @start_time

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -33,8 +33,8 @@ class Assert::Suite
     should have_readers :config, :test_methods, :setups, :teardowns
     should have_accessors :start_time, :end_time
     should have_imeths :suite, :setup, :startup, :teardown, :shutdown
-    should have_imeths :tests_to_run, :tests_to_run?
-    should have_imeths :tests_to_run_count, :clear_tests_to_run
+    should have_imeths :tests_to_run?, :tests_to_run_count, :clear_tests_to_run
+    should have_imeths :find_test_to_run, :sorted_tests_to_run
     should have_imeths :run_time, :test_rate, :result_rate
     should have_imeths :test_count, :result_count, :pass_result_count
     should have_imeths :fail_result_count, :error_result_count
@@ -64,10 +64,11 @@ class Assert::Suite
     end
 
     should "not provide any tests-to-run implementations" do
-      assert_nil subject.tests_to_run
       assert_nil subject.tests_to_run?
       assert_nil subject.tests_to_run_count
       assert_nil subject.clear_tests_to_run
+      assert_nil subject.find_test_to_run(Factory.string)
+      assert_nil subject.sorted_tests_to_run{ }
     end
 
     should "know its run time and rates" do


### PR DESCRIPTION
This builds off the original abstract effort from PR 266.  I realized
I had moved to not use the `tests` reader, but in doing so had just
replaced this reader with a new `tests_to_run` reader.  This kinda
missed the original point.

This switches to letting the suite define how to lookup a single
test by file line and sorting the tests given a `sort_by` proc. I
chose to pass in the sort by proc so the runner continues to force
that the tests are sorted randomly and to continue jux'ing the srand
and rand logic in the runner.

In particular, the sort method taking a `sort_by` proc implies that
a `sort_by` call will be made which implies that at some point
the tests will be in an enumerable in memory.  This makes me wonder
if my choice to move storing test in memory only in the default
suite was a bit premature.  It may work out that, much like the
runner, the base suite forces storing tests in memory while the
default suite has little to no logic in it.  I'll address this
after I rework the view logic to accumulate data and see how the
logic shakes out, FYI.

@jcredding ready for review.