### PR TITLE
accumulate: rework the default view to accumulate results to dump

### DIFF
--- a/lib/assert/default_suite.rb
+++ b/lib/assert/default_suite.rb
@@ -55,27 +55,6 @@ module Assert
       self.ordered_tests_by_run_time.reverse
     end
 
-    def ordered_results
-      self.ordered_tests.inject([]){ |results, test| results += test.results }
-    end
-
-    def reversed_results
-      self.ordered_results.reverse
-    end
-
-    # dump failed or errored results,
-    # dump skipped or ignored results if they have a message
-    def ordered_results_for_dump
-      self.ordered_results.select do |result|
-        [:fail, :error].include?(result.to_sym) ||
-        !!([:skip, :ignore].include?(result.to_sym) && result.message)
-      end
-    end
-
-    def reversed_results_for_dump
-      self.ordered_results_for_dump.reverse
-    end
-
     # Callbacks
 
     def on_test(test)

--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -18,6 +18,11 @@ module Assert
     option 'skip_styles',   :cyan
     option 'ignore_styles', :magenta
 
+    def initialize(*args)
+      super
+      @results_to_dump = []
+    end
+
     def before_load(test_files)
     end
 
@@ -37,7 +42,8 @@ module Assert
     end
 
     def on_result(result)
-      print ansi_styled_msg(self.send("#{result.to_sym}_abbrev"), result)
+      print ansi_styled_msg(self.send("#{result.to_sym}_abbrev"), result.type)
+      @results_to_dump << ResultData.for_result(result) if dumpable_result?(result)
     end
 
     def after_test(test)
@@ -65,8 +71,8 @@ module Assert
       end
 
       # style the summaries of each result set
-      styled_results_sentence = results_summary_sentence do |summary, result_sym|
-        ansi_styled_msg(summary, result_sym)
+      styled_results_sentence = results_summary_sentence do |summary, result_type|
+        ansi_styled_msg(summary, result_type)
       end
 
       puts "#{result_count_statement}: #{styled_results_sentence}"
@@ -82,24 +88,45 @@ module Assert
 
     private
 
+    def dumpable_result?(result)
+      [:fail, :error].include?(result.type) ||
+      !!([:skip, :ignore].include?(result.type) && result.message)
+    end
+
     def dump_test_results
       print "\n"
       puts
 
-      config.suite.reversed_results_for_dump.each do |result|
+      @results_to_dump.sort.each do |result_data|
         # output the styled result details
-        puts ansi_styled_msg(result.to_s, result)
+        puts ansi_styled_msg(result_data.details, result_data.type)
 
         # output any captured stdout
-        puts captured_output(result.output) if result.output && !result.output.empty?
+        if result_data.output && !result_data.output.empty?
+          puts captured_output(result_data.output)
+        end
 
         # output re-run CLI cmd
-        puts re_run_test_cmd(result.test_id)
+        puts re_run_test_cmd(result_data.test_id)
 
-        # add an empty line between each result detail
+        # add an empty line between each dumped result
         puts
       end
+    end
 
+    class ResultData < Struct.new(:type, :details, :output, :file_line, :test_id)
+      def self.for_result(r)
+        self.new(r.type, r.to_s, r.output, r.file_line, r.test_id)
+      end
+
+      def <=>(other_result_data)
+        # show in reverse definition order
+        if other_result_data.kind_of?(ResultData)
+          other_result_data.file_line <=> self.file_line
+        else
+          super
+        end
+      end
     end
 
   end

--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -51,6 +51,10 @@ module Assert::Result
     def backtrace; @backtrace ||= (@build_data[:backtrace] || Backtrace.new([]));           end
     def trace;     @trace     ||= (@build_data[:trace]     || build_trace(self.backtrace)); end
 
+    def file_line
+      @file_line ||= self.backtrace.filtered.first.to_s
+    end
+
     Assert::Result.types.keys.each do |type|
       define_method("#{type}?"){ self.type == type }
     end

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -69,13 +69,6 @@ module Assert
     def ordered_tests_by_run_time;  end
     def reversed_tests_by_run_time; end
 
-    # Result data
-
-    def ordered_results;           end
-    def reversed_results;          end
-    def ordered_results_for_dump;  end
-    def reversed_results_for_dump; end
-
     # Callbacks
 
     # define callback handlers to do special behavior during the test run.  These

--- a/lib/assert/view_helpers.rb
+++ b/lib/assert/view_helpers.rb
@@ -92,9 +92,9 @@ module Assert
       # generate a sentence fragment describing the breakdown of test results
       # if a block is given, yield each msg in the breakdown for custom formatting
       def results_summary_sentence
-        summaries = self.ocurring_result_types.map do |result_sym|
-          summary_msg = self.result_summary_msg(result_sym)
-          block_given? ? yield(summary_msg, result_sym) : summary_msg
+        summaries = self.ocurring_result_types.map do |result_type|
+          summary_msg = self.result_summary_msg(result_type)
+          block_given? ? yield(summary_msg, result_type) : summary_msg
         end
         self.to_sentence(summaries)
       end
@@ -188,9 +188,9 @@ module Assert
         style_names.map{ |n| "\e[#{CODES[n]}m" if CODES.key?(n) }.compact.join('')
       end
 
-      def ansi_styled_msg(msg, result_or_sym)
+      def ansi_styled_msg(msg, result_type)
         return msg if !self.is_tty? || !self.styled
-        code = Assert::ViewHelpers::Ansi.code_for(*self.send("#{result_or_sym.to_sym}_styles"))
+        code = Assert::ViewHelpers::Ansi.code_for(*self.send("#{result_type}_styles"))
         return msg if code.empty?
         code + msg + Assert::ViewHelpers::Ansi.code_for(:reset)
       end

--- a/test/unit/default_suite_tests.rb
+++ b/test/unit/default_suite_tests.rb
@@ -134,9 +134,6 @@ class Assert::DefaultSuite
       assert_equal subject.tests, subject.ordered_tests
       exp = subject.ordered_tests.sort{ |a, b| a.run_time <=> b.run_time }
       assert_equal exp, subject.ordered_tests_by_run_time
-
-      exp = subject.ordered_tests.inject([]){ |results, t| results += t.results }
-      assert_equal exp, subject.ordered_results
     end
 
   end

--- a/test/unit/result_tests.rb
+++ b/test/unit/result_tests.rb
@@ -53,7 +53,7 @@ module Assert::Result
 
     should have_cmeths :type, :name, :for_test
     should have_imeths :type, :name, :test_name, :test_id
-    should have_imeths :message, :output, :backtrace, :trace
+    should have_imeths :message, :output, :backtrace, :trace, :file_line
     should have_imeths *Assert::Result.types.keys.map{ |k| "#{k}?" }
     should have_imeths :set_backtrace, :data, :to_sym, :to_s
 
@@ -100,6 +100,11 @@ module Assert::Result
       assert_equal '',                result.output
       assert_equal Backtrace.new([]), result.backtrace
       assert_equal '',                result.trace
+    end
+
+    should "know its file line attr" do
+      exp = subject.backtrace.filtered.first.to_s
+      assert_equal exp, subject.file_line
     end
 
     should "know if it is a certain type of result" do

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -41,8 +41,6 @@ class Assert::Suite
     should have_imeths :skip_result_count, :ignore_result_count
     should have_imeths :ordered_tests, :reversed_tests
     should have_imeths :ordered_tests_by_run_time, :reversed_tests_by_run_time
-    should have_imeths :ordered_results, :reversed_results
-    should have_imeths :ordered_results_for_dump, :reversed_results_for_dump
     should have_imeths :before_load, :on_test, :after_load
     should have_imeths :on_start, :on_finish, :on_interrupt
     should have_imeths :before_test, :after_test, :on_result
@@ -101,11 +99,6 @@ class Assert::Suite
       assert_nil subject.reversed_tests
       assert_nil subject.ordered_tests_by_run_time
       assert_nil subject.reversed_tests_by_run_time
-
-      assert_nil subject.ordered_results
-      assert_nil subject.reversed_results
-      assert_nil subject.ordered_results_for_dump
-      assert_nil subject.reversed_results_for_dump
     end
 
     should "add setup procs" do

--- a/test/unit/view_helpers_tests.rb
+++ b/test/unit/view_helpers_tests.rb
@@ -185,30 +185,30 @@ module Assert::ViewHelpers
 
     should "know how to build ansi styled messages" do
       msg = Factory.string
-      result = [:pass, :fail, :error, :skip, :ignore].sample
+      result_type = [:pass, :fail, :error, :skip, :ignore].sample
 
       Assert.stub(subject, :is_tty?){ false }
       Assert.stub(subject, :styled){ false }
-      assert_equal msg, subject.ansi_styled_msg(msg, result)
+      assert_equal msg, subject.ansi_styled_msg(msg, result_type)
 
       Assert.stub(subject, :is_tty?){ false }
       Assert.stub(subject, :styled){ true }
-      assert_equal msg, subject.ansi_styled_msg(msg, result)
+      assert_equal msg, subject.ansi_styled_msg(msg, result_type)
 
       Assert.stub(subject, :is_tty?){ true }
       Assert.stub(subject, :styled){ false }
-      assert_equal msg, subject.ansi_styled_msg(msg, result)
+      assert_equal msg, subject.ansi_styled_msg(msg, result_type)
 
       Assert.stub(subject, :is_tty?){ true }
       Assert.stub(subject, :styled){ true }
-      Assert.stub(subject, "#{result}_styles"){ [] }
-      assert_equal msg, subject.ansi_styled_msg(msg, result)
+      Assert.stub(subject, "#{result_type}_styles"){ [] }
+      assert_equal msg, subject.ansi_styled_msg(msg, result_type)
 
       styles = Factory.integer(3).times.map{ Assert::ViewHelpers::Ansi::CODES.keys.sample }
-      Assert.stub(subject, "#{result}_styles"){ styles }
+      Assert.stub(subject, "#{result_type}_styles"){ styles }
       exp_code = Assert::ViewHelpers::Ansi.code_for(*styles)
       exp = exp_code + msg + Assert::ViewHelpers::Ansi.code_for(:reset)
-      assert_equal exp, subject.ansi_styled_msg(msg, result)
+      assert_equal exp, subject.ansi_styled_msg(msg, result_type)
     end
 
   end


### PR DESCRIPTION
This implementation no longer relies on the result objects stored
on each test object that was run.  This is part of switching to
no longer storing test objs that were run and the result objs those
tests produced.

This new implmentation accumulates the results that need to be
dumped as results come in.  This has a few advantages over the
previous implementation.  For starters, not needing to store results
means we use less memory in the test suite (which has a big impact
on large test suites).  Also, this decouples the result object
from the default view b/c we store result data custom to the view.
Only the attrs that need displaying will be stored.  Finally, this
only has to sort a subset of all results generated (the ones that
need to be dumped).  This is more performant on large test suites
that generate many results (most of which are just passing and are
not dumped).

Due to these changes all of the suites result handling methods can
be removed.  All result handling is now expected to be done by the
views themselves (since they are the users of the result data).

There are a couple of additional changes that came out of this
effort.  First, I switched the `ansi_styled_message` view helper
to expect a result type symbol instead of taking either a result or
result type.  This simplifies the impelementation and is of no
consequence given we are collecting result types in the views result
data.

Second, this updates how results are sorted when dumped.
The result now knows its `file_line` (the file/line-num of the test
code that produced the result) and this is collected in the view's
result data.  The view sorts result data in reverse file line order.
This is the same effect the previous implementation had, just more
explicit about it.  The main advantage here is that, no matter what
order results come in, they are always outputted in an expected order.
This will be needed if tests are ever run in parallel so I figured
I should go ahead and be explicit about it now.

@jcredding ready for review.