### PR TITLE
accumulate: rework the default view to accumulate test data

### DIFF
--- a/lib/assert/config_helpers.rb
+++ b/lib/assert/config_helpers.rb
@@ -33,16 +33,28 @@ module Assert
       self.pass_result_count == self.result_count
     end
 
-    def formatted_run_time(format = '%.6f')
-      format % self.config.suite.run_time
+    def formatted_run_time(run_time, format = '%.6f')
+      format % run_time
     end
 
-    def formatted_test_rate(format = '%.6f')
-      format % self.config.suite.test_rate
+    def formatted_test_rate(test_rate, format = '%.6f')
+      format % test_rate
     end
 
-    def formatted_result_rate(format = '%.6f')
-      format % self.config.suite.result_rate
+    def formatted_result_rate(result_rate, format = '%.6f')
+      format % result_rate
+    end
+
+    def formatted_suite_run_time(format = '%.6f')
+      formatted_run_time(self.config.suite.run_time, format)
+    end
+
+    def formatted_suite_test_rate(format = '%.6f')
+      formatted_test_rate(self.config.suite.test_rate, format)
+    end
+
+    def formatted_suite_result_rate(format = '%.6f')
+      formatted_result_rate(self.config.suite.result_rate, format)
     end
 
     def show_test_profile_info?
@@ -58,6 +70,12 @@ module Assert
       @result_types ||= [:pass, :fail, :ignore, :skip, :error].select do |sym|
         self.send("#{sym}_result_count") > 0
       end
+    end
+
+    private
+
+    def get_rate(count, time)
+      time == 0 ? 0.0 : (count.to_f / time.to_f)
     end
 
   end

--- a/lib/assert/default_suite.rb
+++ b/lib/assert/default_suite.rb
@@ -36,25 +36,6 @@ module Assert
     def skip_result_count;   @skip_result_count;   end
     def ignore_result_count; @ignore_result_count; end
 
-    # TODO: move all these ordered methods to the view as it is only needed by
-    # the view for presentation purposes
-
-    def ordered_tests
-      self.tests
-    end
-
-    def reversed_tests
-      self.tests.reverse
-    end
-
-    def ordered_tests_by_run_time
-      self.ordered_tests.sort{ |a, b| a.run_time <=> b.run_time }
-    end
-
-    def reversed_tests_by_run_time
-      self.ordered_tests_by_run_time.reverse
-    end
-
     # Callbacks
 
     def on_test(test)

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -18,7 +18,7 @@ module Assert
     def run
       self.on_start
       self.suite.on_start
-      self.view.on_start  # TODO: reset display result list
+      self.view.on_start
 
       if self.single_test?
         self.view.print "Running test: #{self.single_test_file_line}"
@@ -37,15 +37,15 @@ module Assert
         tests_to_run.each do |test|
           self.before_test(test)
           self.suite.before_test(test)
-          self.view.before_test(test) # TODO: optionally store test presentation info
+          self.view.before_test(test)
           test.run do |result|
             self.on_result(result)
             self.suite.on_result(result)
-            self.view.on_result(result) # TODO: optionally store result presentation info
+            self.view.on_result(result)
           end
           self.after_test(test)
           self.suite.after_test(test)
-          self.view.after_test(test) # TODO: optionally store test presentation info
+          self.view.after_test(test)
         end
         self.suite.teardowns.each(&:call)
         self.suite.end_time = Time.now

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -62,13 +62,6 @@ module Assert
     def skip_result_count;   end
     def ignore_result_count; end
 
-    # Test data
-
-    def ordered_tests;              end
-    def reversed_tests;             end
-    def ordered_tests_by_run_time;  end
-    def reversed_tests_by_run_time; end
-
     # Callbacks
 
     # define callback handlers to do special behavior during the test run.  These
@@ -88,12 +81,6 @@ module Assert
       "#<#{self.class}:#{'0x0%x' % (object_id << 1)}"\
       " test_count=#{self.test_count.inspect}"\
       " result_count=#{self.result_count.inspect}>"
-    end
-
-    private
-
-    def get_rate(count, time)
-      time == 0 ? 0.0 : (count.to_f / time.to_f)
     end
 
   end

--- a/lib/assert/view_helpers.rb
+++ b/lib/assert/view_helpers.rb
@@ -28,18 +28,6 @@ module Assert
 
     module InstanceMethods
 
-      # TODO: get from the suite as test won't store this data
-      # get the formatted run time for an idividual test
-      def test_run_time(test, format = '%.6f')
-        format % test.run_time
-      end
-
-      # TODO: get from the suite as test won't store this data
-      # get the formatted result rate for an individual test
-      def test_result_rate(test, format = '%.6f')
-        format % test.result_rate
-      end
-
       # show any captured output
       def captured_output(output)
         "--- stdout ---\n"\

--- a/test/unit/config_helpers_tests.rb
+++ b/test/unit/config_helpers_tests.rb
@@ -29,6 +29,8 @@ module Assert::ConfigHelpers
     should have_imeths :skip_result_count, :ignore_result_count
     should have_imeths :all_pass?, :formatted_run_time
     should have_imeths :formatted_test_rate, :formatted_result_rate
+    should have_imeths :formatted_suite_run_time
+    should have_imeths :formatted_suite_test_rate, :formatted_suite_result_rate
     should have_imeths :show_test_profile_info?, :show_test_verbose_info?
     should have_imeths :ocurring_result_types
 
@@ -99,14 +101,33 @@ module Assert::ConfigHelpers
     should "know its formatted run time, test rate and result rate" do
       format = '%.6f'
 
+      run_time = Factory.float
+      exp = format % run_time
+      assert_equal exp, subject.formatted_run_time(run_time, format)
+      assert_equal exp, subject.formatted_run_time(run_time)
+
+      test_rate = Factory.float
+      exp = format % test_rate
+      assert_equal exp, subject.formatted_result_rate(test_rate, format)
+      assert_equal exp, subject.formatted_result_rate(test_rate)
+
+      result_rate = Factory.float
+      exp = format % result_rate
+      assert_equal exp, subject.formatted_result_rate(result_rate, format)
+      assert_equal exp, subject.formatted_result_rate(result_rate)
+    end
+
+    should "know its formatted suite run time, test rate and result rate" do
+      format = '%.6f'
+
       exp = format % subject.config.suite.run_time
-      assert_equal exp, subject.formatted_run_time(format)
+      assert_equal exp, subject.formatted_suite_run_time(format)
 
       exp = format % subject.config.suite.test_rate
-      assert_equal exp, subject.formatted_test_rate(format)
+      assert_equal exp, subject.formatted_suite_test_rate(format)
 
       exp = format % subject.config.suite.result_rate
-      assert_equal exp, subject.formatted_result_rate(format)
+      assert_equal exp, subject.formatted_suite_result_rate(format)
     end
 
     should "know whether to show test profile info" do

--- a/test/unit/default_suite_tests.rb
+++ b/test/unit/default_suite_tests.rb
@@ -126,16 +126,6 @@ class Assert::DefaultSuite
       assert_equal 0, subject.pass_result_count
     end
 
-    # TODO: move to the view as only needed for view presentation purposes
-    should "know its test and result attrs" do
-      assert_equal 6, subject.tests.size
-      assert_kind_of Assert::Test, subject.tests.first
-
-      assert_equal subject.tests, subject.ordered_tests
-      exp = subject.ordered_tests.sort{ |a, b| a.run_time <=> b.run_time }
-      assert_equal exp, subject.ordered_tests_by_run_time
-    end
-
   end
 
 end

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -22,7 +22,7 @@ class Assert::Suite
 
   end
 
-  class InitTests < Assert::Context
+  class InitTests < UnitTests
     desc "when init"
     setup do
       @config = Factory.modes_off_config
@@ -39,8 +39,6 @@ class Assert::Suite
     should have_imeths :test_count, :result_count, :pass_result_count
     should have_imeths :fail_result_count, :error_result_count
     should have_imeths :skip_result_count, :ignore_result_count
-    should have_imeths :ordered_tests, :reversed_tests
-    should have_imeths :ordered_tests_by_run_time, :reversed_tests_by_run_time
     should have_imeths :before_load, :on_test, :after_load
     should have_imeths :on_start, :on_finish, :on_interrupt
     should have_imeths :before_test, :after_test, :on_result
@@ -92,13 +90,6 @@ class Assert::Suite
       assert_nil subject.error_result_count
       assert_nil subject.skip_result_count
       assert_nil subject.ignore_result_count
-    end
-
-    should "not provide any test or result attrs" do
-      assert_nil subject.ordered_tests
-      assert_nil subject.reversed_tests
-      assert_nil subject.ordered_tests_by_run_time
-      assert_nil subject.reversed_tests_by_run_time
     end
 
     should "add setup procs" do

--- a/test/unit/view_helpers_tests.rb
+++ b/test/unit/view_helpers_tests.rb
@@ -55,25 +55,11 @@ module Assert::ViewHelpers
     end
     subject{ @helpers }
 
-    should have_imeths :test_run_time, :test_result_rate
     should have_imeths :captured_output, :re_run_test_cmd
     should have_imeths :tests_to_run_count_statement, :result_count_statement
     should have_imeths :to_sentence
     should have_imeths :all_pass_result_summary_msg, :result_summary_msg
     should have_imeths :results_summary_sentence
-
-    should "know a test's formatted run time and result rate" do
-      test   = Factory.test
-      format = '%.6f'
-
-      exp = format % test.run_time
-      assert_equal exp, subject.test_run_time(test, format)
-      assert_equal exp, subject.test_run_time(test)
-
-      exp = format % test.result_rate
-      assert_equal exp, subject.test_result_rate(test, format)
-      assert_equal exp, subject.test_result_rate(test)
-    end
 
     should "know how to build captured output" do
       output = Factory.string


### PR DESCRIPTION
This implementation no longer relies on the test objects stored
on the suite. This is part of switching to no longer storing test
objs that were run and the result objs those tests produced.

This new implementation optionally accumulates test data needed for
presentation.  This test data is only needed if running in verbose
mode or profiling.  Test data is stored by its file line in a hash
on the view.  As results come in, the test data's result count is
incremented.  When the test is finished, the run time and result
rate are captured.  This, plus the static attrs captured when the
test begins, is all the data needed for presentation in both the
verbose and profile scenarios.

Due to these changes all of the suite's test handling methods can
be removed. All test handling is now expected to be done by the
views themselves (since they are the users of the test data).

Finally this commonizes and reworks the helper methods for calculating
formatted run time, test rates and result rates.  These were being
duplicated across the config helpers (for suite stats) and the
view helpers (for verbose/profile stats).  This commonizes them
and reworks them for the new test data needs.

@jcredding ready for review.