### PR TITLE
accumulate: properly sort result data by the file name and line num

### DIFF
--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -150,16 +150,20 @@ module Assert
       end
     end
 
-    attrs = [:type, :details, :output, :file_line, :test_id]
+    attrs = [:type, :details, :output, :file_name, :line_num, :test_id]
     class ResultData < Struct.new(*attrs)
       def self.for_result(r)
-        self.new(r.type, r.to_s, r.output, r.file_line, r.test_id)
+        self.new(r.type, r.to_s, r.output, r.file_name, r.line_num, r.test_id)
       end
 
-      def <=>(other_result_data)
+      def file_name_and_line_num
+        [self.file_name, self.line_num]
+      end
+
+      def <=>(other_rd)
         # show in reverse definition order
-        if other_result_data.kind_of?(ResultData)
-          other_result_data.file_line <=> self.file_line
+        if other_rd.kind_of?(ResultData)
+          other_rd.file_name_and_line_num <=> self.file_name_and_line_num
         else
           super
         end

--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -1,3 +1,5 @@
+require 'assert/file_line'
+
 module Assert; end
 module Assert::Result
 
@@ -76,8 +78,11 @@ module Assert::Result
     end
 
     def file_line
-      @file_line ||= self.backtrace.filtered.first.to_s
+      @file_line ||= Assert::FileLine.parse(self.backtrace.filtered.first.to_s)
     end
+
+    def file_name; self.file_line.file;      end
+    def line_num;  self.file_line.line.to_i; end
 
     Assert::Result.types.keys.each do |type|
       define_method("#{type}?"){ self.type == type }

--- a/test/unit/result_tests.rb
+++ b/test/unit/result_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'assert/result'
 
+require 'assert/file_line'
+
 module Assert::Result
 
   class UnitTests < Assert::Context
@@ -53,7 +55,8 @@ module Assert::Result
 
     should have_cmeths :type, :name, :for_test
     should have_imeths :type, :name, :test_name, :test_file_line, :test_id
-    should have_imeths :message, :output, :backtrace, :trace, :file_line
+    should have_imeths :message, :output, :backtrace, :trace
+    should have_imeths :file_line, :file_name, :line_num
     should have_imeths *Assert::Result.types.keys.map{ |k| "#{k}?" }
     should have_imeths :set_backtrace, :to_sym, :to_s
 
@@ -104,9 +107,11 @@ module Assert::Result
       assert_equal '',                result.trace
     end
 
-    should "know its file line attr" do
-      exp = subject.backtrace.filtered.first.to_s
-      assert_equal exp, subject.file_line
+    should "know its file line attrs" do
+      exp = Assert::FileLine.parse(subject.backtrace.filtered.first.to_s)
+      assert_equal exp,           subject.file_line
+      assert_equal exp.file,      subject.file_name
+      assert_equal exp.line.to_i, subject.line_num
     end
 
     should "know if it is a certain type of result" do


### PR DESCRIPTION
Previously, the data just stored the file_line string which did not
sort the file line number portion as intended b/c string integers
don't sort like integers.  This switches the storing the file name
and line number of the result independently and using those to
properly sort the results by reverse definition order.

This edge case was missed in PR 269 but was missed.  This is part
of the effort to accumulate test run data instead of storing test
objects.

See #269 for reference.

@jcredding ready for review.