### PR TITLE
accumulate: move in-memory test handling back to base suite

### DIFF
--- a/lib/assert/default_suite.rb
+++ b/lib/assert/default_suite.rb
@@ -2,30 +2,15 @@ require 'assert/suite'
 
 module Assert
 
-  # TODO: make this comment/description more accurate once accumulation work done
-  # This is the default suite used by assert.  It stores test/result data in-memory.
+  # This is the default suite used by assert. In addition to the base suite
+  # behavior, it accumulates test/result counts in memory.  This data is used
+  # by the runner/view for handling and presentation purposes.
 
   class DefaultSuite < Assert::Suite
 
-    # TODO: remove once ordered methods are moved to the view
-    attr_reader :tests
-
     def initialize(config)
       super
-      @tests = []
       reset_run_data
-    end
-
-    def tests_to_run?;      @tests.size > 0; end
-    def tests_to_run_count; @tests.size;     end
-    def clear_tests_to_run; @tests.clear;    end
-
-    def find_test_to_run(file_line)
-      @tests.find{ |t| t.file_line == file_line }
-    end
-
-    def sorted_tests_to_run(&sort_by_proc)
-      @tests.sort.sort_by(&sort_by_proc)
     end
 
     def test_count;          @test_count;          end
@@ -37,10 +22,6 @@ module Assert
     def ignore_result_count; @ignore_result_count; end
 
     # Callbacks
-
-    def on_test(test)
-      @tests << test
-    end
 
     def on_start
       reset_run_data

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -3,6 +3,12 @@ require 'assert/test'
 
 module Assert
 
+  # This is the base suite. It loads the tests to run in memory and provides
+  # methods for these tests that the runner/view uses for handling and
+  # presentation purposes. It also stores suite-level setups and teardowns.
+  # Override the test/result count methods and the callbacks as needed.  See
+  # the default suite for example usage.
+
   class Suite
     include Assert::ConfigHelpers
 
@@ -17,6 +23,7 @@ module Assert
 
     def initialize(config)
       @config       = config
+      @tests        = []
       @test_methods = []
       @setups       = []
       @teardowns    = []
@@ -36,11 +43,25 @@ module Assert
     end
     alias_method :shutdown, :teardown
 
-    def tests_to_run?;                      end
-    def tests_to_run_count;                 end
-    def clear_tests_to_run;                 end
-    def find_test_to_run(file_line);        end
-    def sorted_tests_to_run(&sort_by_proc); end
+    def tests_to_run?;      @tests.size > 0; end
+    def tests_to_run_count; @tests.size;     end
+    def clear_tests_to_run; @tests.clear;    end
+
+    def find_test_to_run(file_line)
+      @tests.find{ |t| t.file_line == file_line }
+    end
+
+    def sorted_tests_to_run(&sort_by_proc)
+      @tests.sort.sort_by(&sort_by_proc)
+    end
+
+    def test_count;          end
+    def result_count;        end
+    def pass_result_count;   end
+    def fail_result_count;   end
+    def error_result_count;  end
+    def skip_result_count;   end
+    def ignore_result_count; end
 
     def run_time
       @end_time - @start_time
@@ -54,28 +75,26 @@ module Assert
       get_rate(self.result_count, self.run_time)
     end
 
-    def test_count;          end
-    def result_count;        end
-    def pass_result_count;   end
-    def fail_result_count;   end
-    def error_result_count;  end
-    def skip_result_count;   end
-    def ignore_result_count; end
-
     # Callbacks
 
     # define callback handlers to do special behavior during the test run.  These
     # will be called by the test runner
 
     def before_load(test_files); end
-    def on_test(test);           end
-    def after_load;              end
-    def on_start;                end
-    def before_test(test);       end
-    def on_result(result);       end
-    def after_test(test);        end
-    def on_finish;               end
-    def on_interrupt(err);       end
+
+    # this is required to load tests into the suite, be sure to `super` if you
+    # override this method
+    def on_test(test)
+      @tests << test
+    end
+
+    def after_load;        end
+    def on_start;          end
+    def before_test(test); end
+    def on_result(result); end
+    def after_test(test);  end
+    def on_finish;         end
+    def on_interrupt(err); end
 
     def inspect
       "#<#{self.class}:#{'0x0%x' % (object_id << 1)}"\

--- a/test/unit/context/test_dsl_tests.rb
+++ b/test/unit/context/test_dsl_tests.rb
@@ -12,100 +12,94 @@ module Assert::Context::TestDSL
 
     should "build a test using `test` with a desc and code block" do
       d, b = @test_desc, @test_block
-      context_class = Factory.modes_off_context_class{ test(d, &b) }
+      context, test = build_eval_context{ test(d, &b) }
 
-      assert_equal 1, context_class.suite.tests.size
+      assert_equal 1, context.class.suite.tests_to_run_count
 
-      exp_test_name = @test_desc
-      built_test    = context_class.suite.tests.first
-
-      assert_kind_of Assert::Test, built_test
-      assert_equal exp_test_name, built_test.name
-      assert_equal @test_block,   built_test.code
+      assert_kind_of Assert::Test, test
+      assert_equal @test_desc,  test.name
+      assert_equal @test_block, test.code
     end
 
     should "build a test using `should` with a desc and code block" do
       d, b = @test_desc, @test_block
-      context_class = Factory.modes_off_context_class{ should(d, &b) }
+      context, test = build_eval_context{ should(d, &b) }
 
-      assert_equal 1, context_class.suite.tests.size
+      assert_equal 1, context.class.suite.tests_to_run_count
 
-      exp_test_name = "should #{@test_desc}"
-      built_test    = context_class.suite.tests.last
-
-      assert_kind_of Assert::Test, built_test
-      assert_equal exp_test_name, built_test.name
-      assert_equal @test_block,   built_test.code
+      assert_kind_of Assert::Test, test
+      assert_equal "should #{@test_desc}", test.name
+      assert_equal @test_block, test.code
     end
 
     should "build a test that skips with no msg when `test_eventually` called" do
       d, b = @test_desc, @test_block
-      context = build_eval_context{ test_eventually(d, &b) }
+      context, test = build_eval_context{ test_eventually(d, &b) }
       err = capture_err(Assert::Result::TestSkipped) do
-        context.instance_eval(&context.class.suite.tests.last.code)
+        context.instance_eval(&test.code)
       end
 
-      assert_equal 1,      context.class.suite.tests.size
+      assert_equal 1,      context.class.suite.tests_to_run_count
       assert_equal 'TODO', err.message
       assert_equal 1,      err.backtrace.size
     end
 
     should "build a test that skips with no msg  when `should_eventually` called" do
       d, b = @test_desc, @test_block
-      context = build_eval_context{ should_eventually(d, &b) }
+      context, test = build_eval_context{ should_eventually(d, &b) }
       err = capture_err(Assert::Result::TestSkipped) do
-        context.instance_eval(&context.class.suite.tests.last.code)
+        context.instance_eval(&test.code)
       end
 
-      assert_equal 1,      context.class.suite.tests.size
+      assert_equal 1,      context.class.suite.tests_to_run_count
       assert_equal 'TODO', err.message
       assert_equal 1,      err.backtrace.size
     end
 
     should "skip with the msg \"TODO\" when `test` called with no block" do
       d = @test_desc
-      context = build_eval_context { test(d) } # no block passed
+      context, test = build_eval_context { test(d) } # no block passed
       err = capture_err(Assert::Result::TestSkipped) do
-        context.instance_eval(&context.class.suite.tests.last.code)
+        context.instance_eval(&test.code)
       end
 
-      assert_equal 1,      context.class.suite.tests.size
+      assert_equal 1,      context.class.suite.tests_to_run_count
       assert_equal 'TODO', err.message
       assert_equal 1,      err.backtrace.size
     end
 
     should "skip with the msg \"TODO\" when `should` called with no block" do
       d = @test_desc
-      context = build_eval_context { should(d) } # no block passed
+      context, test = build_eval_context { should(d) } # no block passed
       err = capture_err(Assert::Result::TestSkipped) do
-        context.instance_eval(&context.class.suite.tests.last.code)
+        context.instance_eval(&test.code)
       end
 
-      assert_equal 1,      context.class.suite.tests.size
+      assert_equal 1,      context.class.suite.tests_to_run_count
       assert_equal 'TODO', err.message
       assert_equal 1,      err.backtrace.size
     end
 
     should "skip with the msg \"TODO\" when `test_eventually` called with no block" do
       d = @test_desc
-      context = build_eval_context{ test_eventually(d) } # no block given
+      context, test = build_eval_context{ test_eventually(d) } # no block given
       err = capture_err(Assert::Result::TestSkipped) do
-        context.instance_eval(&context.class.suite.tests.last.code)
+        context.instance_eval(&test.code)
       end
 
-      assert_equal 1,      context.class.suite.tests.size
+      assert_equal 1,      context.class.suite.tests_to_run_count
       assert_equal 'TODO', err.message
       assert_equal 1,      err.backtrace.size
     end
 
     should "skip with the msg \"TODO\" when `should_eventually` called with no block" do
       d = @test_desc
-      context = build_eval_context{ should_eventually(d) } # no block given
+      context, test = build_eval_context{ should_eventually(d) } # no block given
       err = capture_err(Assert::Result::TestSkipped) do
-        context.instance_eval(&context.class.suite.tests.last.code)
+        context.instance_eval(&test.code)
       end
 
-      assert_equal 1,      context.class.suite.tests.size
+      assert_equal 1,      context.class.suite.tests_to_run_count
       assert_equal 'TODO', err.message
       assert_equal 1,      err.backtrace.size
     end
@@ -115,7 +109,7 @@ module Assert::Context::TestDSL
       m = Assert::Macro.new{ test(d, &b); test(d, &b) }
       context_class = Factory.modes_off_context_class{ test(m) }
 
-      assert_equal 2, context_class.suite.tests.size
+      assert_equal 2, context_class.suite.tests_to_run_count
     end
 
     should "build a test from a macro using `should`" do
@@ -123,28 +117,28 @@ module Assert::Context::TestDSL
       m = Assert::Macro.new{ should(d, &b); should(d, &b) }
       context_class = Factory.modes_off_context_class{ should(m) }
 
-      assert_equal 2, context_class.suite.tests.size
+      assert_equal 2, context_class.suite.tests_to_run_count
     end
 
     should "build a test that skips from a macro using `test_eventually`" do
       d, b = @test_desc, @test_block
       m = Assert::Macro.new{ test(d, &b); test(d, &b) }
-      context = build_eval_context{ test_eventually(m) }
+      context, test = build_eval_context{ test_eventually(m) }
 
-      assert_equal 1, context.class.suite.tests.size
+      assert_equal 1, context.class.suite.tests_to_run_count
       assert_raises(Assert::Result::TestSkipped) do
-        context.instance_eval(&context.class.suite.tests.last.code)
+        context.instance_eval(&test.code)
       end
     end
 
     should "build a test that skips from a macro using `should_eventually`" do
       d, b = @test_desc, @test_block
       m = Assert::Macro.new{ should(d, &b); should(d, &b) }
-      context = build_eval_context{ should_eventually(m) }
+      context, test = build_eval_context{ should_eventually(m) }
 
-      assert_equal 1, context.class.suite.tests.size
+      assert_equal 1, context.class.suite.tests_to_run_count
       assert_raises(Assert::Result::TestSkipped) do
-        context.instance_eval(&context.class.suite.tests.last.code)
+        context.instance_eval(&test.code)
       end
 
     end
@@ -153,9 +147,8 @@ module Assert::Context::TestDSL
 
     def build_eval_context(&build_block)
       context_class = Factory.modes_off_context_class &build_block
-      context_info  = Factory.context_info(context_class)
-      test = Factory.test("whatever", context_info)
-      context_class.new(test, test.config, proc{ |r| })
+      test = context_class.suite.sorted_tests_to_run.to_a.last
+      [context_class.new(test, test.config, proc{ |r| }), test]
     end
 
     def capture_err(err_class, &block)

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -114,7 +114,7 @@ class Assert::Runner
       assert_includes exp, @view_output
 
       @view_output.gsub!(/./, '')
-      @config.suite.tests.clear
+      @config.suite.clear_tests_to_run
       subject.run
       assert_not_includes exp, @view_output
     end


### PR DESCRIPTION
It was premature to assume this behavior was specific to just the
default suite.  Any suite, regardless of how they accumulate test
or result counts, will need to keep the tests in memory as they
need the test code blocks to run.  I discussed the likely need to
do this back in PR 268.

This also removes the tests accessor on the suite and updates the
descriptions of both the suite and default suite.  The tests that
were relying on the tests accessor were updated accordingly to use
the proper test handling methods on the suite.

This is all part of the effort to accumulate test run data instead
of storing off the actualy test objs and the result objs they
produce.

See #268 for reference.

@jcredding ready for review.