### PR TITLE
accumulate: update `with_backtrace` to not rely on test `results`

### DIFF
--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -264,6 +264,12 @@ module Assert
       end
     end
 
+    private
+
+    def __assert_config__
+      raise NotImplementedError # should be defined by the config mixing this in
+    end
+
     # exception raised utility classes
 
     class CheckException

--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -48,13 +48,18 @@ module Assert
     end
 
     def initialize(running_test, config, result_callback)
-      @__running_test__    = running_test
-      @__assert_config__   = config
-      @__result_callback__ = result_callback
+      @__assert_running_test__ = running_test
+      @__assert_config__       = config
+      @__assert_with_bt__      = nil
+
+      @__assert_result_callback__ = proc do |result|
+        result.set_backtrace(@__assert_with_bt__) if !@__assert_with_bt__.nil?
+        result_callback.call(result)
+      end
     end
 
-    # check if the assertion is a truthy value, if so create a new pass result, otherwise
-    # create a new fail result with the desc and what failed msg.
+    # check if the assertion is a truthy value, if so create a new pass result,
+    # otherwise create a new fail result with the desc and what failed msg.
     # all other assertion helpers use this one in the end
     def assert(assertion, desc = nil)
       if assertion
@@ -63,7 +68,8 @@ module Assert
         what = if block_given?
           yield
         else
-          "Failed assert: assertion was `#{Assert::U.show(assertion, __assert_config__)}`."
+          "Failed assert: assertion was "\
+          "`#{Assert::U.show(assertion, __assert_config__)}`."
         end
         fail(fail_message(desc, what))
       end
@@ -73,7 +79,8 @@ module Assert
     # result, otherwise create a new fail result with the desc and it's what failed msg
     def assert_not(assertion, fail_desc = nil)
       assert(!assertion, fail_desc) do
-        "Failed assert_not: assertion was `#{Assert::U.show(assertion, __assert_config__)}`."
+        "Failed assert_not: assertion was "\
+        "`#{Assert::U.show(assertion, __assert_config__)}`."
       end
     end
     alias_method :refute, :assert_not
@@ -107,24 +114,24 @@ module Assert
     end
     alias_method :flunk, :fail
 
-    # adds a Skip result to the end of the test's results and breaks test execution
+    # adds a Skip result to the end of the test's results
+    # breaks test execution
     def skip(skip_msg = nil, called_from = nil)
       err = Result::TestSkipped.new(skip_msg || '')
       err.set_backtrace([called_from]) if called_from
       raise(err)
     end
 
-    # alter the backtraces of fail results generated in the given block
+    # alter the backtraces of fail/skip results generated in the given block
     def with_backtrace(bt, &block)
       bt ||= []
-      current_results.size.tap do |size|
-        begin
-          instance_eval(&block)
-        rescue Result::TestSkipped, Result::TestFailure => e
-          e.set_backtrace(bt); raise(e)
-        ensure
-          current_results[size..-1].each{ |r| r.set_backtrace(bt) }
-        end
+      begin
+        @__assert_with_bt__ = bt
+        instance_eval(&block)
+      rescue Result::TestSkipped, Result::TestFailure => e
+        e.set_backtrace(@__assert_with_bt__); raise(e)
+      ensure
+        @__assert_with_bt__ = nil
       end
     end
 
@@ -140,7 +147,8 @@ module Assert
 
     protected
 
-    # Returns a Proc that will output a custom message along with the default fail message.
+    # Returns a Proc that will output a custom message along with the default
+    # fail message.
     def fail_message(fail_desc = nil, what_failed_msg = nil)
       [ fail_desc, what_failed_msg ].compact.join("\n")
     end
@@ -153,18 +161,13 @@ module Assert
 
     def capture_result
       if block_given?
-        result = yield __running_test__, caller
-        __running_test__.capture_result(result, @__result_callback__)
+        result = yield @__assert_running_test__, caller
+        @__assert_running_test__.capture_result(
+          result,
+          @__assert_result_callback__
+        )
         result
       end
-    end
-
-    def current_results
-      __running_test__.results
-    end
-
-    def __running_test__
-      @__running_test__
     end
 
     def __assert_config__


### PR DESCRIPTION
This is prep for no longer storing results on tests.  We can't rely
on a test knowing its results going forward.  I already broke this
method back in PR 269 b/c results are getting accumulated before
this method could set the proper backtrace on them.  This fixes
the regression and preps for a test not knowing its results anymore.

Note: this does some cleanups to the `__whatever__` variables/methods
on the context.  These weirdly named vars are needed by the context
but we don't want to pollute the variable/method space b/c users
will be defining their own variables/methods.  I updated the handling
of these just as cleanups and I added `assert` to each one's name
to add extra protection against name collisions with user defined
things.

See #269 for reference.

@jcredding ready for review.