### PR TITLE
accumulate: more fixes to result handling and view sorting

### DIFF
--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -150,20 +150,20 @@ module Assert
       end
     end
 
-    attrs = [:type, :details, :output, :file_name, :line_num, :test_id]
+    attrs = [:type, :details, :output, :test_id, :sort_by]
     class ResultData < Struct.new(*attrs)
       def self.for_result(r)
-        self.new(r.type, r.to_s, r.output, r.file_name, r.line_num, r.test_id)
+        self.new(r.type, r.to_s, r.output, r.test_id, self.sort_by(r))
       end
 
-      def file_name_and_line_num
-        [self.file_name, self.line_num]
+      def self.sort_by(r)
+        [r.test_file_name, r.test_line_num, r.file_name, r.line_num]
       end
 
       def <=>(other_rd)
         # show in reverse definition order
         if other_rd.kind_of?(ResultData)
-          other_rd.file_name_and_line_num <=> self.file_name_and_line_num
+          other_rd.sort_by <=> self.sort_by
         else
           super
         end

--- a/lib/assert/file_line.rb
+++ b/lib/assert/file_line.rb
@@ -3,7 +3,7 @@ module Assert
   class FileLine
 
     def self.parse(file_line_path)
-      self.new(*(file_line_path.to_s.match(/(^[^\:]*)\:*(\d*)$/) || [])[1..2])
+      self.new(*(file_line_path.to_s.match(/(^[^\:]*)\:*(\d*).*$/) || [])[1..2])
     end
 
     attr_reader :file, :line

--- a/test/unit/file_line_tests.rb
+++ b/test/unit/file_line_tests.rb
@@ -14,7 +14,10 @@ class Assert::FileLine
     should have_imeths :parse
 
     should "know how to parse and init from a file line path string" do
-      file_line_path = "#{@file}:#{@line}"
+      file_line_path = [
+        "#{@file}:#{@line}",
+        "#{@file}:#{@line} #{Factory.string}"
+      ].sample
       file_line = subject.parse(file_line_path)
 
       assert_equal @file, file_line.file

--- a/test/unit/result_tests.rb
+++ b/test/unit/result_tests.rb
@@ -43,7 +43,7 @@ module Assert::Result
         :type           => Factory.string,
         :name           => Factory.string,
         :test_name      => Factory.string,
-        :test_file_line => Factory.string,
+        :test_file_line => Assert::FileLine.new(Factory.string, Factory.integer),
         :message        => Factory.string,
         :output         => Factory.text,
         :backtrace      => Backtrace.new(caller),
@@ -54,7 +54,8 @@ module Assert::Result
     subject{ @result }
 
     should have_cmeths :type, :name, :for_test
-    should have_imeths :type, :name, :test_name, :test_file_line, :test_id
+    should have_imeths :type, :name, :test_name, :test_file_line
+    should have_imeths :test_file_name, :test_line_num, :test_id
     should have_imeths :message, :output, :backtrace, :trace
     should have_imeths :file_line, :file_name, :line_num
     should have_imeths *Assert::Result.types.keys.map{ |k| "#{k}?" }
@@ -86,7 +87,6 @@ module Assert::Result
       assert_equal @given_data[:name],           subject.name
       assert_equal @given_data[:test_name],      subject.test_name
       assert_equal @given_data[:test_file_line], subject.test_file_line
-      assert_equal @given_data[:test_file_line], subject.test_id
       assert_equal @given_data[:message],        subject.message
       assert_equal @given_data[:output],         subject.output
       assert_equal @given_data[:backtrace],      subject.backtrace
@@ -96,19 +96,54 @@ module Assert::Result
     should "default its attrs" do
       result = Base.new({})
 
-      assert_equal :unknown,          result.type
-      assert_equal '',                result.name
-      assert_equal '',                result.test_name
-      assert_equal '',                result.test_file_line
-      assert_equal '',                result.test_id
-      assert_equal '',                result.message
-      assert_equal '',                result.output
-      assert_equal Backtrace.new([]), result.backtrace
-      assert_equal '',                result.trace
+      assert_equal :unknown,                   result.type
+      assert_equal '',                         result.name
+      assert_equal '',                         result.test_name
+      assert_equal Assert::FileLine.parse(''), result.test_file_line
+      assert_equal '',                         result.message
+      assert_equal '',                         result.output
+      assert_equal Backtrace.new([]),          result.backtrace
+      assert_equal '',                         result.trace
+    end
+
+    should "know its test file line attrs" do
+      exp = @given_data[:test_file_line]
+      assert_equal exp.file,      subject.test_file_name
+      assert_equal exp.line.to_i, subject.test_line_num
+      assert_equal exp.to_s,      subject.test_id
+    end
+
+    should "allow setting a new backtrace" do
+      new_bt        = Factory.integer(3).times.map{ Factory.string }
+      exp_backtrace = Backtrace.new(new_bt)
+      exp_trace     = exp_backtrace.filtered.first.to_s
+      subject.set_backtrace(new_bt)
+      assert_equal exp_backtrace, subject.backtrace
+      assert_equal exp_trace,     subject.trace
+
+      # test that the first bt line is used if filtered is empty
+      assert_lib_path = File.join(ROOT_PATH, "lib/#{Factory.string}:#{Factory.integer}")
+      new_bt          = Factory.integer(3).times.map{ assert_lib_path }
+      exp_backtrace   = Backtrace.new(new_bt)
+      exp_trace       = exp_backtrace.first.to_s
+      subject.set_backtrace(new_bt)
+      assert_equal exp_backtrace, subject.backtrace
+      assert_equal exp_trace,     subject.trace
     end
 
     should "know its file line attrs" do
+      new_bt = Factory.integer(3).times.map{ Factory.string }
+      subject.set_backtrace(new_bt)
       exp = Assert::FileLine.parse(subject.backtrace.filtered.first.to_s)
+      assert_equal exp,           subject.file_line
+      assert_equal exp.file,      subject.file_name
+      assert_equal exp.line.to_i, subject.line_num
+
+      # test that the first bt line is used if filtered is empty
+      assert_lib_path = File.join(ROOT_PATH, "lib/#{Factory.string}:#{Factory.integer}")
+      new_bt = Factory.integer(3).times.map{ assert_lib_path }
+      subject.set_backtrace(new_bt)
+      exp = Assert::FileLine.parse(subject.backtrace.first.to_s)
       assert_equal exp,           subject.file_line
       assert_equal exp.file,      subject.file_name
       assert_equal exp.line.to_i, subject.line_num
@@ -120,17 +155,6 @@ module Assert::Result
         Assert.stub(subject, :type){ type }
         assert_true subject.send("#{type}?")
       end
-    end
-
-    should "allow setting a new backtrace" do
-      new_bt        = Factory.integer(3).times.map{ Factory.string }
-      exp_backtrace = Backtrace.new(new_bt)
-      exp_trace     = exp_backtrace.filtered.first.to_s
-
-      subject.set_backtrace(new_bt)
-
-      assert_equal exp_backtrace, subject.backtrace
-      assert_equal exp_trace,     subject.trace
     end
 
     should "know its symbol representation" do
@@ -162,8 +186,10 @@ module Assert::Result
     end
 
     should "show only its class and message when inspected" do
-      exp = "#<#{subject.class}:#{'0x0%x' % (subject.object_id << 1)}"\
-            " @message=#{subject.message.inspect}>"
+      exp = "#<#{subject.class}:#{'0x0%x' % (subject.object_id << 1)} "\
+            "@message=#{subject.message.inspect} "\
+            "@file_line=#{subject.file_line.to_s.inspect} "\
+            "@test_file_line=#{subject.test_file_line.to_s.inspect}>"
       assert_equal exp, subject.inspect
     end
 


### PR DESCRIPTION
This is part of reworking assert to accumulate test run data and
came out of trying to remove the `results` accessor from the test
object (a future effort).  In working on this effort, I broke a
bunch of tests.  I noticed that the test results weren't ordered
as I expected and I started to investigate.

The first thing I noticed was that for the error result backtraces,
the line used for the result file line included extra characters
after the line number (`".../test_tests.rb:123 in some_method"` for
example).  The file line wasn't parsing the backtrace lines
correctly.  So I updated the file line to properly parse backtrace
lines in this form.

Once that was corrected, I noticed that errors that occurred in
Assert's lib source code were being shown first, regardless of the
definition order of the test that generated the error result.  The
first problem was that the result file line used to sort the results
was built off the first filtered backtrace line.  If the backtrace
only contained assert lib lines, the filtered backtrace would be
empty.  So I added a check for empty filtered backtraces and set
the `trace` attr to the first filtered line if present but fall
back to just the first line of the backtrace if not.  Note: the
case where the filtered backtrace is empty is pretty edge - it
should only occur when errors in Assert's test suite come from the
lib source.  This shouldn't occur in any other test suites.

This change got the errors coming from Assert's lib source to now
have a file line but they were still not sorting as expected.  This
was b/c their file line (in Assert's lib source) comes before any
results with a file line in Assert's test source.  This is true of
any test suite - the results generated from non-test code would
always be sorted before results generated from test code,  So this
led me to rework how the view's result data is sorted.  It is now
sorted first by the test's file line and then by the results file
line. This does two things: it ensures all results are jux'd next
to other results from the same test and results are always sorted
by the test that generates them. Within a single test, results will
be sorted by the code file line that generated the result.

Changing the result data sort behavior required me to formally
model not only the test file line, but also the test file name and
test line num.  This matches the result file name and line num
attrs and allows proper sorting.  I also chose to make the test file
line an actual file line object.  The test id attr is still the
string form of the test file line (no change from before).

Note: I also updated the result `inspect` method to include both
the file line and test file line info.  I figured this was helpful
info for determining where a result came from when debugging.

@jcredding whew - that may be the longest commit msg I've ever written.  Sorry for the novel, but I didn't know a better way to give context on where all these rando result changes were coming from and why.  Essentially this is more fall-out from switching to explicit ordering of result data in the view.  I'm happy with the result, though, as it highlighted some edge-case deficiencies in calculating the file lines and cleaned up some result behavior.  Anyway, ready for review. 