### PR TITLE
accumulate: prep tests for removing `results` from test objects

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -17,3 +17,43 @@ if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
     alias_method :sample, :choice
   end
 end
+
+class Assert::Test
+
+  module TestHelpers
+
+    def self.included(receiver)
+      receiver.class_eval do
+        setup do
+          @test_run_results = []
+          @run_callback = proc{ |result| @test_run_results << result }
+        end
+      end
+
+      private
+
+      def test_run_callback
+        @run_callback
+      end
+
+      def test_run_results(type = nil)
+        return @test_run_results if type.nil?
+        @test_run_results.select{ |r| r.type == type }
+      end
+
+      def test_run_result_count(type = nil)
+        test_run_results(type).count
+      end
+
+      def test_run_result_messages
+        @test_run_results.map(&:message)
+      end
+
+      def last_test_run_result
+        @test_run_results.last
+      end
+    end
+
+  end
+
+end

--- a/test/system/test_tests.rb
+++ b/test/system/test_tests.rb
@@ -3,6 +3,8 @@ require 'assert'
 class Assert::Test
 
   class SystemTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "Assert::Test"
     subject{ @test }
 
@@ -12,11 +14,11 @@ class Assert::Test
     desc "when producing no results"
     setup do
       @test = Factory.test
-      @test.run
+      @test.run(&test_run_callback)
     end
 
-    should "have 0 results" do
-      assert_equal 0, subject.result_count
+    should "generate 0 results" do
+      assert_equal 0, test_run_result_count
     end
 
   end
@@ -25,15 +27,15 @@ class Assert::Test
     desc "when passing a single assertion"
     setup do
       @test = Factory.test{ assert(1 == 1) }
-      @test.run
+      @test.run(&test_run_callback)
     end
 
-    should "have 1 result" do
-      assert_equal 1, subject.result_count
+    should "generate 1 result" do
+      assert_equal 1, test_run_result_count
     end
 
-    should "have 1 pass result" do
-      assert_equal 1, subject.result_count(:pass)
+    should "generate 1 pass result" do
+      assert_equal 1, test_run_result_count(:pass)
     end
 
   end
@@ -42,15 +44,15 @@ class Assert::Test
     desc "when failing a single assertion"
     setup do
       @test = Factory.test{ assert(1 == 0) }
-      @test.run
+      @test.run(&test_run_callback)
     end
 
-    should "have 1 result" do
-      assert_equal 1, subject.result_count
+    should "generate 1 result" do
+      assert_equal 1, test_run_result_count
     end
 
-    should "have 1 fail result" do
-      assert_equal 1, subject.result_count(:fail)
+    should "generate 1 fail result" do
+      assert_equal 1, test_run_result_count(:fail)
     end
 
   end
@@ -59,15 +61,15 @@ class Assert::Test
     desc "when skipping once"
     setup do
       @test = Factory.test{ skip }
-      @test.run
+      @test.run(&test_run_callback)
     end
 
-    should "have 1 result" do
-      assert_equal 1, subject.result_count
+    should "generate 1 result" do
+      assert_equal 1, test_run_result_count
     end
 
-    should "have 1 skip result" do
-      assert_equal 1, subject.result_count(:skip)
+    should "generate 1 skip result" do
+      assert_equal 1, test_run_result_count(:skip)
     end
 
   end
@@ -76,15 +78,15 @@ class Assert::Test
     desc "when erroring once"
     setup do
       @test = Factory.test{ raise("WHAT") }
-      @test.run
+      @test.run(&test_run_callback)
     end
 
-    should "have 1 result" do
-      assert_equal 1, subject.result_count
+    should "generate 1 result" do
+      assert_equal 1, test_run_result_count
     end
 
-    should "have 1 error result" do
-      assert_equal 1, subject.result_count(:error)
+    should "generate 1 error result" do
+      assert_equal 1, test_run_result_count(:error)
     end
 
   end
@@ -96,19 +98,19 @@ class Assert::Test
         assert(1 == 1)
         assert(1 == 0)
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
 
-    should "have 2 total results" do
-      assert_equal 2, subject.result_count
+    should "generate 2 total results" do
+      assert_equal 2, test_run_result_count
     end
 
-    should "have 1 pass result" do
-      assert_equal 1, subject.result_count(:pass)
+    should "generate 1 pass result" do
+      assert_equal 1, test_run_result_count(:pass)
     end
 
-    should "have 1 fail result" do
-      assert_equal 1, subject.result_count(:fail)
+    should "generate 1 fail result" do
+      assert_equal 1, test_run_result_count(:fail)
     end
 
   end
@@ -121,27 +123,27 @@ class Assert::Test
         skip
         assert(1 == 0)
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
 
-    should "have 2 total results" do
-      assert_equal 2, subject.result_count
+    should "generate 2 total results" do
+      assert_equal 2, test_run_result_count
     end
 
-    should "have a skip for its last result" do
-      assert_kind_of Assert::Result::Skip, subject.results.last
+    should "generate a skip for its last result" do
+      assert_kind_of Assert::Result::Skip, last_test_run_result
     end
 
-    should "have 1 pass result" do
-      assert_equal 1, subject.result_count(:pass)
+    should "generate 1 pass result" do
+      assert_equal 1, test_run_result_count(:pass)
     end
 
-    should "have 1 skip result" do
-      assert_equal 1, subject.result_count(:skip)
+    should "generate 1 skip result" do
+      assert_equal 1, test_run_result_count(:skip)
     end
 
-    should "have 0 fail results" do
-      assert_equal 0, subject.result_count(:fail)
+    should "generate 0 fail results" do
+      assert_equal 0, test_run_result_count(:fail)
     end
 
   end
@@ -154,27 +156,27 @@ class Assert::Test
         raise Exception, "something errored"
         assert(1 == 0)
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
 
-    should "have 2 total results" do
-      assert_equal 2, subject.result_count
+    should "generate 2 total results" do
+      assert_equal 2, test_run_result_count
     end
 
-    should "have an error for its last result" do
-      assert_kind_of Assert::Result::Error, subject.results.last
+    should "generate an error for its last result" do
+      assert_kind_of Assert::Result::Error, last_test_run_result
     end
 
-    should "have 1 pass result" do
-      assert_equal 1, subject.result_count(:pass)
+    should "generate 1 pass result" do
+      assert_equal 1, test_run_result_count(:pass)
     end
 
-    should "have 1 error result" do
-      assert_equal 1, subject.result_count(:error)
+    should "generate 1 error result" do
+      assert_equal 1, test_run_result_count(:error)
     end
 
-    should "have 0 fail results" do
-      assert_equal 0, subject.result_count(:fail)
+    should "generate 0 fail results" do
+      assert_equal 0, test_run_result_count(:fail)
     end
 
   end
@@ -187,23 +189,23 @@ class Assert::Test
         pass
         assert(1 == 0)
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
 
-    should "have 3 total results" do
-      assert_equal 3, subject.result_count
+    should "generate 3 total results" do
+      assert_equal 3, test_run_result_count
     end
 
-    should "have a fail for its last result" do
-      assert_kind_of Assert::Result::Fail, subject.results.last
+    should "generate a fail for its last result" do
+      assert_kind_of Assert::Result::Fail, last_test_run_result
     end
 
-    should "have 2 pass results" do
-      assert_equal 2, subject.result_count(:pass)
+    should "generate 2 pass results" do
+      assert_equal 2, test_run_result_count(:pass)
     end
 
-    should "have 1 fail result" do
-      assert_equal 1, subject.result_count(:fail)
+    should "generate 1 fail result" do
+      assert_equal 1, test_run_result_count(:fail)
     end
 
   end
@@ -216,23 +218,23 @@ class Assert::Test
         fail
         assert(1 == 1)
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
 
-    should "have 3 total results" do
-      assert_equal 3, subject.result_count
+    should "generate 3 total results" do
+      assert_equal 3, test_run_result_count
     end
 
-    should "have a pass for its last result" do
-      assert_kind_of Assert::Result::Pass, subject.results.last
+    should "generate a pass for its last result" do
+      assert_kind_of Assert::Result::Pass, last_test_run_result
     end
 
-    should "have 1 pass result" do
-      assert_equal 1, subject.result_count(:pass)
+    should "generate 1 pass result" do
+      assert_equal 1, test_run_result_count(:pass)
     end
 
-    should "have 2 fail results" do
-      assert_equal 2, subject.result_count(:fail)
+    should "generate 2 fail results" do
+      assert_equal 2, test_run_result_count(:fail)
     end
 
   end
@@ -245,23 +247,23 @@ class Assert::Test
         flunk
         assert(1 == 1)
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
 
-    should "have 3 total results" do
-      assert_equal 3, subject.result_count
+    should "generate 3 total results" do
+      assert_equal 3, test_run_result_count
     end
 
-    should "have a pass for its last result" do
-      assert_kind_of Assert::Result::Pass, subject.results.last
+    should "generate a pass for its last result" do
+      assert_kind_of Assert::Result::Pass, last_test_run_result
     end
 
-    should "have 1 pass results" do
-      assert_equal 1, subject.result_count(:pass)
+    should "generate 1 pass results" do
+      assert_equal 1, test_run_result_count(:pass)
     end
 
-    should "have 2 fail results" do
-      assert_equal 2, subject.result_count(:fail)
+    should "generate 2 fail results" do
+      assert_equal 2, test_run_result_count(:fail)
     end
 
   end
@@ -276,14 +278,14 @@ class Assert::Test
         def setup; pass 'test/unit style setup'; end
       end
       @test = Factory.test("t", Factory.context_info(@context_class)){ pass 'TEST' }
-      @test.run
+      @test.run(&test_run_callback)
     end
 
     should "execute all setup logic when run" do
-      assert_equal 3, subject.result_count(:pass)
+      assert_equal 3, test_run_result_count(:pass)
 
       exp = ['assert style setup', 'test/unit style setup', 'TEST']
-      assert_equal exp, subject.results.map(&:message)
+      assert_equal exp, test_run_result_messages
     end
 
   end
@@ -298,14 +300,14 @@ class Assert::Test
         def teardown; pass 'test/unit style teardown'; end
       end
       @test = Factory.test("t", Factory.context_info(@context_class)){ pass 'TEST' }
-      @test.run
+      @test.run(&test_run_callback)
     end
 
     should "execute all teardown logic when run" do
-      assert_equal 3, subject.result_count(:pass)
+      assert_equal 3, test_run_result_count(:pass)
 
       exp = ['TEST', 'assert style teardown', 'test/unit style teardown']
-      assert_equal exp, subject.results.map(&:message)
+      assert_equal exp, test_run_result_messages
     end
 
   end
@@ -339,11 +341,11 @@ class Assert::Test
         teardown{ pass "child teardown2" }
       end
       @test = Factory.test("t", Factory.context_info(@context_class)){ pass "TEST" }
-      @test.run
+      @test.run(&test_run_callback)
     end
 
     should "run the arounds outside of the setups/teardowns/test" do
-      assert_equal 13, subject.result_count(:pass)
+      assert_equal 13, test_run_result_count(:pass)
 
       exp = [
         'parent around start', 'child around1 start', 'child around2 start',
@@ -351,7 +353,7 @@ class Assert::Test
         'child teardown1', 'child teardown2', 'parent teardown',
         'child around2 end', 'child around1 end', 'parent around end'
       ]
-      assert_equal exp, subject.results.map(&:message)
+      assert_equal exp, test_run_result_messages
     end
 
   end

--- a/test/unit/assertions/assert_block_tests.rb
+++ b/test/unit/assertions/assert_block_tests.rb
@@ -4,6 +4,8 @@ require 'assert/assertions'
 module Assert::Assertions
 
   class AssertBlockTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_block`"
     setup do
       desc = @desc = "assert block fail desc"
@@ -11,24 +13,26 @@ module Assert::Assertions
         assert_block{ true }        # pass
         assert_block(desc){ false } # fail
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@desc}\nExpected block to return a true value."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertNotBlockTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_not_block`"
     setup do
       desc = @desc = "assert not block fail desc"
@@ -36,19 +40,19 @@ module Assert::Assertions
         assert_not_block(desc){ true } # fail
         assert_not_block{ false }      # pass
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@desc}\nExpected block to not return a true value."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end

--- a/test/unit/assertions/assert_empty_tests.rb
+++ b/test/unit/assertions/assert_empty_tests.rb
@@ -6,6 +6,8 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertEmptyTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_empty`"
     setup do
       desc = @desc = "assert empty fail desc"
@@ -15,24 +17,26 @@ module Assert::Assertions
         assert_empty(*args) # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to be empty."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertNotEmptyTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_not_empty`"
     setup do
       desc = @desc = "assert not empty fail desc"
@@ -42,19 +46,19 @@ module Assert::Assertions
         assert_not_empty(*args) # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to not be empty."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end

--- a/test/unit/assertions/assert_equal_tests.rb
+++ b/test/unit/assertions/assert_equal_tests.rb
@@ -6,6 +6,8 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertEqualTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_equal`"
     setup do
       desc = @desc = "assert equal fail desc"
@@ -15,25 +17,27 @@ module Assert::Assertions
         assert_equal(*a)   # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@a[2]}\nExpected #{Assert::U.show(@a[1], @c)}"\
             " to be equal to #{Assert::U.show(@a[0], @c)}."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertNotEqualTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_not_equal`"
     setup do
       desc = @desc = "assert not equal fail desc"
@@ -43,25 +47,27 @@ module Assert::Assertions
         assert_not_equal(1, 2) # pass
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@a[2]}\nExpected #{Assert::U.show(@a[1], @c)}"\
             " to not be equal to #{Assert::U.show(@a[0], @c)}."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class EqualOrderTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "with objects that define custom equality operators"
     setup do
       is_class = Class.new do
@@ -83,6 +89,8 @@ module Assert::Assertions
   end
 
   class DiffTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "with objects that should use diff when showing"
     setup do
       @exp_obj = "I'm a\nstring"
@@ -105,14 +113,14 @@ module Assert::Assertions
       @test = Factory.test(@c) do
         assert_equal(exp_obj, act_obj)
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "include diff output in the fail messages" do
       exp = "Expected does not equal actual, diff:\n"\
             "#{Assert::U.syscmd_diff_proc.call(@exp_obj_show, @act_obj_show)}"
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
@@ -124,14 +132,14 @@ module Assert::Assertions
       @test = Factory.test(@c) do
         assert_not_equal(exp_obj, exp_obj)
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "include diff output in the fail messages" do
       exp = "Expected equals actual, diff:\n"\
             "#{Assert::U.syscmd_diff_proc.call(@exp_obj_show, @exp_obj_show)}"
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end

--- a/test/unit/assertions/assert_file_exists_tests.rb
+++ b/test/unit/assertions/assert_file_exists_tests.rb
@@ -6,6 +6,8 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertFileExistsTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_file_exists`"
     setup do
       desc = @desc = "assert file exists empty fail desc"
@@ -15,24 +17,26 @@ module Assert::Assertions
         assert_file_exists(*args)    # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to exist."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertNotFileExistsTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_not_file_exists`"
     setup do
       desc = @desc = "assert not file exists empty fail desc"
@@ -42,19 +46,19 @@ module Assert::Assertions
         assert_not_file_exists(*args) # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to not exist."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end

--- a/test/unit/assertions/assert_includes_tests.rb
+++ b/test/unit/assertions/assert_includes_tests.rb
@@ -6,6 +6,8 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertIncludesTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_includes`"
     setup do
       desc = @desc = "assert includes fail desc"
@@ -15,26 +17,28 @@ module Assert::Assertions
         assert_includes(*args)    # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
             "Expected #{Assert::U.show(@args[1], @c)}"\
             " to include #{Assert::U.show(@args[0], @c)}."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertNotIncludedTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_not_included`"
     setup do
       desc = @desc = "assert not included fail desc"
@@ -44,21 +48,21 @@ module Assert::Assertions
         assert_not_included(*args)    # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
             "Expected #{Assert::U.show(@args[1], @c)}"\
             " to not include #{Assert::U.show(@args[0], @c)}."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end

--- a/test/unit/assertions/assert_instance_of_tests.rb
+++ b/test/unit/assertions/assert_instance_of_tests.rb
@@ -6,6 +6,8 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertInstanceOfTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_instance_of`"
     setup do
       desc = @desc = "assert instance of fail desc"
@@ -15,25 +17,27 @@ module Assert::Assertions
         assert_instance_of(*args)            # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
             " to be an instance of #{@args[0]}."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertNotInstanceOfTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_not_instance_of`"
     setup do
       desc = @desc = "assert not instance of fail desc"
@@ -43,20 +47,20 @@ module Assert::Assertions
         assert_not_instance_of(Array, "object") # pass
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
             " to not be an instance of #{@args[0]}."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end

--- a/test/unit/assertions/assert_kind_of_tests.rb
+++ b/test/unit/assertions/assert_kind_of_tests.rb
@@ -6,6 +6,8 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertKindOfTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_kind_of`"
     setup do
       desc = @desc = "assert kind of fail desc"
@@ -15,25 +17,27 @@ module Assert::Assertions
         assert_kind_of(*args)            # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
             " to be a kind of #{@args[0]}."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertNotKindOfTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_not_kind_of`"
     setup do
       desc = @desc = "assert not kind of fail desc"
@@ -43,20 +47,20 @@ module Assert::Assertions
         assert_not_kind_of(Array, "object") # pass
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
             " to not be a kind of #{@args[0]}."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end

--- a/test/unit/assertions/assert_match_tests.rb
+++ b/test/unit/assertions/assert_match_tests.rb
@@ -6,6 +6,8 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertMatchTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_match`"
     setup do
       desc = @desc = "assert match fail desc"
@@ -15,25 +17,27 @@ module Assert::Assertions
         assert_match(*args)           # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)}"\
             " to match #{Assert::U.show(@args[0], @c)}."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertNotMatchTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_not_match`"
     setup do
       desc = @desc = "assert not match fail desc"
@@ -43,20 +47,20 @@ module Assert::Assertions
         assert_not_match("not", "a string") # pass
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)}"\
             " to not match #{Assert::U.show(@args[0], @c)}."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end

--- a/test/unit/assertions/assert_nil_tests.rb
+++ b/test/unit/assertions/assert_nil_tests.rb
@@ -6,6 +6,8 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertNilTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_nil`"
     setup do
       desc = @desc = "assert nil empty fail desc"
@@ -15,24 +17,26 @@ module Assert::Assertions
         assert_nil(*args) # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to be nil."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertNotNilTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_not_nil`"
     setup do
       desc = @desc = "assert not nil empty fail desc"
@@ -42,19 +46,19 @@ module Assert::Assertions
         assert_not_nil(*args) # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to not be nil."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end

--- a/test/unit/assertions/assert_raises_tests.rb
+++ b/test/unit/assertions/assert_raises_tests.rb
@@ -4,6 +4,8 @@ require 'assert/assertions'
 module Assert::Assertions
 
   class AssertRaisesTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_raises`"
     setup do
       d = @d = "assert raises fail desc"
@@ -14,14 +16,14 @@ module Assert::Assertions
         assert_raises(RuntimeError, d){ true }                             # fail
         assert_raises(d){ true }                                           # fail
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 5, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 4, subject.result_count(:fail)
+      assert_equal 5, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 4, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
@@ -31,7 +33,7 @@ module Assert::Assertions
         "#{@d}\nRuntimeError exception expected but nothing raised.",
         "#{@d}\nAn exception expected but nothing raised."
       ]
-      messages = @test.fail_results.map(&:message)
+      messages = test_run_results(:fail).map(&:message)
       messages.each_with_index{ |msg, n| assert_match /^#{exp[n]}/, msg }
     end
 
@@ -58,6 +60,8 @@ module Assert::Assertions
   end
 
   class AssertNothingRaisedTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_nothing_raised`"
     setup do
       d = @d = "assert nothing raised fail desc"
@@ -68,14 +72,14 @@ module Assert::Assertions
         self.send(anr, d){ raise(RuntimeError) }                               # fail
         self.send(anr){ true }                                                 # pass
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 4, subject.result_count
-      assert_equal 2, subject.result_count(:pass)
-      assert_equal 2, subject.result_count(:fail)
+      assert_equal 4, test_run_result_count
+      assert_equal 2, test_run_result_count(:pass)
+      assert_equal 2, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
@@ -83,7 +87,7 @@ module Assert::Assertions
         "#{@d}\nStandardError or RuntimeError exception not expected, but raised:",
         "#{@d}\nAn exception not expected, but raised:"
       ]
-      messages = @test.fail_results.map(&:message)
+      messages = test_run_results(:fail).map(&:message)
       messages.each_with_index{ |msg, n| assert_match /^#{exp[n]}/, msg }
     end
 

--- a/test/unit/assertions/assert_respond_to_tests.rb
+++ b/test/unit/assertions/assert_respond_to_tests.rb
@@ -6,6 +6,8 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertRespondToTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_respond_to`"
     setup do
       desc = @desc = "assert respond to fail desc"
@@ -15,26 +17,28 @@ module Assert::Assertions
         assert_respond_to(*args)   # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
             "Expected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
             " to respond to `#{@args[0]}`."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertNotRespondToTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_not_respond_to`"
     setup do
       desc = @desc = "assert not respond to fail desc"
@@ -44,21 +48,21 @@ module Assert::Assertions
         assert_not_respond_to(:abs, "1") # pass
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[2]}\n"\
             "Expected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
             " to not respond to `#{@args[0]}`."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end

--- a/test/unit/assertions/assert_same_tests.rb
+++ b/test/unit/assertions/assert_same_tests.rb
@@ -6,6 +6,8 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertSameTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_same`"
     setup do
       klass = Class.new; object = klass.new
@@ -16,14 +18,14 @@ module Assert::Assertions
         assert_same(*args)          # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
@@ -32,12 +34,14 @@ module Assert::Assertions
             " (#<#{@args[1].class}:#{'0x0%x' % (@args[1].object_id << 1)}>)"\
             " to be the same as #{Assert::U.show(@args[0], @c)}"\
             " (#<#{@args[0].class}:#{'0x0%x' % (@args[0].object_id << 1)}>)."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertNotSameTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_not_same`"
     setup do
       klass = Class.new; object = klass.new
@@ -48,14 +52,14 @@ module Assert::Assertions
         assert_not_same(object, klass.new) # pass
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
@@ -64,12 +68,14 @@ module Assert::Assertions
             " (#<#{@args[1].class}:#{'0x0%x' % (@args[1].object_id << 1)}>)"\
             " to not be the same as #{Assert::U.show(@args[0], @c)}"\
             " (#<#{@args[0].class}:#{'0x0%x' % (@args[0].object_id << 1)}>)."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class DiffTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "with objects that should use diff when showing"
     setup do
       @exp_obj = "I'm a\nstring"
@@ -92,7 +98,7 @@ module Assert::Assertions
       @test = Factory.test(@c) do
         assert_same(exp_obj, act_obj)
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
@@ -102,7 +108,7 @@ module Assert::Assertions
             " #<#{@exp_obj.class}:#{'0x0%x' % (@exp_obj.object_id << 1)}>"\
             ", diff:\n"\
             "#{Assert::U.syscmd_diff_proc.call(@exp_obj_show, @act_obj_show)}"
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
@@ -117,7 +123,7 @@ module Assert::Assertions
       @test = Factory.test(@c) do
         assert_not_same(exp_obj, exp_obj)
       end
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
@@ -127,7 +133,7 @@ module Assert::Assertions
             " #<#{@exp_obj.class}:#{'0x0%x' % (@exp_obj.object_id << 1)}>"\
             ", diff:\n"\
             "#{Assert::U.syscmd_diff_proc.call(@exp_obj_show, @act_obj_show)}"
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end

--- a/test/unit/assertions/assert_true_false_tests.rb
+++ b/test/unit/assertions/assert_true_false_tests.rb
@@ -6,6 +6,8 @@ require 'assert/utils'
 module Assert::Assertions
 
   class AssertTrueTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_true`"
     setup do
       desc = @desc = "assert true fail desc"
@@ -15,24 +17,26 @@ module Assert::Assertions
         assert_true(*args) # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to be true."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertNotTrueTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_not_true`"
     setup do
       desc = @desc = "assert not true fail desc"
@@ -42,24 +46,26 @@ module Assert::Assertions
         assert_not_true(*args) # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to not be true."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertFalseTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_false`"
     setup do
       desc = @desc = "assert false fail desc"
@@ -69,24 +75,26 @@ module Assert::Assertions
         assert_false(*args) # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to be false."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end
 
   class AssertNotFalseTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "`assert_not_false`"
     setup do
       desc = @desc = "assert not false fail desc"
@@ -96,19 +104,19 @@ module Assert::Assertions
         assert_not_false(*args) # fail
       end
       @c = @test.config
-      @test.run
+      @test.run(&test_run_callback)
     end
     subject{ @test }
 
     should "produce results as expected" do
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.result_count(:pass)
-      assert_equal 1, subject.result_count(:fail)
+      assert_equal 2, test_run_result_count
+      assert_equal 1, test_run_result_count(:pass)
+      assert_equal 1, test_run_result_count(:fail)
     end
 
     should "have a fail message with custom and generic explanations" do
       exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to not be false."
-      assert_equal exp, subject.fail_results.first.message
+      assert_equal exp, test_run_results(:fail).first.message
     end
 
   end

--- a/test/unit/assertions_tests.rb
+++ b/test/unit/assertions_tests.rb
@@ -4,6 +4,8 @@ require 'assert/assertions'
 module Assert::Assertions
 
   class UnitTests < Assert::Context
+    include Assert::Test::TestHelpers
+
     desc "Assert::Context"
     setup do
       @context_class = Factory.modes_off_context_class
@@ -43,23 +45,24 @@ module Assert::Assertions
           self.send(helper, "doesn't matter")
         end
       end
-      @expected_messages = Assert::Assertions::IGNORED_ASSERTION_HELPERS.map do |helper|
-        "The assertion `#{helper}` is not supported."\
-        " Please use another assertion or the basic `assert`."
-      end
-      @results = @tests.map(&:run).flatten
+      @tests.each{ |test| test.run(&test_run_callback) }
     end
-    subject{ @results }
 
     should "have an ignored result for each helper in the constant" do
-      subject.each do |result|
+      exp = Assert::Assertions::IGNORED_ASSERTION_HELPERS.size
+      assert_equal exp, test_run_result_count
+
+      test_run_results.each do |result|
         assert_kind_of Assert::Result::Ignore, result
       end
-      assert_equal(Assert::Assertions::IGNORED_ASSERTION_HELPERS.size, subject.size)
     end
 
     should "have a custom ignore message for each helper in the constant" do
-      assert_equal(@expected_messages, subject.collect(&:message))
+      exp = Assert::Assertions::IGNORED_ASSERTION_HELPERS.map do |helper|
+        "The assertion `#{helper}` is not supported."\
+        " Please use another assertion or the basic `assert`."
+      end
+      assert_equal exp, test_run_results.collect(&:message)
     end
 
   end


### PR DESCRIPTION
This reworks a bunch of the assertion tests and system tests to
not expect a test to know its results.  This is prep for removing
the `results` accessor from tests, which in turn is part of switching
to accumulating test run data.

I chose to break out a test helpers module so I could include it
on all the test contexts.  Since the tests all needed to accumulate
results and tested the results in a similar manner, this commonization
works.

I chose to break this out into a separate PR to remove some noise
from the coming effort where I remove the `results` accessor on
the Test class.

@jcredding ready for review.