### PR TITLE
accumulate: simplify `capture_result` in both test and context

### DIFF
--- a/test/unit/test_tests.rb
+++ b/test/unit/test_tests.rb
@@ -90,10 +90,9 @@ class Assert::Test
     end
     subject{ @test }
 
-    should have_readers :file_line, :name, :output, :run_time
-    should have_readers :context_info, :config, :code
-    should have_imeths :context_class, :file_name, :line_num
-    should have_imeths :capture_result, :run
+    should have_imeths :file_line, :file_name, :line_num
+    should have_imeths :name, :output, :run_time
+    should have_imeths :context_info, :context_class, :config, :code, :run
 
     should "use any given attrs" do
       assert_equal @file_line,             subject.file_line
@@ -126,14 +125,6 @@ class Assert::Test
     should "know its file line attrs" do
       assert_equal subject.file_line.file,      subject.file_name
       assert_equal subject.file_line.line.to_i, subject.line_num
-    end
-
-    should "capture results" do
-      result           = Factory.pass_result
-      callback_result  = nil
-      subject.capture_result(result, proc{ |r| callback_result = r })
-
-      assert_equal result, callback_result
     end
 
     should "have a custom inspect that only shows limited attributes" do


### PR DESCRIPTION
This reworks the `capture_result` behavior in both the Test and
Context objects.  This is part of the cleaning up now that we are
accumulating test run data instead of storing it on the test objs.

This Context capture removes an unnecessary `yield` call and instead
builds the result itself from given/static inputs.  There is no need
to go through the ceremony of yielding to the given block to get
a result.  Because the test and caller params are static/common
to all results, we only need to be given the result class and msg.
This simplifies everywhere we call `capture_result` and should
give a slight performance improvement.  Plus there is no reason
to call to the test's `capture_result` as the test doesn't do any
extra logic on capture (it just calls the callback which we can
do directly).  Note: I updated the context's result callback to
return the result so that the legacy behavior of `capture_result`
returning the result was maintained.

The Test capture is now a private method b/c the Context no longer
needs to call it.  Like the Context, it has been simplified to just
take a result class and exception.  We now store the result callback
on the instance and the test is static/common to all results.  This
simplifies everywhere we call `capture_results`.  In addition the
test attrs were reorganized a bit now that capture result is a
private method.

@jcredding ready for review.