### PR TITLE
accumulate: clear out tests from the suite as they are run.

### DIFF
--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -32,9 +32,7 @@ module Assert
       begin
         self.suite.start_time = Time.now
         self.suite.setups.each(&:call)
-        # TODO: tests_to_run.tap{ self.suite.clear_tests_to_run }.each
-        # TODO: maybe while/pop off tests_to_run so tests get gc'd
-        tests_to_run.each do |test|
+        tests_to_run.tap{ self.suite.clear_tests_to_run }.delete_if do |test|
           self.before_test(test)
           self.suite.before_test(test)
           self.view.before_test(test)
@@ -46,6 +44,9 @@ module Assert
           self.after_test(test)
           self.suite.after_test(test)
           self.view.after_test(test)
+
+          # always delete `test` from `tests_to_run` since it has been run
+          true
         end
         self.suite.teardowns.each(&:call)
         self.suite.end_time = Time.now
@@ -84,8 +85,6 @@ module Assert
       if self.single_test?
         [self.suite.find_test_to_run(self.single_test_file_line)].compact
       else
-        # TODO: implies tests are always stored in memory?
-        # TODO: move this back to base suite definition?
         self.suite.sorted_tests_to_run{ rand self.tests_to_run_count }
       end
     end

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -14,7 +14,6 @@ module Assert
 
     TEST_METHOD_REGEX = /^test./.freeze
 
-    # TODO: improve this comment
     # A suite is a set of tests to run.  When a test class subclasses
     # the Context class, that test class is pushed to the suite.
 


### PR DESCRIPTION
This is a slight optimization related to now accumulating test run
data.  We no longer need to keep references to the tests-to-run
since we are accumulating their meta and result data.  This switches
to clearing out the suite tests-to-run just before the running
starts iterating them.  It also updates the runner to remove its
reference to the test as each test is done running.

Note: I had to update a couple of runner tests where they were
incorrectly relying on tests being available post-run.  This
should have been done back when I added these tests but was missed
b/c we kept the tests around and I just didn't notice at the time.

@jcredding ready for review.