### PR TITLE
prefer raising Exceptions with custom backtrace over manually setting

### DIFF
--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -114,9 +114,7 @@ module Assert
     # adds a Skip result to the end of the test's results
     # breaks test execution
     def skip(skip_msg = nil, called_from = nil)
-      err = Result::TestSkipped.new(skip_msg || '')
-      err.set_backtrace([called_from]) if called_from
-      raise(err)
+      raise Result::TestSkipped, (skip_msg || ''), called_from
     end
 
     # alter the backtraces of fail/skip results generated in the given block

--- a/lib/assert/stub.rb
+++ b/lib/assert/stub.rb
@@ -22,8 +22,7 @@ module Assert
   def self.stub_send(obj, meth, *args, &block)
     orig_caller = caller
     stub = self.stubs.fetch(Assert::Stub.key(obj, meth)) do
-      msg = "`#{meth}` not stubbed"
-      raise NotStubbedError.new(msg).tap{ |e| e.set_backtrace(orig_caller) }
+      raise NotStubbedError, "`#{meth}` not stubbed.", orig_caller
     end
     stub.call_method(args, &block)
   end
@@ -72,7 +71,7 @@ module Assert
         msg = "arity mismatch on `#{@method_name}`: " \
               "expected #{number_of_args(@method.arity)}, " \
               "called with #{args.size}"
-        raise StubArityError.new(msg).tap{ |e| e.set_backtrace(orig_caller) }
+        raise StubArityError, msg, orig_caller
       end
       lookup(args, orig_caller).call(*args, &block)
     rescue NotStubbedError => exception
@@ -86,7 +85,7 @@ module Assert
         msg = "arity mismatch on `#{@method_name}`: " \
               "expected #{number_of_args(@method.arity)}, " \
               "stubbed with #{args.size}"
-        raise StubArityError.new(msg).tap{ |e| e.set_backtrace(orig_caller) }
+        raise StubArityError, msg, orig_caller
       end
       @lookup[args] = block
     end
@@ -104,12 +103,12 @@ module Assert
       ">"
     end
 
-    protected
+    private
 
     def setup(object, orig_caller)
       unless object.respond_to?(@method_name)
         msg = "#{object.inspect} does not respond to `#{@method_name}`"
-        raise StubError.new(msg).tap{ |e| e.set_backtrace(orig_caller) }
+        raise StubError, msg, orig_caller
       end
       is_constant = object.kind_of?(Module)
       local_object_methods = object.methods(false).map(&:to_s)
@@ -135,8 +134,6 @@ module Assert
       stub_method
     end
 
-    private
-
     def lookup(args, orig_caller)
       @lookup.fetch(args) do
         self.do || begin
@@ -144,7 +141,7 @@ module Assert
           inspect_lookup_stubs.tap do |stubs|
             msg += "\nStubs:\n#{stubs}" if !stubs.empty?
           end
-          raise NotStubbedError.new(msg).tap{ |e| e.set_backtrace(orig_caller) }
+          raise NotStubbedError, msg, orig_caller
         end
       end
     end

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -96,7 +96,9 @@ module Assert
     end
 
     should "be able to call a stub's original method" do
-      assert_raises(NotStubbedError){ Assert.stub_send(@myobj, :mymeth) }
+      err = assert_raises(NotStubbedError){ Assert.stub_send(@myobj, :mymeth) }
+      assert_includes 'not stubbed.',              err.message
+      assert_includes 'test/unit/assert_tests.rb', err.backtrace.first
 
       Assert.stub(@myobj, :mymeth){ @stub_value }
 

--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -70,7 +70,7 @@ class Assert::Context
     desc "skip method"
     setup do
       @skip_msg = "I need to implement this in the future."
-      begin; @context.skip(@skip_msg); rescue Exception => @exception; end
+      begin; @context.skip(@skip_msg); rescue StandardError => @exception; end
       @result = Factory.skip_result(@exception)
     end
     subject{ @result }
@@ -89,7 +89,7 @@ class Assert::Context
       assert_not_equal 1, @exception.backtrace.size
 
       called_from = Factory.string
-      begin; @context.skip(@skip_msg, called_from); rescue Exception => exception; end
+      begin; @context.skip(@skip_msg, called_from); rescue StandardError => exception; end
       assert_equal 1,           exception.backtrace.size
       assert_equal called_from, exception.backtrace.first
     end
@@ -188,11 +188,7 @@ class Assert::Context
     subject{ @result }
 
     should "raise an exception with the failure's message" do
-      err = begin
-        @context.fail @fail_msg
-      rescue Exception => exception
-        exception
-      end
+      begin; @context.fail(@fail_msg); rescue StandardError => err; end
       assert_kind_of Assert::Result::TestFailure, err
       assert_equal @fail_msg, err.message
 

--- a/test/unit/stub_tests.rb
+++ b/test/unit/stub_tests.rb
@@ -42,7 +42,9 @@ class Assert::Stub
     end
 
     should "complain when called if no do block was given" do
-      assert_raises(Assert::NotStubbedError){ @myobj.mymeth }
+      err = assert_raises(Assert::NotStubbedError){ @myobj.mymeth }
+      assert_includes 'not stubbed.',            err.message
+      assert_includes 'test/unit/stub_tests.rb', err.backtrace.first
 
       subject.do = proc{ 'mymeth' }
       assert_nothing_raised do
@@ -55,7 +57,9 @@ class Assert::Stub
     end
 
     should "complain if stubbing a method that the object doesn't respond to" do
-      assert_raises(Assert::StubError){ Assert::Stub.new(@myobj, :some_other_meth) }
+      err = assert_raises(Assert::StubError){ Assert::Stub.new(@myobj, :some_other_meth) }
+      assert_includes 'does not respond to',     err.message
+      assert_includes 'test/unit/stub_tests.rb', err.backtrace.first
     end
 
     should "complain if stubbed and called with no `do` proc given" do
@@ -64,7 +68,10 @@ class Assert::Stub
 
     should "complain if stubbed and called with mismatched arity" do
       Assert::Stub.new(@myobj, :myval){ 'myval' }
-      assert_raises(Assert::StubArityError){ @myobj.myval }
+      err = assert_raises(Assert::StubArityError){ @myobj.myval }
+      assert_includes 'arity mismatch on',       err.message
+      assert_includes 'test/unit/stub_tests.rb', err.backtrace.first
+
       assert_nothing_raised { @myobj.myval(1) }
       assert_raises(Assert::StubArityError){ @myobj.myval(1,2) }
 
@@ -81,9 +88,12 @@ class Assert::Stub
     end
 
     should "complain if stubbed with mismatched arity" do
-      assert_raises(Assert::StubArityError) do
+      err = assert_raises(Assert::StubArityError) do
         Assert::Stub.new(@myobj, :myval).with(){ 'myval' }
       end
+      assert_includes 'arity mismatch on',       err.message
+      assert_includes 'test/unit/stub_tests.rb', err.backtrace.first
+
       assert_raises(Assert::StubArityError) do
         Assert::Stub.new(@myobj, :myval).with(1,2){ 'myval' }
       end


### PR DESCRIPTION
This is just a small cleanup to prefer using the idiomatic `raise`
method to raise custom exceptions with custom backtraces instead
of manually raising a pre-built exception with a manually set
backtrace.  This addresses issue 260.

I also chose to update the custom exception tests to formally test
the exception message and backtrace (in some way at least) to help
ensure this change didn't introduce any regressions.

Finally, this does a few other minor cleanups: switch to not
rescuing `Exception` in the context/stub tests and removing a use
of `protected`, in the stub implementation.

Closes #260.

@jcredding ready for review.