### PR TITLE
prefer using `caller_locations` over `caller`

### DIFF
--- a/lib/assert.rb
+++ b/lib/assert.rb
@@ -23,3 +23,12 @@ module Assert
   end
 
 end
+
+# Kernel#caller_locations polyfill for pre ruby 2.0.0
+if RUBY_VERSION =~ /\A1\..+/ && !Kernel.respond_to?(:caller_locations)
+  module Kernel
+    def caller_locations(start = 1, length = nil)
+      length ? caller[start, length] : caller[start..-1]
+    end
+  end
+end

--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -34,14 +34,14 @@ module Assert
 
         if self.suite.test_methods.include?(klass_method_name)
           puts "WARNING: redefining '#{klass_method_name}'"
-          puts "  from: #{caller.first}"
+          puts "  from: #{caller_locations(1,1)}"
         else
           self.suite.test_methods << klass_method_name
         end
 
         self.suite.on_test(Test.for_method(
           method_name.to_s,
-          ContextInfo.new(self, nil, caller.first),
+          ContextInfo.new(self, nil, caller_locations(1,1)),
           self.suite.config
         ))
       end
@@ -159,7 +159,7 @@ module Assert
 
     def capture_result(result_klass, msg)
       @__assert_result_callback__.call(
-        result_klass.for_test(@__assert_running_test__, msg, caller)
+        result_klass.for_test(@__assert_running_test__, msg, caller_locations)
       )
     end
 

--- a/lib/assert/context/test_dsl.rb
+++ b/lib/assert/context/test_dsl.rb
@@ -15,23 +15,23 @@ class Assert::Context
         # create a test from the given code block
         self.suite.on_test(Assert::Test.for_block(
           desc_or_macro.kind_of?(Assert::Macro) ? desc_or_macro.name : desc_or_macro,
-          Assert::ContextInfo.new(self, called_from, first_caller || caller.first),
+          Assert::ContextInfo.new(self, called_from, first_caller || caller_locations.first),
           self.suite.config,
           &block
         ))
       else
-        test_eventually(desc_or_macro, called_from, first_caller || caller.first, &block)
+        test_eventually(desc_or_macro, called_from, first_caller || caller_locations.first, &block)
       end
     end
 
     def test_eventually(desc_or_macro, called_from = nil, first_caller = nil, &block)
       # create a test from a proc that just skips
-      ci = Assert::ContextInfo.new(self, called_from, first_caller || caller.first)
+      ci = Assert::ContextInfo.new(self, called_from, first_caller || caller_locations.first)
       self.suite.on_test(Assert::Test.for_block(
         desc_or_macro.kind_of?(Assert::Macro) ? desc_or_macro.name : desc_or_macro,
         ci,
         self.suite.config,
-        &proc { skip('TODO', ci.called_from) }
+        &proc { skip('TODO', [ci.called_from.to_s]) }
       ))
     end
     alias_method :test_skip, :test_eventually
@@ -40,14 +40,14 @@ class Assert::Context
       if !desc_or_macro.kind_of?(Assert::Macro)
         desc_or_macro = "should #{desc_or_macro}"
       end
-      test(desc_or_macro, called_from, first_caller || caller.first, &block)
+      test(desc_or_macro, called_from, first_caller || caller_locations.first, &block)
     end
 
     def should_eventually(desc_or_macro, called_from = nil, first_caller = nil, &block)
       if !desc_or_macro.kind_of?(Assert::Macro)
         desc_or_macro = "should #{desc_or_macro}"
       end
-      test_eventually(desc_or_macro, called_from, first_caller || caller.first, &block)
+      test_eventually(desc_or_macro, called_from, first_caller || caller_locations.first, &block)
     end
     alias_method :should_skip, :should_eventually
 

--- a/lib/assert/context_info.rb
+++ b/lib/assert/context_info.rb
@@ -7,7 +7,7 @@ module Assert
     def initialize(klass, called_from = nil, first_caller = nil)
       @called_from = called_from || first_caller
       @klass = klass
-      @file = @called_from.gsub(/\:[0-9]+.*$/, '') if @called_from
+      @file = @called_from.to_s.gsub(/\:[0-9]+.*$/, '') if @called_from
     end
 
     def test_name(name)

--- a/lib/assert/macros/methods.rb
+++ b/lib/assert/macros/methods.rb
@@ -10,7 +10,7 @@ module Assert::Macros
     module ClassMethods
 
       def have_instance_method(*methods)
-        called_from = (methods.last.kind_of?(Array) ? methods.pop : caller).first
+        called_from = (methods.last.kind_of?(Array) ? methods.pop : caller_locations).first
         Assert::Macro.new do
           methods.each{ |m| _methods_macro_instance_methods << [m, called_from] }
           _methods_macro_test called_from
@@ -21,7 +21,7 @@ module Assert::Macros
       alias_method :have_imeths, :have_instance_method
 
       def not_have_instance_method(*methods)
-        called_from = (methods.last.kind_of?(Array) ? methods.pop : caller).first
+        called_from = (methods.last.kind_of?(Array) ? methods.pop : caller_locations).first
         Assert::Macro.new do
           methods.each{ |m| _methods_macro_not_instance_methods << [m, called_from] }
           _methods_macro_test called_from
@@ -32,7 +32,7 @@ module Assert::Macros
       alias_method :not_have_imeths, :not_have_instance_method
 
       def have_class_method(*methods)
-        called_from = (methods.last.kind_of?(Array) ? methods.pop : caller).first
+        called_from = (methods.last.kind_of?(Array) ? methods.pop : caller_locations).first
         Assert::Macro.new do
           methods.each{ |m| _methods_macro_class_methods << [m, called_from] }
           _methods_macro_test called_from
@@ -43,7 +43,7 @@ module Assert::Macros
       alias_method :have_cmeths, :have_class_method
 
       def not_have_class_method(*methods)
-        called_from = (methods.last.kind_of?(Array) ? methods.pop : caller).first
+        called_from = (methods.last.kind_of?(Array) ? methods.pop : caller_locations).first
         Assert::Macro.new do
           methods.each{ |m| _methods_macro_not_class_methods << [m, called_from] }
           _methods_macro_test called_from
@@ -54,19 +54,19 @@ module Assert::Macros
       alias_method :not_have_cmeths, :not_have_class_method
 
       def have_reader(*methods)
-        methods << caller if !methods.last.kind_of?(Array)
+        methods << caller_locations if !methods.last.kind_of?(Array)
         have_instance_methods(*methods)
       end
       alias_method :have_readers, :have_reader
 
       def not_have_reader(*methods)
-        methods << caller if !methods.last.kind_of?(Array)
+        methods << caller_locations if !methods.last.kind_of?(Array)
         not_have_instance_methods(*methods)
       end
       alias_method :not_have_readers, :not_have_reader
 
       def have_writer(*methods)
-        called = methods.last.kind_of?(Array) ? methods.pop : caller
+        called = methods.last.kind_of?(Array) ? methods.pop : caller_locations
         writer_meths = methods.collect{|m| "#{m}="}
         writer_meths << called
         have_instance_methods(*writer_meths)
@@ -74,7 +74,7 @@ module Assert::Macros
       alias_method :have_writers, :have_writer
 
       def not_have_writer(*methods)
-        called = methods.last.kind_of?(Array) ? methods.pop : caller
+        called = methods.last.kind_of?(Array) ? methods.pop : caller_locations
         writer_meths = methods.collect{|m| "#{m}="}
         writer_meths << called
         not_have_instance_methods(*writer_meths)
@@ -82,7 +82,7 @@ module Assert::Macros
       alias_method :not_have_writers, :not_have_writer
 
       def have_accessor(*methods)
-        called = methods.last.kind_of?(Array) ? methods.pop : caller
+        called = methods.last.kind_of?(Array) ? methods.pop : caller_locations
         accessor_meths = methods.collect{|m| [m, "#{m}="]}.flatten
         accessor_meths << called
         have_instance_methods(*accessor_meths)
@@ -90,7 +90,7 @@ module Assert::Macros
       alias_method :have_accessors, :have_accessor
 
       def not_have_accessor(*methods)
-        called = methods.last.kind_of?(Array) ? methods.pop : caller
+        called = methods.last.kind_of?(Array) ? methods.pop : caller_locations
         accessor_meths = methods.collect{|m| [m, "#{m}="]}.flatten
         accessor_meths << called
         not_have_instance_methods(*accessor_meths)

--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -265,7 +265,7 @@ module Assert::Result
     end
 
     def filtered
-      self.class.new(self.reject { |line| filter_out?(line) })
+      self.class.new(self.reject { |line| filter_out?(line.to_s) })
     end
 
     protected

--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -59,8 +59,8 @@ class Assert::Context
       with_backtrace(caller) do
         assert_false result.with_bt_set?
 
-        assert_equal result.src_line,                 result.trace
-        assert_equal result.backtrace.filtered.first, result.src_line
+        assert_equal result.src_line,                      result.trace
+        assert_equal result.backtrace.filtered.first.to_s, result.src_line
       end
     end
 
@@ -162,7 +162,7 @@ class Assert::Context
 
     should "create a fail result and set its backtrace" do
       assert_kind_of Assert::Result::Fail, subject
-      assert_equal subject.backtrace.filtered.first, subject.trace
+      assert_equal subject.backtrace.filtered.first.to_s, subject.trace
       assert_kind_of Array, subject.backtrace
     end
 


### PR DESCRIPTION
So I've previously noticed that `caller` is a bit expensive in
processing time and is adding overhead to our test suites.  I set
out to look into alternatives and squeeze some performance out of
running tests in Assert.

In Ruby 2.0+ a new Kernel method, `caller_locations`, was introduced
that is significantly more performant than `caller`.  It also
returns an array of location objects instead of an array of Strings.

See:
 * http://blog.marc-andre.ca/2013/02/23/ruby-2-by-example/#caller_locations
 * https://stackoverflow.com/questions/5100299/how-to-get-the-name-of-the-calling-method (scroll down)

So, this sets out to switch to using `caller_locations` instead of
`caller` if in Ruby 2.0+.

First off, I wanted to keep Assert compatible with pre Ruby 2.0
(selfishly b/c we still have some legacy apps I want to continue
supporting).  I chose to go the polyfill route and monkeypatch in
a `caller_locations` method that behaves *similarly enough* to the
Ruby 2.0+ method.  I preferred this approach over some conditional
logic as it is easier to remove once I no longer wnat to support
pre Ruby 2.0.  The polyfill just uses `caller` under the covers so
it continue to return a list of Strings, not objects like the native
implementation.  I used this link for the method implementation ref:
https://www.rubydoc.info/stdlib/core/2.0.0/Kernel%3Acaller_locations.

Next, I just had to go through the implementation and start
replacing `caller` with `caller_locations`.  This was fairly
straightforward except for where the caller info was used as a
backtrace to custom raised exceptions.  Exceptions require
backtraces that are arrays of strings so I had to map in those
cases.  All of this is backwards compatible with pre Ruby 2.0.

Performance-wise, on Assert's test suite on my dev machine:

* before: 0.460706 seconds, 1013.661641 tests/s, 3318.819377 results/s
* after:  0.367983 seconds, 1269.080365 tests/s, 4155.083251 results/s

On one of our medium size apps with 3541 tests (10488 results):

* before: ~25 secs
* after:  ~24 secs

On pre Ruby 2.0, there is no significant performance changes as
it is still using `caller` (under the covers).

So, this doesn't result in a massive performance improvement but
it does squeeze out a bit.

@jcredding ready for review.