### PR TITLE
trap INFO signal; use to display current test run info in default view

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Available callbacks from the runner, and when they are called:
 * `on_result`: when a running tests generates a result, the result is passed as an arg
 * `after_test`: after a test finishes running, the test is passed as an arg
 * `on_finish`: when the test suite is finished running
+* `on_info`: called when the INFO signal is triggered while running the test suite (Ctrl-T on Macs)
 * `on_interrupt`: called when the test suite is interrupted while running
 
 Beyond that, each view can do as it sees fit.  Initialize how you wish, take whatever settings you'd like, and output results as you see fit, given the available callbacks.

--- a/lib/assert/default_view.rb
+++ b/lib/assert/default_view.rb
@@ -59,6 +59,15 @@ module Assert
            "#{formatted_suite_result_rate} results/s)"
     end
 
+    def on_info(test)
+      dump_test_results
+
+      puts "Current test:"
+      puts test.name
+      puts test.file_line.to_s
+      puts
+    end
+
     def on_interrupt(err)
       dump_test_results
     end

--- a/lib/assert/runner.rb
+++ b/lib/assert/runner.rb
@@ -29,10 +29,20 @@ module Assert
         self.view.puts ", seeded with \"#{self.runner_seed}\""
       end
 
+      # if INFO signal requested (Ctrl+T on Macs), process it
+      @current_running_test = nil
+      trap("INFO") do
+        self.on_info(@current_running_test)
+        self.suite.on_info(@current_running_test)
+        self.view.on_info(@current_running_test)
+      end
+
       begin
         self.suite.start_time = Time.now
         self.suite.setups.each(&:call)
         tests_to_run.tap{ self.suite.clear_tests_to_run }.delete_if do |test|
+          @current_running_test = test
+
           self.before_test(test)
           self.suite.before_test(test)
           self.view.before_test(test)
@@ -76,6 +86,7 @@ module Assert
     def on_result(result);       end
     def after_test(test);        end
     def on_finish;               end
+    def on_info(test);           end
     def on_interrupt(err);       end
 
     private

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -93,6 +93,7 @@ module Assert
     def on_result(result); end
     def after_test(test);  end
     def on_finish;         end
+    def on_info(test);     end
     def on_interrupt(err); end
 
     def inspect

--- a/lib/assert/view.rb
+++ b/lib/assert/view.rb
@@ -74,9 +74,10 @@ module Assert
     # * `after_test`:   called after a test finishes running
     #                   the test is passed as an arg
     # * `on_finish`:    called when the test suite is finished running
+    # * `on_info`:      called when the INFO signal is triggered whil runninng
+    #                   the test suite
     # * `on_interrupt`: called when the test suite is interrupted while running
     #                   the interrupt exception is passed as an arg
-
     def before_load(test_files); end
     def after_load;              end
     def on_start;                end
@@ -84,6 +85,7 @@ module Assert
     def on_result(result);       end
     def after_test(test);        end
     def on_finish;               end
+    def on_info(test);           end
     def on_interrupt(err);       end
 
     # IO capture

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -33,7 +33,7 @@ class Assert::Runner
     should have_readers :config
     should have_imeths :runner, :run
     should have_imeths :before_load, :after_load
-    should have_imeths :on_start, :on_finish, :on_interrupt
+    should have_imeths :on_start, :on_finish, :on_info, :on_interrupt
     should have_imeths :before_test, :after_test, :on_result
 
     should "know its config" do

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -40,7 +40,7 @@ class Assert::Suite
     should have_imeths :fail_result_count, :error_result_count
     should have_imeths :skip_result_count, :ignore_result_count
     should have_imeths :before_load, :on_test, :after_load
-    should have_imeths :on_start, :on_finish, :on_interrupt
+    should have_imeths :on_start, :on_finish, :on_info, :on_interrupt
     should have_imeths :before_test, :after_test, :on_result
 
     should "know its config" do

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -37,7 +37,7 @@ class Assert::View
     should have_readers :config
     should have_imeths :view, :is_tty?
     should have_imeths :before_load, :after_load
-    should have_imeths :on_start, :on_finish, :on_interrupt
+    should have_imeths :on_start, :on_finish, :on_info, :on_interrupt
     should have_imeths :before_test, :after_test, :on_result
 
     should "default its style options" do


### PR DESCRIPTION
This feature is designed to give you hints about what is going on
in a long-running test suite without having to interrupt it. This
addresses issue 220.

The runner now traps the INFO signal and calls `on_info` callbacks
on itself, its suite, and its view.  The default view implements
this callback and dumps any accumulated results it has (so far) and
also outputs info about the currently running test.  It looks
something like this (for example, on my Mac dev machine):

```
Running tests in random order, seeded with "60909"
.....F..FF.........load: 1.71  cmd: ruby 17628 running 1.60u 0.36s

FAIL: Yet Another Thing should also even do something
Expected equals actual, diff:
--- expected
+++ actual
/[...]/tests.rb:178:in `block in <class:Tests>'
assert -t ./[...]/tests.rb:167

FAIL: Another Thing should also do something
Expected [5, 2, 3, 4, 7, 6] to not include 6.
/[...]/tests.rb:96:in `block in <class:Tests>'
assert -t ./[...]/tests.rb:89

FAIL: Some Thing should do something
Expected 19 to not be equal to 19.
/[...]/tests.rb:32:in `block in <class:Tests>'
assert -t ./[...]/tests.rb:31

Current test:
Some Thing should do something
/[...]/tests.rb:31

.................................................
```

With this feature, if you see your suite blowing up with
fails/errors, send the INFO signal (Ctrl-T on my Mac) and the
results will be dumped.  If you see your test run hanging, sent
the INFO signal and info about the current running test will be
shown.  Unlike interrupting (Ctrl-C), the test suite will continue
while you investigate this info.

This was inspired by this post:
https://www.justinweiss.com/articles/how-to-see-your-minitest-failures-instantly/

Closes #220. 

@jcredding ready for review.