### PR TITLE
add CircleCI configuration from GGem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,82 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+
+jobs:
+  test_ruby_2.3.7:
+    working_directory: ~/redding/assert/ruby-2.3.7
+    docker:
+       - image: circleci/ruby:2.3.7
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - ruby-2.3.7-dependencies
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: ruby-2.3.7-dependencies
+      - run:
+          name: run Assert test suite
+          command: |
+            ruby -v
+            bundle exec assert
+
+  test_ruby_2.4.5:
+    working_directory: ~/redding/assert/ruby-2.4.5
+    docker:
+       - image: circleci/ruby:2.4.5
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - ruby-2.4.5-dependencies
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: ruby-2.4.5-dependencies
+      - run:
+          name: run Assert test suite
+          command: |
+            ruby -v
+            bundle exec assert
+
+  test_ruby_2.5.3:
+    working_directory: ~/redding/assert/ruby-2.5.3
+    docker:
+       - image: circleci/ruby:2.5.3
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - ruby-2.5.3-dependencies
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: ruby-2.5.3-dependencies
+      - run:
+          name: run Assert test suite
+          command: |
+            ruby -v
+            bundle exec assert
+workflows:
+  version: 2
+  test_ruby_versions:
+    jobs:
+      - test_ruby_2.3.7
+      - test_ruby_2.4.5
+      - test_ruby_2.5.3


### PR DESCRIPTION
This is the config GGem generates for our gems.  This sets up
running tests against Ruby 2.3, 2.4, and 2.5.  I'm going to try
and set this up with all of our gems as I touch them.  GGem will
automatically generate it for new gems going forward.

@jcredding ready for review.