### PR TITLE
add `Assert.stub_tap`

### DIFF
--- a/assert.gemspec
+++ b/assert.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = "~> 2.4"
 
   gem.add_dependency("much-factory", ["~> 0.1.0"])
-  gem.add_dependency("much-stub",    ["~> 0.1.1"])
+  gem.add_dependency("much-stub",    ["~> 0.1.2"])
 end

--- a/lib/assert/stub.rb
+++ b/lib/assert/stub.rb
@@ -26,4 +26,8 @@ module Assert
       raise err
     end
   end
+
+  def self.stub_tap(*args, &block)
+    MuchStub.tap(*args, &block)
+  end
 end

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -104,5 +104,15 @@ module Assert
       assert_equal @stub_value, @myobj.mymeth
       assert_equal @orig_value, Assert.stub_send(@myobj, :mymeth)
     end
+
+    should "be able to add a stub tap" do
+      my_meth_called_with = nil
+      Assert.stub_tap(@myobj, :mymeth){ |value, *args, &block|
+        my_meth_called_with = args
+      }
+
+      assert_equal @orig_value, @myobj.mymeth
+      assert_equal [], my_meth_called_with
+    end
   end
 end


### PR DESCRIPTION
See https://github.com/redding/much-stub/pull/6 for reference.

This updates to the latest version of MuchStub and adds a proxy for
its new `.tap` API. This also updates the README to remove
abbreviations like MuchStub has and adds brief references to the
new tap API.

This makes the tap API available as you'd expect in Assert.