### PR TITLE
update to the latest MuchStub

### DIFF
--- a/assert.gemspec
+++ b/assert.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = "~> 2.4"
+  gem.required_ruby_version = "~> 2.5"
 
   gem.add_dependency("much-factory", ["~> 0.1.0"])
-  gem.add_dependency("much-stub",    ["~> 0.1.2"])
+  gem.add_dependency("much-stub",    ["~> 0.1.3"])
 end

--- a/lib/assert/stub.rb
+++ b/lib/assert/stub.rb
@@ -30,4 +30,12 @@ module Assert
   def self.stub_tap(*args, &block)
     MuchStub.tap(*args, &block)
   end
+
+  def self.stub_tap_on_call(*args, &block)
+    MuchStub.tap_on_call(*args, &block)
+  end
+
+  def self.stub_spy(*args, &block)
+    MuchStub.spy(*args, &block)
+  end
 end

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -114,5 +114,47 @@ module Assert
       assert_equal @orig_value, @myobj.mymeth
       assert_equal [], my_meth_called_with
     end
+
+    should "be able to add a stub tap with an on_call block" do
+      my_meth_called_with = nil
+      Assert.stub_tap_on_call(@myobj, :mymeth){ |value, call|
+        my_meth_called_with = call
+      }
+
+      assert_equal @orig_value, @myobj.mymeth
+      assert_equal [], my_meth_called_with.args
+    end
+
+    should "be able to add a stubbed spy" do
+      myclass = Class.new do
+        def one; self; end
+        def two(val); self; end
+        def three; self; end
+        def ready?; false; end
+      end
+      myobj = myclass.new
+
+      spy =
+        Assert.stub_spy(
+          myobj,
+          :one,
+          :two,
+          :three,
+          ready?: true)
+
+      assert_equal spy, myobj.one
+      assert_equal spy, myobj.two("a")
+      assert_equal spy, myobj.three
+
+      assert_true myobj.one.two("b").three.ready?
+
+      assert_kind_of MuchStub::CallSpy, spy
+      assert_equal 2, spy.one_call_count
+      assert_equal 2, spy.two_call_count
+      assert_equal 2, spy.three_call_count
+      assert_equal 1, spy.ready_predicate_call_count
+      assert_equal ["b"], spy.two_last_called_with.args
+      assert_true spy.ready_predicate_called?
+    end
   end
 end


### PR DESCRIPTION
This adds the new API methods: `stub_tap_on_call` and `stub_spy`
See https://github.com/redding/much-stub/pull/7 for details.

This also ups the required ruby version since MuchStub imposes
this restriction now anyway.