### PR TITLE
add Assert::Context::LetDSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ Running tests in random order, seeded with "56382"
 
 ## What Assert is not
 
-* **RSpec/spec-anything**: define tests using assertion statements
-* **Unit/Functional/Integration/etc**: Assert is agnostic - you define whatever kinds of tests you like (one or more of the above) and assert runs them in context
-* **Mock/Spec/BDD/etc**: Assert is the framework and there are a variety of 3rd party tools to do such things - feel free to use whatever you like
+* **RSpec/spec-anything**: define tests using assertion statements.
+* **Unit/Functional/Integration/etc**: Assert is agnostic - you define whatever kinds of tests you like and Assert runs them in context.
+* **Mock/Spec/BDD/etc**: Assert is the framework and there are a variety of 3rd party tools to do such things. Feel free to use whatever you like.
 
 ## Description
 
-Assert is an assertion style testing framework, meaning you use assertion statements to define your tests and create results.  Assert uses class-based contexts so if you want to nest your contexts, use inheritance.
+Assert is an assertion-style testing framework, meaning you use assertion statements to define your tests and create results. Assert uses class-based contexts so if you want to nest your contexts, use inheritance.
 
 ### Features
 
@@ -50,6 +50,7 @@ Assert is an assertion style testing framework, meaning you use assertion statem
 * class-based contexts
 * multiple before/setup & after/teardown blocks
 * around blocks
+* `let` value declarations
 * full backtrace for errors
 * optionally pretty print objects in failure descriptions
 * [stubbing API](https://github.com/redding/assert#stub)
@@ -666,4 +667,4 @@ If submitting a Pull Request, please:
 
 One note: please respect that Assert itself is intended to be the flexible, base-level, framework-type logic that should change little if at all.  Pull requests for niche functionality or personal testing philosphy stuff will likely not be accepted.
 
-If you wish to extend Assert for your niche purpose/desire/philosophy, please do so in it's own gem (preferrably named `assert-<whatever>`) that uses Assert as a dependency.
+If you wish to extend Assert for your niche purpose/desire/philosophy, please do so in its own gem (preferrably named `assert-<whatever>`) that uses Assert as a dependency.

--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -2,6 +2,15 @@ require "assert/utils"
 
 module Assert
   module Assertions
+    IGNORED_ASSERTION_HELPERS =
+      [
+        :assert_throws,     :assert_nothing_thrown,
+        :assert_operator,   :refute_operator,
+        :assert_in_epsilon, :refute_in_epsilon,
+        :assert_in_delta,   :refute_in_delta,
+        :assert_send
+      ]
+
     def assert_block(desc = nil)
       assert(yield, desc){ "Expected block to return a true value." }
     end
@@ -243,24 +252,6 @@ module Assert
       end
     end
     alias_method :refute_same, :assert_not_same
-
-    # ignored assertion helpers
-
-    IGNORED_ASSERTION_HELPERS = [
-      :assert_throws,     :assert_nothing_thrown,
-      :assert_operator,   :refute_operator,
-      :assert_in_epsilon, :refute_in_epsilon,
-      :assert_in_delta,   :refute_in_delta,
-      :assert_send
-    ]
-    def method_missing(method, *args, &block)
-      if IGNORED_ASSERTION_HELPERS.include?(method.to_sym)
-        ignore "The assertion `#{method}` is not supported."\
-               " Please use another assertion or the basic `assert`."
-      else
-        super
-      end
-    end
 
     private
 

--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -1,4 +1,5 @@
 require "assert/assertions"
+require "assert/context/method_missing"
 require "assert/context/setup_dsl"
 require "assert/context/subject_dsl"
 require "assert/context/suite_dsl"
@@ -16,6 +17,7 @@ module Assert
     extend SubjectDSL
     extend SuiteDSL
     extend TestDSL
+    include MethodMissing
     include Assert::Assertions
     include Assert::Macros::Methods
 

--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -1,4 +1,5 @@
 require "assert/assertions"
+require "assert/context/let_dsl"
 require "assert/context/method_missing"
 require "assert/context/setup_dsl"
 require "assert/context/subject_dsl"
@@ -17,6 +18,7 @@ module Assert
     extend SubjectDSL
     extend SuiteDSL
     extend TestDSL
+    extend LetDSL
     include MethodMissing
     include Assert::Assertions
     include Assert::Macros::Methods
@@ -81,7 +83,7 @@ module Assert
     end
 
     # the opposite of assert, check if the assertion is a false value, if so create a new pass
-    # result, otherwise create a new fail result with the desc and it's what failed msg
+    # result, otherwise create a new fail result with the desc and fail msg
     def assert_not(assertion, fail_desc = nil)
       assert(!assertion, fail_desc) do
         "Failed assert_not: assertion was "\

--- a/lib/assert/context/let_dsl.rb
+++ b/lib/assert/context/let_dsl.rb
@@ -1,0 +1,13 @@
+module Assert; end
+class Assert::Context; end
+module Assert::Context::LetDSL
+  def let(name, &block)
+    self.send(:define_method, name, &-> {
+      if instance_variable_get("@#{name}").nil?
+        instance_variable_set("@#{name}", instance_eval(&block))
+      end
+
+      instance_variable_get("@#{name}")
+    })
+  end
+end

--- a/lib/assert/context/method_missing.rb
+++ b/lib/assert/context/method_missing.rb
@@ -1,0 +1,19 @@
+require "assert/assertions"
+
+module Assert; end
+class Assert::Context; end
+module Assert::Context::MethodMissing
+  def method_missing(method, *args, &block)
+    if Assert::Assertions::IGNORED_ASSERTION_HELPERS.include?(method.to_sym)
+      ignore "The assertion `#{method}` is not supported."\
+             " Please use another assertion or the basic `assert`."
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(method, *)
+    Assert::Assertions::IGNORED_ASSERTION_HELPERS.include?(method.to_sym) ||
+    super
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,38 +9,36 @@ $LOAD_PATH.unshift(ROOT_PATH)
 require "pry"
 require "test/support/factory"
 
-class Assert::Test
-  module TestHelpers
-    def self.included(receiver)
-      receiver.class_eval do
-        setup do
-          @test_run_results = []
-          @run_callback = proc{ |result| @test_run_results << result }
-        end
+module Assert::Test::TestHelpers
+  def self.included(receiver)
+    receiver.class_eval do
+      setup do
+        @test_run_results = []
+        @run_callback = proc { |result| @test_run_results << result }
       end
+    end
 
-      private
+    private
 
-      def test_run_callback
-        @run_callback
-      end
+    def test_run_callback
+      @run_callback
+    end
 
-      def test_run_results(type = nil)
-        return @test_run_results if type.nil?
-        @test_run_results.select{ |r| r.type == type }
-      end
+    def test_run_results(type = nil)
+      return @test_run_results if type.nil?
+      @test_run_results.select{ |r| r.type == type }
+    end
 
-      def test_run_result_count(type = nil)
-        test_run_results(type).count
-      end
+    def test_run_result_count(type = nil)
+      test_run_results(type).count
+    end
 
-      def test_run_result_messages
-        @test_run_results.map(&:message)
-      end
+    def test_run_result_messages
+      @test_run_results.map(&:message)
+    end
 
-      def last_test_run_result
-        @test_run_results.last
-      end
+    def last_test_run_result
+      @test_run_results.last
     end
   end
 end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -85,4 +85,10 @@ module Factory
       instance_eval(&block) if !block.nil?
     end
   end
+
+  def self.backtrace
+    assert_lib_path =
+      File.join(ROOT_PATH, "lib/#{Factory.string}:#{Factory.integer}")
+    (Factory.integer(3).times.map{ Factory.string } + [assert_lib_path]).shuffle
+  end
 end

--- a/test/system/stub_tests.rb
+++ b/test/system/stub_tests.rb
@@ -8,24 +8,26 @@ class Assert::Stub
 
   class InstanceTests < SystemTests
     desc "for instance methods"
+    subject { instance1 }
+
     setup do
-      @instance = TestClass.new
-      Assert.stub(@instance, :noargs){ "default" }
-      Assert.stub(@instance, :noargs).with{ "none" }
+      Assert.stub(instance1, :noargs){ "default" }
+      Assert.stub(instance1, :noargs).with{ "none" }
 
-      Assert.stub(@instance, :withargs){ "default" }
-      Assert.stub(@instance, :withargs).with(1){ "one" }
+      Assert.stub(instance1, :withargs){ "default" }
+      Assert.stub(instance1, :withargs).with(1){ "one" }
 
-      Assert.stub(@instance, :anyargs){ "default" }
-      Assert.stub(@instance, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(instance1, :anyargs){ "default" }
+      Assert.stub(instance1, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(@instance, :minargs){ "default" }
-      Assert.stub(@instance, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(@instance, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(instance1, :minargs){ "default" }
+      Assert.stub(instance1, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(instance1, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(@instance, :withblock){ "default" }
+      Assert.stub(instance1, :withblock){ "default" }
     end
-    subject{ @instance }
+
+    let(:instance1) { TestClass.new }
 
     should "allow stubbing a method that doesn't take args" do
       assert_equal "none", subject.noargs
@@ -81,24 +83,26 @@ class Assert::Stub
 
   class ClassTests < SystemTests
     desc "for singleton methods on a class"
+    subject { class1 }
+
     setup do
-      @class = TestClass
-      Assert.stub(@class, :noargs){ "default" }
-      Assert.stub(@class, :noargs).with{ "none" }
+      Assert.stub(class1, :noargs){ "default" }
+      Assert.stub(class1, :noargs).with{ "none" }
 
-      Assert.stub(@class, :withargs){ "default" }
-      Assert.stub(@class, :withargs).with(1){ "one" }
+      Assert.stub(class1, :withargs){ "default" }
+      Assert.stub(class1, :withargs).with(1){ "one" }
 
-      Assert.stub(@class, :anyargs){ "default" }
-      Assert.stub(@class, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(class1, :anyargs){ "default" }
+      Assert.stub(class1, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(@class, :minargs){ "default" }
-      Assert.stub(@class, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(@class, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(class1, :minargs){ "default" }
+      Assert.stub(class1, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(class1, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(@class, :withblock){ "default" }
+      Assert.stub(class1, :withblock){ "default" }
     end
-    subject{ @class }
+
+    let(:class1) { TestClass }
 
     should "allow stubbing a method that doesn't take args" do
       assert_equal "none", subject.noargs
@@ -154,24 +158,26 @@ class Assert::Stub
 
   class ModuleTests < SystemTests
     desc "for singleton methods on a module"
+    subject { module1 }
+
     setup do
-      @module = TestModule
-      Assert.stub(@module, :noargs){ "default" }
-      Assert.stub(@module, :noargs).with{ "none" }
+      Assert.stub(module1, :noargs){ "default" }
+      Assert.stub(module1, :noargs).with{ "none" }
 
-      Assert.stub(@module, :withargs){ "default" }
-      Assert.stub(@module, :withargs).with(1){ "one" }
+      Assert.stub(module1, :withargs){ "default" }
+      Assert.stub(module1, :withargs).with(1){ "one" }
 
-      Assert.stub(@module, :anyargs){ "default" }
-      Assert.stub(@module, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(module1, :anyargs){ "default" }
+      Assert.stub(module1, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(@module, :minargs){ "default" }
-      Assert.stub(@module, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(@module, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(module1, :minargs){ "default" }
+      Assert.stub(module1, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(module1, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(@module, :withblock){ "default" }
+      Assert.stub(module1, :withblock){ "default" }
     end
-    subject{ @module }
+
+    let(:module1) { TestModule }
 
     should "allow stubbing a method that doesn't take args" do
       assert_equal "none", subject.noargs
@@ -227,24 +233,26 @@ class Assert::Stub
 
   class ExtendedTests < SystemTests
     desc "for extended methods"
+    subject { class1 }
+
     setup do
-      @class = Class.new{ extend TestMixin }
-      Assert.stub(@class, :noargs){ "default" }
-      Assert.stub(@class, :noargs).with{ "none" }
+      Assert.stub(class1, :noargs){ "default" }
+      Assert.stub(class1, :noargs).with{ "none" }
 
-      Assert.stub(@class, :withargs){ "default" }
-      Assert.stub(@class, :withargs).with(1){ "one" }
+      Assert.stub(class1, :withargs){ "default" }
+      Assert.stub(class1, :withargs).with(1){ "one" }
 
-      Assert.stub(@class, :anyargs){ "default" }
-      Assert.stub(@class, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(class1, :anyargs){ "default" }
+      Assert.stub(class1, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(@class, :minargs){ "default" }
-      Assert.stub(@class, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(@class, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(class1, :minargs){ "default" }
+      Assert.stub(class1, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(class1, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(@class, :withblock){ "default" }
+      Assert.stub(class1, :withblock){ "default" }
     end
-    subject{ @class }
+
+    let(:class1) { Class.new{ extend TestMixin } }
 
     should "allow stubbing a method that doesn't take args" do
       assert_equal "none", subject.noargs
@@ -300,25 +308,26 @@ class Assert::Stub
 
   class IncludedTests < SystemTests
     desc "for an included method"
+    subject { instance1 }
+
     setup do
-      @class = Class.new{ include TestMixin }
-      @instance = @class.new
-      Assert.stub(@instance, :noargs){ "default" }
-      Assert.stub(@instance, :noargs).with{ "none" }
+      Assert.stub(instance1, :noargs){ "default" }
+      Assert.stub(instance1, :noargs).with{ "none" }
 
-      Assert.stub(@instance, :withargs){ "default" }
-      Assert.stub(@instance, :withargs).with(1){ "one" }
+      Assert.stub(instance1, :withargs){ "default" }
+      Assert.stub(instance1, :withargs).with(1){ "one" }
 
-      Assert.stub(@instance, :anyargs){ "default" }
-      Assert.stub(@instance, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(instance1, :anyargs){ "default" }
+      Assert.stub(instance1, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(@instance, :minargs){ "default" }
-      Assert.stub(@instance, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(@instance, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(instance1, :minargs){ "default" }
+      Assert.stub(instance1, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(instance1, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(@instance, :withblock){ "default" }
+      Assert.stub(instance1, :withblock){ "default" }
     end
-    subject{ @instance }
+
+    let(:instance1) { Class.new { include TestMixin }.new }
 
     should "allow stubbing a method that doesn't take args" do
       assert_equal "none", subject.noargs
@@ -374,24 +383,26 @@ class Assert::Stub
 
   class InheritedClassTests < SystemTests
     desc "for an inherited class method"
+    subject { class1 }
+
     setup do
-      @class = Class.new(TestClass)
-      Assert.stub(@class, :noargs){ "default" }
-      Assert.stub(@class, :noargs).with{ "none" }
+      Assert.stub(class1, :noargs){ "default" }
+      Assert.stub(class1, :noargs).with{ "none" }
 
-      Assert.stub(@class, :withargs){ "default" }
-      Assert.stub(@class, :withargs).with(1){ "one" }
+      Assert.stub(class1, :withargs){ "default" }
+      Assert.stub(class1, :withargs).with(1){ "one" }
 
-      Assert.stub(@class, :anyargs){ "default" }
-      Assert.stub(@class, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(class1, :anyargs){ "default" }
+      Assert.stub(class1, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(@class, :minargs){ "default" }
-      Assert.stub(@class, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(@class, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(class1, :minargs){ "default" }
+      Assert.stub(class1, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(class1, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(@class, :withblock){ "default" }
+      Assert.stub(class1, :withblock){ "default" }
     end
-    subject{ @class }
+
+    let(:class1) { Class.new(TestClass) }
 
     should "allow stubbing a method that doesn't take args" do
       assert_equal "none", subject.noargs
@@ -447,25 +458,26 @@ class Assert::Stub
 
   class InheritedInstanceTests < SystemTests
     desc "for an inherited instance method"
+    subject { instance1 }
+
     setup do
-      @class = Class.new(TestClass)
-      @instance = @class.new
-      Assert.stub(@instance, :noargs){ "default" }
-      Assert.stub(@instance, :noargs).with{ "none" }
+      Assert.stub(instance1, :noargs){ "default" }
+      Assert.stub(instance1, :noargs).with{ "none" }
 
-      Assert.stub(@instance, :withargs){ "default" }
-      Assert.stub(@instance, :withargs).with(1){ "one" }
+      Assert.stub(instance1, :withargs){ "default" }
+      Assert.stub(instance1, :withargs).with(1){ "one" }
 
-      Assert.stub(@instance, :anyargs){ "default" }
-      Assert.stub(@instance, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(instance1, :anyargs){ "default" }
+      Assert.stub(instance1, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(@instance, :minargs){ "default" }
-      Assert.stub(@instance, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(@instance, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(instance1, :minargs){ "default" }
+      Assert.stub(instance1, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(instance1, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(@instance, :withblock){ "default" }
+      Assert.stub(instance1, :withblock){ "default" }
     end
-    subject{ @instance }
+
+    let(:instance1) { Class.new(TestClass).new }
 
     should "allow stubbing a method that doesn't take args" do
       assert_equal "none", subject.noargs
@@ -521,24 +533,26 @@ class Assert::Stub
 
   class DelegateClassTests < SystemTests
     desc "a class that delegates another object"
+    subject { class1 }
+
     setup do
-      @class = DelegateClass
-      Assert.stub(@class, :noargs){ "default" }
-      Assert.stub(@class, :noargs).with{ "none" }
+      Assert.stub(class1, :noargs){ "default" }
+      Assert.stub(class1, :noargs).with{ "none" }
 
-      Assert.stub(@class, :withargs){ "default" }
-      Assert.stub(@class, :withargs).with(1){ "one" }
+      Assert.stub(class1, :withargs){ "default" }
+      Assert.stub(class1, :withargs).with(1){ "one" }
 
-      Assert.stub(@class, :anyargs){ "default" }
-      Assert.stub(@class, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(class1, :anyargs){ "default" }
+      Assert.stub(class1, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(@class, :minargs){ "default" }
-      Assert.stub(@class, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(@class, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(class1, :minargs){ "default" }
+      Assert.stub(class1, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(class1, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(@class, :withblock){ "default" }
+      Assert.stub(class1, :withblock){ "default" }
     end
-    subject{ @class }
+
+    let(:class1) { DelegateClass }
 
     should "allow stubbing a method that doesn't take args" do
       assert_equal "none", subject.noargs
@@ -594,24 +608,26 @@ class Assert::Stub
 
   class DelegateInstanceTests < SystemTests
     desc "an instance that delegates another object"
+    subject { instance1 }
+
     setup do
-      @instance = DelegateClass.new
-      Assert.stub(@instance, :noargs){ "default" }
-      Assert.stub(@instance, :noargs).with{ "none" }
+      Assert.stub(instance1, :noargs){ "default" }
+      Assert.stub(instance1, :noargs).with{ "none" }
 
-      Assert.stub(@instance, :withargs){ "default" }
-      Assert.stub(@instance, :withargs).with(1){ "one" }
+      Assert.stub(instance1, :withargs){ "default" }
+      Assert.stub(instance1, :withargs).with(1){ "one" }
 
-      Assert.stub(@instance, :anyargs){ "default" }
-      Assert.stub(@instance, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(instance1, :anyargs){ "default" }
+      Assert.stub(instance1, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(@instance, :minargs){ "default" }
-      Assert.stub(@instance, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(@instance, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(instance1, :minargs){ "default" }
+      Assert.stub(instance1, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(instance1, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(@instance, :withblock){ "default" }
+      Assert.stub(instance1, :withblock){ "default" }
     end
-    subject{ @instance }
+
+    let(:instance1) { DelegateClass.new }
 
     should "allow stubbing a method that doesn't take args" do
       assert_equal "none", subject.noargs
@@ -668,16 +684,16 @@ class Assert::Stub
   class ParentAndChildClassTests < SystemTests
     desc "for a parent method stubbed on both the parent and child"
     setup do
-      @parent_class = Class.new
-      @child_class = Class.new(@parent_class)
-
-      Assert.stub(@parent_class, :new){ "parent" }
-      Assert.stub(@child_class, :new){ "child" }
+      Assert.stub(parent_class, :new){ "parent" }
+      Assert.stub(child_class, :new){ "child" }
     end
 
+    let(:parent_class) { Class.new }
+    let(:child_class) { Class.new(parent_class) }
+
     should "allow stubbing the methods individually" do
-      assert_equal "parent", @parent_class.new
-      assert_equal "child", @child_class.new
+      assert_equal "parent", parent_class.new
+      assert_equal "child", child_class.new
     end
   end
 

--- a/test/system/test_tests.rb
+++ b/test/system/test_tests.rb
@@ -6,15 +6,17 @@ class Assert::Test
     include Assert::Test::TestHelpers
 
     desc "Assert::Test"
-    subject{ @test }
+    subject { test1 }
+
+    setup do
+      test1.run(&test_run_callback)
+    end
   end
 
   class NoResultsTests < SystemTests
     desc "when producing no results"
-    setup do
-      @test = Factory.test
-      @test.run(&test_run_callback)
-    end
+
+    let(:test1) { Factory.test }
 
     should "generate 0 results" do
       assert_equal 0, test_run_result_count
@@ -23,10 +25,8 @@ class Assert::Test
 
   class PassTests < SystemTests
     desc "when passing a single assertion"
-    setup do
-      @test = Factory.test{ assert(1 == 1) }
-      @test.run(&test_run_callback)
-    end
+
+    let(:test1) { Factory.test{ assert(1 == 1) } }
 
     should "generate 1 result" do
       assert_equal 1, test_run_result_count
@@ -39,10 +39,8 @@ class Assert::Test
 
   class FailTests < SystemTests
     desc "when failing a single assertion"
-    setup do
-      @test = Factory.test{ assert(1 == 0) }
-      @test.run(&test_run_callback)
-    end
+
+    let(:test1) { Factory.test{ assert(1 == 0) } }
 
     should "generate 1 result" do
       assert_equal 1, test_run_result_count
@@ -55,10 +53,8 @@ class Assert::Test
 
   class SkipTests < SystemTests
     desc "when skipping once"
-    setup do
-      @test = Factory.test{ skip }
-      @test.run(&test_run_callback)
-    end
+
+    let(:test1) { Factory.test{ skip } }
 
     should "generate 1 result" do
       assert_equal 1, test_run_result_count
@@ -71,10 +67,8 @@ class Assert::Test
 
   class ErrorTests < SystemTests
     desc "when erroring once"
-    setup do
-      @test = Factory.test{ raise("WHAT") }
-      @test.run(&test_run_callback)
-    end
+
+    let(:test1) { Factory.test{ raise("WHAT") } }
 
     should "generate 1 result" do
       assert_equal 1, test_run_result_count
@@ -87,13 +81,13 @@ class Assert::Test
 
   class MixedTests < SystemTests
     desc "when passing 1 assertion and failing 1 assertion"
-    setup do
-      @test = Factory.test do
+
+    let(:test1) {
+      Factory.test do
         assert(1 == 1)
         assert(1 == 0)
       end
-      @test.run(&test_run_callback)
-    end
+    }
 
     should "generate 2 total results" do
       assert_equal 2, test_run_result_count
@@ -110,14 +104,14 @@ class Assert::Test
 
   class MixedSkipTests < SystemTests
     desc "when passing 1 assertion and failing 1 assertion with a skip call in between"
-    setup do
-      @test = Factory.test do
+
+    let(:test1) {
+      Factory.test do
         assert(1 == 1)
         skip
         assert(1 == 0)
       end
-      @test.run(&test_run_callback)
-    end
+    }
 
     should "generate 2 total results" do
       assert_equal 2, test_run_result_count
@@ -142,14 +136,14 @@ class Assert::Test
 
   class MixedErrorTests < SystemTests
     desc "when passing 1 assertion and failing 1 assertion with an exception raised in between"
-    setup do
-      @test = Factory.test do
+
+    let(:test1) {
+      Factory.test do
         assert(1 == 1)
         raise Exception, "something errored"
         assert(1 == 0)
       end
-      @test.run(&test_run_callback)
-    end
+    }
 
     should "generate 2 total results" do
       assert_equal 2, test_run_result_count
@@ -174,14 +168,14 @@ class Assert::Test
 
   class MixedPassTests < SystemTests
     desc "when passing 1 assertion and failing 1 assertion with a pass call in between"
-    setup do
-      @test = Factory.test do
+
+    let(:test1) {
+      Factory.test do
         assert(1 == 1)
         pass
         assert(1 == 0)
       end
-      @test.run(&test_run_callback)
-    end
+    }
 
     should "generate 3 total results" do
       assert_equal 3, test_run_result_count
@@ -202,14 +196,14 @@ class Assert::Test
 
   class MixedFailTests < SystemTests
     desc "when failing 1 assertion and passing 1 assertion with a fail call in between"
-    setup do
-      @test = Factory.test do
+
+    let(:test1) {
+      Factory.test do
         assert(1 == 0)
         fail
         assert(1 == 1)
       end
-      @test.run(&test_run_callback)
-    end
+    }
 
     should "generate 3 total results" do
       assert_equal 3, test_run_result_count
@@ -230,14 +224,14 @@ class Assert::Test
 
   class MixedFlunkTests < SystemTests
     desc "has failing 1 assertion and passing 1 assertion with a flunk call in between"
-    setup do
-      @test = Factory.test do
+
+    let(:test1) {
+      Factory.test do
         assert(1 == 0)
         flunk
         assert(1 == 1)
       end
-      @test.run(&test_run_callback)
-    end
+    }
 
     should "generate 3 total results" do
       assert_equal 3, test_run_result_count
@@ -258,16 +252,18 @@ class Assert::Test
 
   class WithSetupsTests < SystemTests
     desc "that has setup logic"
-    setup do
-      @context_class = Factory.context_class do
+
+    let(:context_class1) {
+      Factory.context_class do
         # assert style
-        setup{ pass "assert style setup" }
+        setup { pass "assert style setup" }
         # test/unit style
         def setup; pass "test/unit style setup"; end
       end
-      @test = Factory.test("t", Factory.context_info(@context_class)){ pass "TEST" }
-      @test.run(&test_run_callback)
-    end
+    }
+    let(:test1) {
+      Factory.test("t", Factory.context_info(context_class1)) { pass "TEST" }
+    }
 
     should "execute all setup logic when run" do
       assert_equal 3, test_run_result_count(:pass)
@@ -279,16 +275,18 @@ class Assert::Test
 
   class WithTeardownsTests < SystemTests
     desc "that has teardown logic"
-    setup do
-      @context_class = Factory.context_class do
+
+    let(:context_class1) {
+      Factory.context_class do
         # assert style
-        teardown{ pass "assert style teardown" }
+        teardown { pass "assert style teardown" }
         # test/unit style
         def teardown; pass "test/unit style teardown"; end
       end
-      @test = Factory.test("t", Factory.context_info(@context_class)){ pass "TEST" }
-      @test.run(&test_run_callback)
-    end
+    }
+    let(:test1) {
+      Factory.test("t", Factory.context_info(context_class1)) { pass "TEST" }
+    }
 
     should "execute all teardown logic when run" do
       assert_equal 3, test_run_result_count(:pass)
@@ -300,35 +298,39 @@ class Assert::Test
 
   class WithAroundsTests < SystemTests
     desc "that has around logic (in addition to setups/teardowns)"
-    setup do
-      @parent_context_class = Factory.modes_off_context_class do
+
+    let(:parent_context_class1) {
+      Factory.modes_off_context_class do
         around do |block|
           pass "parent around start"
           block.call
           pass "parent around end"
         end
-        setup{ pass "parent setup" }
-        teardown{ pass "parent teardown" }
+        setup { pass "parent setup" }
+        teardown { pass "parent teardown" }
       end
-      @context_class = Factory.modes_off_context_class(@parent_context_class) do
-        setup{ pass "child setup1" }
+    }
+    let(:context_class1) {
+      Factory.modes_off_context_class(parent_context_class1) do
+        setup { pass "child setup1" }
         around do |block|
           pass "child around1 start"
           block.call
           pass "child around1 end"
         end
-        teardown{ pass "child teardown1" }
-        setup{ pass "child setup2" }
+        teardown { pass "child teardown1" }
+        setup { pass "child setup2" }
         around do |block|
           pass "child around2 start"
           block.call
           pass "child around2 end"
         end
-        teardown{ pass "child teardown2" }
+        teardown { pass "child teardown2" }
       end
-      @test = Factory.test("t", Factory.context_info(@context_class)){ pass "TEST" }
-      @test.run(&test_run_callback)
-    end
+    }
+    let(:test1) {
+      Factory.test("t", Factory.context_info(context_class1)) { pass "TEST" }
+    }
 
     should "run the arounds outside of the setups/teardowns/test" do
       assert_equal 13, test_run_result_count(:pass)

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -27,56 +27,67 @@ module Assert
   end
 
   class StubTests < UnitTests
-    setup do
-      @orig_value = Factory.string
-      @stub_value = Factory.string
+    # setup do
+    #   orig_value1 = Factory.string
+    #   stub_value1 = Factory.string
 
-      @myclass = Class.new do
+    #   @myclass =
+    #   Class.new do
+    #     def initialize(value); @value = value; end
+    #     def mymeth; @value; end
+    #   end
+    #   object1 = @myclass.new(orig_value1)
+    # end
+
+    let(:class1) {
+      Class.new do
         def initialize(value); @value = value; end
         def mymeth; @value; end
       end
-      @myobj = @myclass.new(@orig_value)
-    end
+    }
+    let(:object1) { class1.new(orig_value1) }
+    let(:orig_value1) { Factory.string }
+    let(:stub_value1) { Factory.string }
 
     should "build a stub" do
-      stub1 = Assert.stub(@myobj, :mymeth)
+      stub1 = Assert.stub(object1, :mymeth)
       assert_kind_of MuchStub::Stub, stub1
     end
 
     should "lookup stubs that have been called before" do
-      stub1 = Assert.stub(@myobj, :mymeth)
-      stub2 = Assert.stub(@myobj, :mymeth)
+      stub1 = Assert.stub(object1, :mymeth)
+      stub2 = Assert.stub(object1, :mymeth)
       assert_same stub1, stub2
     end
 
     should "set the stub's do block if given a block" do
-      Assert.stub(@myobj, :mymeth)
-      assert_raises(MuchStub::NotStubbedError){ @myobj.mymeth }
-      Assert.stub(@myobj, :mymeth){ @stub_value }
-      assert_equal @stub_value, @myobj.mymeth
+      Assert.stub(object1, :mymeth)
+      assert_raises(MuchStub::NotStubbedError){ object1.mymeth }
+      Assert.stub(object1, :mymeth){ stub_value1 }
+      assert_equal stub_value1, object1.mymeth
     end
 
     should "teardown stubs" do
-      assert_equal @orig_value, @myobj.mymeth
-      Assert.unstub(@myobj, :mymeth)
-      assert_equal @orig_value, @myobj.mymeth
+      assert_equal orig_value1, object1.mymeth
+      Assert.unstub(object1, :mymeth)
+      assert_equal orig_value1, object1.mymeth
 
-      assert_equal @orig_value, @myobj.mymeth
-      Assert.stub(@myobj, :mymeth){ @stub_value }
-      assert_equal @stub_value, @myobj.mymeth
-      Assert.unstub(@myobj, :mymeth)
-      assert_equal @orig_value, @myobj.mymeth
+      assert_equal orig_value1, object1.mymeth
+      Assert.stub(object1, :mymeth){ stub_value1 }
+      assert_equal stub_value1, object1.mymeth
+      Assert.unstub(object1, :mymeth)
+      assert_equal orig_value1, object1.mymeth
     end
 
     should "know and teardown all stubs" do
-      assert_equal @orig_value, @myobj.mymeth
+      assert_equal orig_value1, object1.mymeth
 
-      Assert.stub(@myobj, :mymeth){ @stub_value }
-      assert_equal @stub_value, @myobj.mymeth
+      Assert.stub(object1, :mymeth){ stub_value1 }
+      assert_equal stub_value1, object1.mymeth
       assert_equal 1, Assert.stubs.size
 
       Assert.unstub!
-      assert_equal @orig_value, @myobj.mymeth
+      assert_equal orig_value1, object1.mymeth
       assert_empty Assert.stubs
     end
 
@@ -95,33 +106,33 @@ module Assert
     end
 
     should "be able to call a stub's original method" do
-      err = assert_raises(MuchStub::NotStubbedError){ Assert.stub_send(@myobj, :mymeth) }
+      err = assert_raises(MuchStub::NotStubbedError){ Assert.stub_send(object1, :mymeth) }
       assert_includes "not stubbed.",              err.message
       assert_includes "test/unit/assert_tests.rb", err.backtrace.first
 
-      Assert.stub(@myobj, :mymeth){ @stub_value }
+      Assert.stub(object1, :mymeth){ stub_value1 }
 
-      assert_equal @stub_value, @myobj.mymeth
-      assert_equal @orig_value, Assert.stub_send(@myobj, :mymeth)
+      assert_equal stub_value1, object1.mymeth
+      assert_equal orig_value1, Assert.stub_send(object1, :mymeth)
     end
 
     should "be able to add a stub tap" do
       my_meth_called_with = nil
-      Assert.stub_tap(@myobj, :mymeth){ |value, *args, &block|
+      Assert.stub_tap(object1, :mymeth){ |value, *args, &block|
         my_meth_called_with = args
       }
 
-      assert_equal @orig_value, @myobj.mymeth
+      assert_equal orig_value1, object1.mymeth
       assert_equal [], my_meth_called_with
     end
 
     should "be able to add a stub tap with an on_call block" do
       my_meth_called_with = nil
-      Assert.stub_tap_on_call(@myobj, :mymeth){ |value, call|
+      Assert.stub_tap_on_call(object1, :mymeth){ |value, call|
         my_meth_called_with = call
       }
 
-      assert_equal @orig_value, @myobj.mymeth
+      assert_equal orig_value1, object1.mymeth
       assert_equal [], my_meth_called_with.args
     end
 

--- a/test/unit/assertions/assert_block_tests.rb
+++ b/test/unit/assertions/assert_block_tests.rb
@@ -6,24 +6,25 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_block`"
-    setup do
-      desc = @desc = "assert block fail desc"
-      @test = Factory.test do
-        assert_block{ true }        # pass
-        assert_block(desc){ false } # fail
+    subject { test1 }
+
+    let(:desc1) { "assert block fail desc" }
+    let(:test1) {
+      desc = desc1
+      Factory.test do
+        assert_block { true }        # pass
+        assert_block(desc) { false } # fail
       end
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@desc}\nExpected block to return a true value."
+      exp = "#{desc1}\nExpected block to return a true value."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
@@ -32,26 +33,26 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_block`"
-    setup do
-      desc = @desc = "assert not block fail desc"
-      @test = Factory.test do
-        assert_not_block(desc){ true } # fail
-        assert_not_block{ false }      # pass
+    subject { test1 }
+
+    let(:desc1) { "assert not block fail desc" }
+    let(:test1) {
+      desc = desc1
+      Factory.test do
+        assert_not_block(desc) { true } # fail
+        assert_not_block { false }      # pass
       end
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@desc}\nExpected block to not return a true value."
+      exp = "#{desc1}\nExpected block to not return a true value."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
 end
-

--- a/test/unit/assertions/assert_empty_tests.rb
+++ b/test/unit/assertions/assert_empty_tests.rb
@@ -8,55 +8,58 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_empty`"
-    setup do
-      desc = @desc = "assert empty fail desc"
-      args = @args = [[1], desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert empty fail desc" }
+    let(:args1) { [[1], desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_empty([])    # pass
         assert_empty(*args) # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to be empty."
+      exp =
+        "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to be empty."
       assert_equal exp, test_run_results(:fail).first.message
     end
-
   end
 
   class AssertNotEmptyTests < Assert::Context
     include Assert::Test::TestHelpers
 
     desc "`assert_not_empty`"
-    setup do
-      desc = @desc = "assert not empty fail desc"
-      args = @args = [[], desc]
-      @test = Factory.test do
-        assert_not_empty([1]) # pass
+    subject { test1 }
+
+    let(:desc1) { "assert not empty fail desc" }
+    let(:args1) { [[], desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
+        assert_not_empty([1])   # pass
         assert_not_empty(*args) # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to not be empty."
+      exp =
+        "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to not be empty."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end

--- a/test/unit/assertions/assert_file_exists_tests.rb
+++ b/test/unit/assertions/assert_file_exists_tests.rb
@@ -9,26 +9,27 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_file_exists`"
-    setup do
-      desc = @desc = "assert file exists empty fail desc"
-      args = @args = ["/a/path/to/some/file/that/no/exists", desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert file exists fail desc" }
+    let(:args1) { ["/a/path/to/some/file/that/no/exists", desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_file_exists(__FILE__) # pass
         assert_file_exists(*args)    # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to exist."
+      exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to exist."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
@@ -37,28 +38,28 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_file_exists`"
-    setup do
-      desc = @desc = "assert not file exists empty fail desc"
-      args = @args = [__FILE__, desc]
-      @test = Factory.test do
-        assert_not_file_exists("/a/path/to/some/file/that/no/exists") # pass
-        assert_not_file_exists(*args) # fail
+    subject { test1 }
+
+    let(:desc1) { "assert not file exists fail desc" }
+    let(:args1) { [__FILE__, desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
+        assert_not_file_exists("/file/path") # pass
+        assert_not_file_exists(*args)        # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to not exist."
+      exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to not exist."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
 end
-

--- a/test/unit/assertions/assert_includes_tests.rb
+++ b/test/unit/assertions/assert_includes_tests.rb
@@ -8,28 +8,30 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_includes`"
-    setup do
-      desc = @desc = "assert includes fail desc"
-      args = @args = [2, [1], desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert includes fail desc" }
+    let(:args1) { [2, [1], desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_includes(1, [1]) # pass
-        assert_includes(*args)    # fail
+        assert_includes(*args)  # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n"\
-            "Expected #{Assert::U.show(@args[1], @c)}"\
-            " to include #{Assert::U.show(@args[0], @c)}."
+      exp =
+        "#{args1[2]}\n"\
+        "Expected #{Assert::U.show(args1[1], config1)}"\
+        " to include #{Assert::U.show(args1[0], config1)}."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
@@ -38,30 +40,31 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_included`"
-    setup do
-      desc = @desc = "assert not included fail desc"
-      args = @args = [1, [1], desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert not included fail desc" }
+    let(:args1) { [1, [1], desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_not_included(2, [1]) # pass
-        assert_not_included(*args)    # fail
+        assert_not_included(*args)  # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n"\
-            "Expected #{Assert::U.show(@args[1], @c)}"\
-            " to not include #{Assert::U.show(@args[0], @c)}."
+      exp =
+        "#{args1[2]}\n"\
+        "Expected #{Assert::U.show(args1[1], config1)}"\
+        " to not include #{Assert::U.show(args1[0], config1)}."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
 end
-

--- a/test/unit/assertions/assert_instance_of_tests.rb
+++ b/test/unit/assertions/assert_instance_of_tests.rb
@@ -8,27 +8,29 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_instance_of`"
-    setup do
-      desc = @desc = "assert instance of fail desc"
-      args = @args = [Array, "object", desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert instance of fail desc" }
+    let(:args1) { [Array, "object", desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_instance_of(String, "object") # pass
         assert_instance_of(*args)            # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
-            " to be an instance of #{@args[0]}."
+      exp =
+        "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)} (#{args1[1].class})"\
+        " to be an instance of #{args1[0]}."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
@@ -37,29 +39,30 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_instance_of`"
-    setup do
-      desc = @desc = "assert not instance of fail desc"
-      args = @args = [String, "object", desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert not instance of fail desc" }
+    let(:args1) { [String, "object", desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_not_instance_of(*args)           # fail
         assert_not_instance_of(Array, "object") # pass
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
-            " to not be an instance of #{@args[0]}."
+      exp =
+        "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)} (#{args1[1].class})"\
+        " to not be an instance of #{args1[0]}."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
 end
-

--- a/test/unit/assertions/assert_kind_of_tests.rb
+++ b/test/unit/assertions/assert_kind_of_tests.rb
@@ -8,27 +8,29 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_kind_of`"
-    setup do
-      desc = @desc = "assert kind of fail desc"
-      args = @args = [Array, "object", desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert kind of fail desc" }
+    let(:args1) { [Array, "object", desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_kind_of(String, "object") # pass
         assert_kind_of(*args)            # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
-            " to be a kind of #{@args[0]}."
+      exp =
+        "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)} (#{args1[1].class})"\
+        " to be a kind of #{args1[0]}."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
@@ -37,29 +39,30 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_kind_of`"
-    setup do
-      desc = @desc = "assert not kind of fail desc"
-      args = @args = [String, "object", desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert not kind of fail desc" }
+    let(:args1) { [String, "object", desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_not_kind_of(*args)           # fail
         assert_not_kind_of(Array, "object") # pass
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
-            " to not be a kind of #{@args[0]}."
+      exp =
+        "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)} (#{args1[1].class})"\
+        " to not be a kind of #{args1[0]}."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
 end
-

--- a/test/unit/assertions/assert_match_tests.rb
+++ b/test/unit/assertions/assert_match_tests.rb
@@ -8,27 +8,29 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_match`"
-    setup do
-      desc = @desc = "assert match fail desc"
-      args = @args = ["not", "a string", desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert match fail desc" }
+    let(:args1) { ["not", "a string", desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_match(/a/, "a string") # pass
         assert_match(*args)           # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)}"\
-            " to match #{Assert::U.show(@args[0], @c)}."
+      exp =
+        "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)}"\
+        " to match #{Assert::U.show(args1[0], config1)}."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
@@ -37,29 +39,30 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_match`"
-    setup do
-      desc = @desc = "assert not match fail desc"
-      args = @args = [/a/, "a string", desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert not match fail desc" }
+    let(:args1) { [/a/, "a string", desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_not_match(*args)             # fail
         assert_not_match("not", "a string") # pass
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\nExpected #{Assert::U.show(@args[1], @c)}"\
-            " to not match #{Assert::U.show(@args[0], @c)}."
+      exp =
+        "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)}"\
+        " to not match #{Assert::U.show(args1[0], config1)}."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
 end
-

--- a/test/unit/assertions/assert_nil_tests.rb
+++ b/test/unit/assertions/assert_nil_tests.rb
@@ -8,26 +8,27 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_nil`"
-    setup do
-      desc = @desc = "assert nil empty fail desc"
-      args = @args = [1, desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert nil empty fail desc" }
+    let(:args1) { [1, desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_nil(nil)   # pass
         assert_nil(*args) # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to be nil."
+      exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to be nil."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
@@ -36,28 +37,28 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_nil`"
-    setup do
-      desc = @desc = "assert not nil empty fail desc"
-      args = @args = [nil, desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert not nil empty fail desc" }
+    let(:args1) { [nil, desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_not_nil(1)     # pass
         assert_not_nil(*args) # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to not be nil."
+      exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to not be nil."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
 end
-

--- a/test/unit/assertions/assert_raises_tests.rb
+++ b/test/unit/assertions/assert_raises_tests.rb
@@ -6,32 +6,33 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_raises`"
-    setup do
-      d = @d = "assert raises fail desc"
-      @test = Factory.test do
-        assert_raises(StandardError, RuntimeError){ raise(StandardError) } # pass
-        assert_raises(StandardError, RuntimeError, d){ raise(Exception) }  # fail
-        assert_raises(RuntimeError, d){ raise(StandardError) }             # fail
-        assert_raises(RuntimeError, d){ true }                             # fail
-        assert_raises(d){ true }                                           # fail
+    subject { test1 }
+
+    let(:desc1) { "assert raises fail desc" }
+    let(:test1) {
+      desc = desc1
+      Factory.test do
+        assert_raises(StandardError, RuntimeError) { raise(StandardError) }    # pass
+        assert_raises(StandardError, RuntimeError, desc) { raise(Exception) }  # fail
+        assert_raises(RuntimeError, desc) { raise(StandardError) }             # fail
+        assert_raises(RuntimeError, desc) { true }                             # fail
+        assert_raises(desc) { true }                                           # fail
       end
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 5, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 4, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = [
-        "#{@d}\nStandardError or RuntimeError exception expected, not:",
-        "#{@d}\nRuntimeError exception expected, not:",
-        "#{@d}\nRuntimeError exception expected but nothing raised.",
-        "#{@d}\nAn exception expected but nothing raised."
-      ]
+      exp =
+        [ "#{desc1}\nStandardError or RuntimeError exception expected, not:",
+          "#{desc1}\nRuntimeError exception expected, not:",
+          "#{desc1}\nRuntimeError exception expected but nothing raised.",
+          "#{desc1}\nAn exception expected but nothing raised."
+        ]
       messages = test_run_results(:fail).map(&:message)
       messages.each_with_index{ |msg, n| assert_match(/^#{exp[n]}/, msg) }
     end
@@ -39,18 +40,18 @@ module Assert::Assertions
     should "return any raised exception instance" do
       error     = nil
       error_msg = Factory.string
-      test = Factory.test do
-        error = assert_raises(RuntimeError){ raise(RuntimeError, error_msg) }
-      end
+
+      test =
+        Factory.test do
+          error = assert_raises(RuntimeError) { raise(RuntimeError, error_msg) }
+        end
       test.run
 
       assert_not_nil error
       assert_kind_of RuntimeError, error
       assert_equal error_msg, error.message
 
-      test = Factory.test do
-        error = assert_raises(RuntimeError){ }
-      end
+      test = Factory.test { error = assert_raises(RuntimeError) {} }
       test.run
 
       assert_nil error
@@ -61,33 +62,32 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_nothing_raised`"
-    setup do
-      d = @d = "assert nothing raised fail desc"
-      @test = Factory.test do
-        anr = :assert_nothing_raised
-        self.send(anr, StandardError, RuntimeError, d){ raise(StandardError) } # fail
-        self.send(anr, RuntimeError){ raise(StandardError) }                   # pass
-        self.send(anr, d){ raise(RuntimeError) }                               # fail
-        self.send(anr){ true }                                                 # pass
+    subject { test1 }
+
+    let(:desc1) { "assert nothing raised fail desc" }
+    let(:test1) {
+      desc = desc1
+      Factory.test do
+        assert_nothing_raised(StandardError, RuntimeError, desc) { raise(StandardError) } # fail
+        assert_nothing_raised(RuntimeError) { raise(StandardError) }                      # pass
+        assert_nothing_raised(desc) { raise(RuntimeError) }                               # fail
+        assert_nothing_raised { true }                                                    # pass
       end
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 4, test_run_result_count
       assert_equal 2, test_run_result_count(:pass)
       assert_equal 2, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = [
-        "#{@d}\nStandardError or RuntimeError exception not expected, but raised:",
-        "#{@d}\nAn exception not expected, but raised:"
-      ]
+      exp =
+        [ "#{desc1}\nStandardError or RuntimeError exception not expected, but raised:",
+          "#{desc1}\nAn exception not expected, but raised:"
+        ]
       messages = test_run_results(:fail).map(&:message)
       messages.each_with_index{ |msg, n| assert_match(/^#{exp[n]}/, msg) }
     end
   end
 end
-

--- a/test/unit/assertions/assert_respond_to_tests.rb
+++ b/test/unit/assertions/assert_respond_to_tests.rb
@@ -8,28 +8,30 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_respond_to`"
-    setup do
-      desc = @desc = "assert respond to fail desc"
-      args = @args = [:abs, "1", desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert respond to fail desc" }
+    let(:args1) { [:abs, "1", desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_respond_to(:abs, 1) # pass
         assert_respond_to(*args)   # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n"\
-            "Expected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
-            " to respond to `#{@args[0]}`."
+      exp =
+        "#{args1[2]}\n"\
+        "Expected #{Assert::U.show(args1[1], config1)} (#{args1[1].class})"\
+        " to respond to `#{args1[0]}`."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
@@ -38,30 +40,31 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_respond_to`"
-    setup do
-      desc = @desc = "assert not respond to fail desc"
-      args = @args = [:abs, 1, desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert not respond to fail desc" }
+    let(:args1) { [:abs, 1, desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_not_respond_to(*args)     # fail
         assert_not_respond_to(:abs, "1") # pass
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[2]}\n"\
-            "Expected #{Assert::U.show(@args[1], @c)} (#{@args[1].class})"\
-            " to not respond to `#{@args[0]}`."
+      exp =
+        "#{args1[2]}\n"\
+        "Expected #{Assert::U.show(args1[1], config1)} (#{args1[1].class})"\
+        " to not respond to `#{args1[0]}`."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
 end
-

--- a/test/unit/assertions/assert_true_false_tests.rb
+++ b/test/unit/assertions/assert_true_false_tests.rb
@@ -8,26 +8,27 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_true`"
-    setup do
-      desc = @desc = "assert true fail desc"
-      args = @args = ["whatever", desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert true fail desc" }
+    let(:args1) { ["whatever", desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_true(true)  # pass
         assert_true(*args) # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to be true."
+      exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to be true."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
@@ -36,26 +37,27 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_true`"
-    setup do
-      desc = @desc = "assert not true fail desc"
-      args = @args = [true, desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert not true fail desc" }
+    let(:args1) { [true, desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_not_true(false) # pass
         assert_not_true(*args) # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to not be true."
+      exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to not be true."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
@@ -64,26 +66,27 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_false`"
-    setup do
-      desc = @desc = "assert false fail desc"
-      args = @args = ["whatever", desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert false fail desc" }
+    let(:args1) { ["whatever", desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_false(false) # pass
         assert_false(*args) # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to be false."
+      exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to be false."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end
@@ -92,26 +95,27 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_false`"
-    setup do
-      desc = @desc = "assert not false fail desc"
-      args = @args = [false, desc]
-      @test = Factory.test do
+    subject { test1 }
+
+    let(:desc1) { "assert not false fail desc" }
+    let(:args1) { [false, desc1] }
+    let(:test1) {
+      args = args1
+      Factory.test do
         assert_not_false(true)  # pass
         assert_not_false(*args) # fail
       end
-      @c = @test.config
-      @test.run(&test_run_callback)
-    end
-    subject{ @test }
+    }
+    let(:config1) { test1.config }
 
     should "produce results as expected" do
+      subject.run(&test_run_callback)
+
       assert_equal 2, test_run_result_count
       assert_equal 1, test_run_result_count(:pass)
       assert_equal 1, test_run_result_count(:fail)
-    end
 
-    should "have a fail message with custom and generic explanations" do
-      exp = "#{@args[1]}\nExpected #{Assert::U.show(@args[0], @c)} to not be false."
+      exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to not be false."
       assert_equal exp, test_run_results(:fail).first.message
     end
   end

--- a/test/unit/assertions_tests.rb
+++ b/test/unit/assertions_tests.rb
@@ -6,12 +6,11 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "Assert::Context"
-    setup do
-      @context_class = Factory.modes_off_context_class
-      @test = Factory.test
-      @context = @context_class.new(@test, @test.config, proc{ |r| })
-    end
-    subject{ @context }
+    subject { context1 }
+
+    let(:context_class1) { Factory.modes_off_context_class }
+    let(:test1) { Factory.test }
+    let(:context1) { context_class1.new(test1, test1.config, proc{ |r| }) }
 
     should have_imeths :assert_block, :assert_not_block, :refute_block
     should have_imeths :assert_raises, :assert_not_raises
@@ -37,14 +36,17 @@ module Assert::Assertions
   class IgnoredTests < UnitTests
     desc "ignored assertions helpers"
     setup do
-      @tests = Assert::Assertions::IGNORED_ASSERTION_HELPERS.map do |helper|
-        context_info = Factory.context_info(@context_class)
+      tests.each{ |test| test.run(&test_run_callback) }
+    end
+
+    let(:tests) {
+      context_info = Factory.context_info(context_class1)
+      Assert::Assertions::IGNORED_ASSERTION_HELPERS.map do |helper|
         Factory.test("ignored assertion helper #{helper}", context_info) do
           self.send(helper, "doesn't matter")
         end
       end
-      @tests.each{ |test| test.run(&test_run_callback) }
-    end
+    }
 
     should "have an ignored result for each helper in the constant" do
       exp = Assert::Assertions::IGNORED_ASSERTION_HELPERS.size

--- a/test/unit/config_helpers_tests.rb
+++ b/test/unit/config_helpers_tests.rb
@@ -6,8 +6,10 @@ require "assert/config"
 module Assert::ConfigHelpers
   class UnitTests < Assert::Context
     desc "Assert::ConfigHelpers"
-    setup do
-      @helpers_class = Class.new do
+    subject { helpers1 }
+
+    let(:helpers_class1) {
+      Class.new do
         include Assert::ConfigHelpers
 
         def config
@@ -16,9 +18,8 @@ module Assert::ConfigHelpers
           @config ||= [Assert.config, Assert::Config.new].sample
         end
       end
-      @helpers = @helpers_class.new
-    end
-    subject{ @helpers }
+    }
+    let(:helpers1) { helpers_class1.new }
 
     should have_imeths :runner, :suite, :view
     should have_imeths :runner_seed, :single_test?, :single_test_file_line

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -10,10 +10,9 @@ require "assert/runner"
 class Assert::Config
   class UnitTests < Assert::Context
     desc "Assert::Config"
-    setup do
-      @config = Assert::Config.new
-    end
-    subject{ @config }
+    subject { config1 }
+
+    let(:config1) { Assert::Config.new }
 
     should have_imeths :view, :suite, :runner
     should have_imeths :test_dir, :test_helper, :test_file_suffixes

--- a/test/unit/context/let_dsl_tests.rb
+++ b/test/unit/context/let_dsl_tests.rb
@@ -1,0 +1,10 @@
+require "assert"
+require "assert/context/let_dsl"
+
+module Assert::Context::LetDSL
+  class UnitTests < Assert::Context
+    desc "Assert::Context::LetDSL"
+
+    # This is tested implicitly by running Assert's test suite.
+  end
+end

--- a/test/unit/context/setup_dsl_tests.rb
+++ b/test/unit/context/setup_dsl_tests.rb
@@ -4,77 +4,65 @@ require "assert/context/setup_dsl"
 module Assert::Context::SetupDSL
   class UnitTests < Assert::Context
     desc "Assert::Context::SetupDSL"
-    subject{ @context_class }
+    subject { context_class1 }
+
+    let(:block1) { ::Proc.new {} }
+    let(:context_class1) { Factory.modes_off_context_class }
   end
 
   class SetupTeardownOnceMethodsTests < UnitTests
     desc "once methods"
-    setup do
-      block = @block = ::Proc.new{ something_once = true }
-      @context_class = Factory.modes_off_context_class do
-        setup_once(&block)
-        teardown_once(&block)
-      end
-    end
 
     should "add the block to the suite" do
-      assert_includes @block, subject.suite.send(:setups)
-      assert_includes @block, subject.suite.send(:teardowns)
+      subject.setup_once(&block1)
+      subject.teardown_once(&block1)
+
+      assert_includes block1, subject.suite.send(:setups)
+      assert_includes block1, subject.suite.send(:teardowns)
     end
   end
 
   class SetupTeardownMethodsTests < UnitTests
     desc "methods"
-    setup do
-      block = @block = ::Proc.new{ something = true }
-      @context_class = Factory.modes_off_context_class do
-        setup(&block)
-        teardown(&block)
-      end
-    end
 
     should "add the block to the context" do
-      assert_includes @block, subject.send(:setups)
-      assert_includes @block, subject.send(:teardowns)
+      subject.setup(&block1)
+      subject.teardown(&block1)
+
+      assert_includes block1, subject.send(:setups)
+      assert_includes block1, subject.send(:teardowns)
     end
   end
 
   class SetupTeardownWithMethodNameTests < UnitTests
     desc "methods given a method name"
-    setup do
-      method_name = @method_name = :something_amazing
-      @context_class = Factory.modes_off_context_class do
-        setup(method_name)
-        teardown(method_name)
-      end
-    end
+
+    let(:method_name1) { :something_amazing }
 
     should "add the method name to the context" do
-      assert_includes @method_name, subject.send(:setups)
-      assert_includes @method_name, subject.send(:teardowns)
+      subject.setup(method_name1)
+      subject.teardown(method_name1)
+
+      assert_includes method_name1, subject.send(:setups)
+      assert_includes method_name1, subject.send(:teardowns)
     end
   end
 
-  class SetupTeardownMultipleTests < UnitTests
+  class ParentContextClassTests < UnitTests
+    let(:parent_class1)  { Factory.modes_off_context_class }
+    let(:context_class1) { Factory.modes_off_context_class(parent_class1) }
+  end
+
+  class SetupTeardownMultipleTests < ParentContextClassTests
     desc "with multiple calls"
-    setup do
-      parent_setup_block    = ::Proc.new{ self.setup_status    =  "the setup"    }
-      parent_teardown_block = ::Proc.new{ self.teardown_status += "the teardown" }
-      @parent_class = Factory.modes_off_context_class do
-        setup(&parent_setup_block)
-        teardown(&parent_teardown_block)
-      end
 
-      context_setup_block    = ::Proc.new{ self.setup_status    += " has been run" }
-      context_teardown_block = ::Proc.new{ self.teardown_status += "has been run " }
-      @context_class = Factory.modes_off_context_class(@parent_class) do
-        setup(&context_setup_block)
-        setup(:setup_something)
-        teardown(:teardown_something)
-        teardown(&context_teardown_block)
-      end
+    let(:parent_setup_block1)     { ::Proc.new { self.setup_status     = "the setup"     } }
+    let(:parent_teardown_block1)  { ::Proc.new { self.teardown_status += "the teardown"  } }
+    let(:context_setup_block1)    { ::Proc.new { self.setup_status    += " has been run" } }
+    let(:context_teardown_block1) { ::Proc.new { self.teardown_status += "has been run " } }
 
-      @test_status_class = Class.new do
+    let(:test_status_class) {
+      Class.new do
         attr_accessor :setup_status, :teardown_status
         define_method(:setup_something) do
           self.setup_status += " with something"
@@ -83,56 +71,57 @@ module Assert::Context::SetupDSL
           self.teardown_status = "with something "
         end
       end
-    end
+    }
 
-    should "run it's parent and it's own blocks in the correct order" do
-      subject.send("run_setups", obj = @test_status_class.new)
+    should "run its parent and its own blocks in the correct order" do
+      parent_class1.setup(&parent_setup_block1)
+      parent_class1.teardown(&parent_teardown_block1)
+      subject.setup(&context_setup_block1)
+      subject.setup(:setup_something)
+      subject.teardown(:teardown_something)
+      subject.teardown(&context_teardown_block1)
+
+      subject.send("run_setups", obj = test_status_class.new)
       assert_equal "the setup has been run with something", obj.setup_status
 
-      subject.send("run_teardowns", obj = @test_status_class.new)
+      subject.send("run_teardowns", obj = test_status_class.new)
       assert_equal "with something has been run the teardown", obj.teardown_status
     end
   end
 
-  class AroundMethodTests < UnitTests
+  class AroundMethodTests < ParentContextClassTests
     desc "with multiple `around` calls"
-    setup do
-      @parent_class = Factory.modes_off_context_class do
-        around do |block|
-          self.out_status ||= ""
-          self.out_status += "p-around start, "
-          block.call
-          self.out_status += "p-around end."
-        end
+
+    let(:test_status_class) { Class.new { attr_accessor :out_status } }
+
+    should "run its parent and its own blocks in the correct order" do
+      parent_class1.around do |block|
+        self.out_status ||= ""
+        self.out_status += "p-around start, "
+        block.call
+        self.out_status += "p-around end."
       end
 
-      @context_class = Factory.modes_off_context_class(@parent_class) do
-        around do |block|
-          self.out_status += "c-around1 start, "
-          block.call
-          self.out_status += "c-around1 end, "
-        end
-        around do |block|
-          self.out_status += "c-around2 start, "
-          block.call
-          self.out_status += "c-around2 end, "
-        end
+      subject.around do |block|
+        self.out_status += "c-around1 start, "
+        block.call
+        self.out_status += "c-around1 end, "
+      end
+      subject.around do |block|
+        self.out_status += "c-around2 start, "
+        block.call
+        self.out_status += "c-around2 end, "
       end
 
-      @test_status_class = Class.new do
-        attr_accessor :out_status
-      end
-    end
-
-    should "run it's parent and it's own blocks in the correct order" do
-      obj = @test_status_class.new
+      obj = test_status_class.new
       subject.send("run_arounds", obj) do
         obj.instance_eval{ self.out_status += "TEST, " }
       end
 
-      exp = "p-around start, c-around1 start, c-around2 start, "\
-            "TEST, "\
-            "c-around2 end, c-around1 end, p-around end."
+      exp =
+        "p-around start, c-around1 start, c-around2 start, "\
+        "TEST, "\
+        "c-around2 end, c-around1 end, p-around end."
       assert_equal exp, obj.out_status
     end
   end

--- a/test/unit/context/subject_dsl_tests.rb
+++ b/test/unit/context/subject_dsl_tests.rb
@@ -2,71 +2,44 @@ require "assert"
 require "assert/context/subject_dsl"
 
 module Assert::Context::SubjectDSL
-
   class UnitTests < Assert::Context
     desc "Assert::Context::SubjectDSL"
-    subject{ @context_class }
-  end
+    subject { context_class1 }
 
-  class DescriptionsTests < UnitTests
-    desc "`descriptions` method"
-    setup do
-      descs = @descs = ["something amazing", "it really is"]
-      @context_class = Factory.modes_off_context_class do
-        descs.each{ |text| desc text }
-      end
-    end
-
-    should "return a collection containing any descriptions defined on the class" do
-      assert_equal @descs, subject.send(:descriptions)
-    end
+    let(:parent_class1)  { Factory.modes_off_context_class }
+    let(:context_class1) { Factory.modes_off_context_class(parent_class1) }
+    let(:subject_block1) { Proc.new {} }
   end
 
   class DescriptionTests < UnitTests
     desc "`description` method"
-    setup do
-      parent_text = @parent_desc = "parent description"
-      @parent_class = Factory.modes_off_context_class do
-        desc parent_text
-      end
-      text = @desc = "and the description for this context"
-      @context_class = Factory.modes_off_context_class(@parent_class) do
-        desc text
-      end
-    end
 
     should "return a string of all the inherited descriptions" do
-      exp_desc = "parent description and the description for this context"
-      assert_equal exp_desc, @context_class.description
+      parent_class1.desc("parent description")
+      subject.desc("and the description for this context")
+
+      exp = "parent description and the description for this context"
+      assert_equal exp, subject.description
     end
   end
 
   class SubjectFromLocalTests < UnitTests
     desc "`subject` method using local context"
-    setup do
-      subject_block = @subject_block = ::Proc.new{ @something }
-      @context_class = Factory.modes_off_context_class do
-        subject(&subject_block)
-      end
-    end
 
     should "set the subject block on the context class" do
-      assert_equal @subject_block, @context_class.subject
+      subject.subject(&subject_block1)
+
+      assert_equal subject_block1, subject.subject
     end
   end
 
   class SubjectFromParentTests < UnitTests
     desc "`subject` method using parent context"
-    setup do
-      parent_block = @parent_block = ::Proc.new{ @something }
-      @parent_class = Factory.modes_off_context_class do
-        subject(&parent_block)
-      end
-      @context_class = Factory.modes_off_context_class(@parent_class)
-    end
 
-    should "default to it's parents subject block" do
-      assert_equal @parent_block, @context_class.subject
+    should "default to its parents subject block" do
+      parent_class1.subject(&subject_block1)
+
+      assert_equal subject_block1, subject.subject
     end
   end
 end

--- a/test/unit/context/suite_dsl_tests.rb
+++ b/test/unit/context/suite_dsl_tests.rb
@@ -6,38 +6,38 @@ require "assert/suite"
 module Assert::Context::SuiteDSL
   class UnitTests < Assert::Context
     desc "Assert::Context::SuiteDSL"
-    setup do
-      @custom_suite = Factory.modes_off_suite
-      @context_class = Factory.context_class
-    end
-    subject{ @context_class }
+    subject { context_class1 }
+
+    let(:parent_class1)  { Factory.context_class }
+    let(:context_class1) { Factory.context_class(parent_class1) }
+    let(:custom_suite1)  { Factory.modes_off_suite }
 
     should "use `Assert.suite` by default" do
       assert_equal Assert.suite, subject.suite
     end
 
     should "use any given custom suite" do
-      subject.suite(@custom_suite)
-      assert_equal @custom_suite, subject.suite
+      subject.suite(custom_suite1)
+      assert_equal custom_suite1, subject.suite
     end
   end
 
   class SuiteFromParentTests < UnitTests
     desc "`suite` method using parent context"
+
     setup do
-      @parent_class = Factory.context_class
-      @parent_class.suite(@custom_suite)
-      @context_class = Factory.context_class(@parent_class)
+      parent_class1.suite(custom_suite1)
     end
 
-    should "default to it's parent's suite" do
-      assert_equal @custom_suite, subject.suite
+    let(:custom_suite2) { Factory.modes_off_suite }
+
+    should "default to its parent's suite" do
+      assert_equal custom_suite1, subject.suite
     end
 
     should "use any given custom suite" do
-      another_suite = Factory.modes_off_suite
-      subject.suite(another_suite)
-      assert_equal another_suite, subject.suite
+      subject.suite(custom_suite2)
+      assert_equal custom_suite2, subject.suite
     end
   end
 end

--- a/test/unit/context/test_dsl_tests.rb
+++ b/test/unit/context/test_dsl_tests.rb
@@ -4,35 +4,34 @@ require "assert/context/test_dsl"
 module Assert::Context::TestDSL
   class UnitTests < Assert::Context
     desc "Assert::Context::TestDSL"
-    setup do
-      @test_desc = "be true"
-      @test_block = ::Proc.new{ assert(true) }
-    end
+
+    let(:test_desc1)  { "be true" }
+    let(:test_block1) { Proc.new{ assert(true) } }
 
     should "build a test using `test` with a desc and code block" do
-      d, b = @test_desc, @test_block
+      d, b = test_desc1, test_block1
       context, test = build_eval_context{ test(d, &b) }
 
       assert_equal 1, context.class.suite.tests_to_run_count
 
       assert_kind_of Assert::Test, test
-      assert_equal @test_desc,  test.name
-      assert_equal @test_block, test.code
+      assert_equal test_desc1,  test.name
+      assert_equal test_block1, test.code
     end
 
     should "build a test using `should` with a desc and code block" do
-      d, b = @test_desc, @test_block
+      d, b = test_desc1, test_block1
       context, test = build_eval_context{ should(d, &b) }
 
       assert_equal 1, context.class.suite.tests_to_run_count
 
       assert_kind_of Assert::Test, test
-      assert_equal "should #{@test_desc}", test.name
-      assert_equal @test_block, test.code
+      assert_equal "should #{test_desc1}", test.name
+      assert_equal test_block1, test.code
     end
 
     should "build a test that skips with no msg when `test_eventually` called" do
-      d, b = @test_desc, @test_block
+      d, b = test_desc1, test_block1
       context, test = build_eval_context{ test_eventually(d, &b) }
       err = capture_err(Assert::Result::TestSkipped) do
         context.instance_eval(&test.code)
@@ -44,7 +43,7 @@ module Assert::Context::TestDSL
     end
 
     should "build a test that skips with no msg  when `should_eventually` called" do
-      d, b = @test_desc, @test_block
+      d, b = test_desc1, test_block1
       context, test = build_eval_context{ should_eventually(d, &b) }
       err = capture_err(Assert::Result::TestSkipped) do
         context.instance_eval(&test.code)
@@ -56,7 +55,7 @@ module Assert::Context::TestDSL
     end
 
     should "skip with the msg \"TODO\" when `test` called with no block" do
-      d = @test_desc
+      d = test_desc1
       context, test = build_eval_context { test(d) } # no block passed
       err = capture_err(Assert::Result::TestSkipped) do
         context.instance_eval(&test.code)
@@ -68,7 +67,7 @@ module Assert::Context::TestDSL
     end
 
     should "skip with the msg \"TODO\" when `should` called with no block" do
-      d = @test_desc
+      d = test_desc1
       context, test = build_eval_context { should(d) } # no block passed
       err = capture_err(Assert::Result::TestSkipped) do
         context.instance_eval(&test.code)
@@ -80,7 +79,7 @@ module Assert::Context::TestDSL
     end
 
     should "skip with the msg \"TODO\" when `test_eventually` called with no block" do
-      d = @test_desc
+      d = test_desc1
       context, test = build_eval_context{ test_eventually(d) } # no block given
       err = capture_err(Assert::Result::TestSkipped) do
         context.instance_eval(&test.code)
@@ -92,7 +91,7 @@ module Assert::Context::TestDSL
     end
 
     should "skip with the msg \"TODO\" when `should_eventually` called with no block" do
-      d = @test_desc
+      d = test_desc1
       context, test = build_eval_context{ should_eventually(d) } # no block given
       err = capture_err(Assert::Result::TestSkipped) do
         context.instance_eval(&test.code)
@@ -104,7 +103,7 @@ module Assert::Context::TestDSL
     end
 
     should "build a test from a macro using `test`" do
-      d, b = @test_desc, @test_block
+      d, b = test_desc1, test_block1
       m = Assert::Macro.new{ test(d, &b); test(d, &b) }
       context_class = Factory.modes_off_context_class{ test(m) }
 
@@ -112,7 +111,7 @@ module Assert::Context::TestDSL
     end
 
     should "build a test from a macro using `should`" do
-      d, b = @test_desc, @test_block
+      d, b = test_desc1, test_block1
       m = Assert::Macro.new{ should(d, &b); should(d, &b) }
       context_class = Factory.modes_off_context_class{ should(m) }
 
@@ -120,7 +119,7 @@ module Assert::Context::TestDSL
     end
 
     should "build a test that skips from a macro using `test_eventually`" do
-      d, b = @test_desc, @test_block
+      d, b = test_desc1, test_block1
       m = Assert::Macro.new{ test(d, &b); test(d, &b) }
       context, test = build_eval_context{ test_eventually(m) }
 
@@ -131,7 +130,7 @@ module Assert::Context::TestDSL
     end
 
     should "build a test that skips from a macro using `should_eventually`" do
-      d, b = @test_desc, @test_block
+      d, b = test_desc1, test_block1
       m = Assert::Macro.new{ should(d, &b); should(d, &b) }
       context, test = build_eval_context{ should_eventually(m) }
 
@@ -139,13 +138,12 @@ module Assert::Context::TestDSL
       assert_raises(Assert::Result::TestSkipped) do
         context.instance_eval(&test.code)
       end
-
     end
 
     private
 
     def build_eval_context(&build_block)
-      context_class = Factory.modes_off_context_class &build_block
+      context_class = Factory.modes_off_context_class(&build_block)
       test = context_class.suite.sorted_tests_to_run.to_a.last
       [context_class.new(test, test.config, proc{ |r| }), test]
     end

--- a/test/unit/context_info_tests.rb
+++ b/test/unit/context_info_tests.rb
@@ -8,23 +8,24 @@ class Assert::ContextInfo
     desc "Assert::ContextInfo"
     setup do
       @caller = caller
-      @klass  = Assert::Context
-      @info   = Assert::ContextInfo.new(@klass, nil, @caller.first)
     end
-    subject{ @info }
+    subject { info1 }
+
+    let(:context1) { Assert::Context }
+    let(:info1)    { Assert::ContextInfo.new(context1, nil, @caller.first) }
 
     should have_readers :called_from, :klass, :file
     should have_imeths :test_name
 
     should "set its klass on init" do
-      assert_equal @klass, subject.klass
+      assert_equal context1, subject.klass
     end
 
     should "set its called_from to the called_from or first caller on init" do
-      info = Assert::ContextInfo.new(@klass, @caller.first, nil)
+      info = Assert::ContextInfo.new(context1, @caller.first, nil)
       assert_equal @caller.first, info.called_from
 
-      info = Assert::ContextInfo.new(@klass, nil, @caller.first)
+      info = Assert::ContextInfo.new(context1, nil, @caller.first)
       assert_equal @caller.first, info.called_from
     end
 
@@ -33,7 +34,7 @@ class Assert::ContextInfo
     end
 
     should "not have any file info if no caller is given" do
-      info = Assert::ContextInfo.new(@klass)
+      info = Assert::ContextInfo.new(context1)
       assert_nil info.file
     end
 

--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -8,18 +8,21 @@ require "assert/utils"
 class Assert::Context
   class UnitTests < Assert::Context
     desc "Assert::Context"
+    subject { context1 }
+
     setup do
-      @test = Factory.test
-      @context_class = @test.context_class
       @callback_result = nil
-      @test_results = []
-      @result_callback = proc do |result|
-        @callback_result = result
-        @test_results << result
-      end
-      @context = @context_class.new(@test, @test.config, @result_callback)
     end
-    subject{ @context }
+
+    let(:test1)            { Factory.test }
+    let(:context_class1)   { test1.context_class }
+    let(:test_results1)    { [] }
+    let(:result_callback1) {
+      proc { |result| @callback_result = result; test_results1 << result }
+    }
+    let(:context1) { context_class1.new(test1, test1.config, result_callback1) }
+    let(:halt_config1) { Assert::Config.new(:halt_on_fail => true) }
+    let(:msg1) { Factory.string }
 
     # DSL methods
     should have_cmeths :description, :desc, :describe, :subject, :suite
@@ -66,17 +69,17 @@ class Assert::Context
 
   class SkipTests < UnitTests
     desc "skip method"
+    subject { @result }
+
     setup do
-      @skip_msg = "I need to implement this in the future."
-      begin; @context.skip(@skip_msg); rescue StandardError => @exception; end
+      begin; context1.skip(msg1); rescue StandardError => @exception; end
       @result = Factory.skip_result(@exception)
     end
-    subject{ @result }
 
     should "raise a test skipped exception and set its message" do
       assert_kind_of Assert::Result::TestSkipped, @exception
-      assert_equal @skip_msg, @exception.message
-      assert_equal @skip_msg, subject.message
+      assert_equal msg1, @exception.message
+      assert_equal msg1, subject.message
     end
 
     should "not call the result callback" do
@@ -87,7 +90,7 @@ class Assert::Context
       assert_not_equal 1, @exception.backtrace.size
 
       called_from = Factory.string
-      begin; @context.skip(@skip_msg, called_from); rescue StandardError => exception; end
+      begin; context1.skip(msg1, called_from); rescue StandardError => exception; end
       assert_equal 1,           exception.backtrace.size
       assert_equal called_from, exception.backtrace.first
     end
@@ -95,15 +98,15 @@ class Assert::Context
 
   class IgnoreTests < UnitTests
     desc "ignore method"
+    subject { @result }
+
     setup do
-      @ignore_msg = "Ignore this for now, will do later."
-      @result = @context.ignore(@ignore_msg)
+      @result = context1.ignore(msg1)
     end
-    subject{ @result }
 
     should "create an ignore result and set its message" do
       assert_kind_of Assert::Result::Ignore, subject
-      assert_equal @ignore_msg, subject.message
+      assert_equal msg1, subject.message
     end
 
     should "call the result callback" do
@@ -113,15 +116,15 @@ class Assert::Context
 
   class PassTests < UnitTests
     desc "pass method"
+    subject { @result }
+
     setup do
-      @pass_msg = "That's right, it works."
-      @result = @context.pass(@pass_msg)
+      @result = context1.pass(msg1)
     end
-    subject{ @result }
 
     should "create a pass result and set its message" do
       assert_kind_of Assert::Result::Pass, subject
-      assert_equal @pass_msg, subject.message
+      assert_equal msg1, subject.message
     end
 
     should "call the result callback" do
@@ -131,15 +134,15 @@ class Assert::Context
 
   class FlunkTests < UnitTests
     desc "flunk method"
+    subject { @result }
+
     setup do
-      @flunk_msg = "It flunked."
-      @result = @context.flunk(@flunk_msg)
+      @result = context1.flunk(msg1)
     end
-    subject{ @result }
 
     should "create a fail result and set its message" do
       assert_kind_of Assert::Result::Fail, subject
-      assert_equal @flunk_msg, subject.message
+      assert_equal msg1, subject.message
     end
 
     should "call the result callback" do
@@ -149,10 +152,11 @@ class Assert::Context
 
   class FailTests < UnitTests
     desc "fail method"
+    subject { @result }
+
     setup do
-      @result = @context.fail
+      @result = context1.fail
     end
-    subject{ @result }
 
     should "create a fail result and set its backtrace" do
       assert_kind_of Assert::Result::Fail, subject
@@ -161,9 +165,8 @@ class Assert::Context
     end
 
     should "set any given result message" do
-      fail_msg = "Didn't work"
-      result = @context.fail(fail_msg)
-      assert_equal fail_msg, result.message
+      result = context1.fail(msg1)
+      assert_equal msg1, result.message
     end
 
     should "call the result callback" do
@@ -173,20 +176,17 @@ class Assert::Context
 
   class HaltOnFailTests < UnitTests
     desc "failing when halting on fails"
-    setup do
-      @halt_config = Assert::Config.new(:halt_on_fail => true)
-      @context = @context_class.new(@test, @halt_config, @result_callback)
-      @fail_msg = "something failed"
-    end
-    subject{ @result }
+    subject { @result }
+
+    let(:context1) { context_class1.new(test1, halt_config1, result_callback1) }
 
     should "raise an exception with the failure's message" do
-      begin; @context.fail(@fail_msg); rescue StandardError => err; end
+      begin; context1.fail(msg1); rescue StandardError => err; end
       assert_kind_of Assert::Result::TestFailure, err
-      assert_equal @fail_msg, err.message
+      assert_equal msg1, err.message
 
       result = Assert::Result::Fail.for_test(Factory.test("something"), err)
-      assert_equal @fail_msg, result.message
+      assert_equal msg1, result.message
     end
 
     should "not call the result callback" do
@@ -196,32 +196,30 @@ class Assert::Context
 
   class AssertTests < UnitTests
     desc "assert method"
-    setup do
-      @fail_desc = "my fail desc"
-      @what_failed = "what failed"
-    end
+
+    let(:what_failed) { Factory.string }
 
     should "return a pass result given a `true` assertion" do
-      result = subject.assert(true, @fail_desc){ @what_failed }
+      result = subject.assert(true, msg1){ what_failed }
       assert_kind_of Assert::Result::Pass, result
       assert_equal "", result.message
     end
 
     should "return a fail result given a `false` assertion" do
-      result = subject.assert(false, @fail_desc){ @what_failed }
+      result = subject.assert(false, msg1){ what_failed }
       assert_kind_of Assert::Result::Fail, result
     end
 
     should "pp the assertion value in the fail message by default" do
-      exp_def_what = "Failed assert: assertion was `#{Assert::U.show(false, @test.config)}`."
-      result = subject.assert(false, @fail_desc)
+      exp_def_what = "Failed assert: assertion was `#{Assert::U.show(false, test1.config)}`."
+      result = subject.assert(false, msg1)
 
-      assert_equal [@fail_desc, exp_def_what].join("\n"), result.message
+      assert_equal [msg1, exp_def_what].join("\n"), result.message
     end
 
     should "use a custom fail message if one is given" do
-      result = subject.assert(false, @fail_desc){ @what_failed }
-      assert_equal [@fail_desc, @what_failed].join("\n"), result.message
+      result = subject.assert(false, msg1){ what_failed }
+      assert_equal [msg1, what_failed].join("\n"), result.message
     end
 
     should "return a pass result given a \"truthy\" assertion" do
@@ -235,26 +233,23 @@ class Assert::Context
 
   class AssertNotTests < UnitTests
     desc "assert_not method"
-    setup do
-      @fail_desc = "my fail desc"
-    end
 
     should "return a pass result given a `false` assertion" do
-      result = subject.assert_not(false, @fail_desc)
+      result = subject.assert_not(false, msg1)
       assert_kind_of Assert::Result::Pass, result
       assert_equal "", result.message
     end
 
     should "return a fail result given a `true` assertion" do
-      result = subject.assert_not(true, @fail_desc)
+      result = subject.assert_not(true, msg1)
       assert_kind_of Assert::Result::Fail, result
     end
 
     should "pp the assertion value in the fail message by default" do
-      exp_def_what = "Failed assert_not: assertion was `#{Assert::U.show(true, @test.config)}`."
-      result = subject.assert_not(true, @fail_desc)
+      exp_def_what = "Failed assert_not: assertion was `#{Assert::U.show(true, test1.config)}`."
+      result = subject.assert_not(true, msg1)
 
-      assert_equal [@fail_desc, exp_def_what].join("\n"), result.message
+      assert_equal [msg1, exp_def_what].join("\n"), result.message
     end
 
     should "return a fail result given a \"truthy\" assertion" do
@@ -268,35 +263,36 @@ class Assert::Context
 
   class SubjectTests < UnitTests
     desc "subject method"
+    subject { @subject }
+
     setup do
-      expected = @expected = "amazing"
-      @context_class = Factory.modes_off_context_class do
-        subject{ @something = expected }
-      end
-      @context = @context_class.new(@test, @test.config, proc{ |result| })
-      @subject = @context.subject
+      expected = expected1
+      context_class1.subject { @something = expected }
+      @subject = context1.subject
     end
-    subject{ @subject }
+
+    let(:context_class1) { Factory.modes_off_context_class }
+    let(:context1) { context_class1.new(test1, test1.config, proc{ |result| }) }
+    let(:expected1) { Factory.string }
 
     should "instance evaluate the block set with the class setup method" do
-      assert_equal @expected, subject
+      assert_equal expected1, subject
     end
   end
 
   class PendingTests < UnitTests
     desc "`pending` method"
-    setup do
-      block2  = proc { fail; pass; }
-      @block1 = proc { pending(&block2) } # test nesting
-    end
+
+    let(:block2) { proc { fail; pass; } }
+    let(:block1) { block = block2; proc { pending(&block) } } # test nesting
 
     should "make fails skips and make passes fails" do
-      @context.fail "not affected"
-      @context.pass
-      @context.pending(&@block1)
+      context1.fail "not affected"
+      context1.pass
+      context1.pending(&block1)
 
-      assert_equal 4, @test_results.size
-      norm_fail, norm_pass, pending_fail, pending_pass = @test_results
+      assert_equal 4, test_results1.size
+      norm_fail, norm_pass, pending_fail, pending_pass = test_results1
 
       assert_kind_of Assert::Result::Fail, norm_fail
       assert_kind_of Assert::Result::Pass, norm_pass
@@ -311,42 +307,39 @@ class Assert::Context
 
   class PendingWithHaltOnFailTests < PendingTests
     desc "when halting on fails"
-    setup do
-      @halt_config = Assert::Config.new(:halt_on_fail => true)
-      @context = @context_class.new(@test, @halt_config, @result_callback)
-    end
-    subject{ @result }
+    subject { @result }
+
+    let(:context1) { context_class1.new(test1, halt_config1, result_callback1) }
 
     should "make fails skips and stop the test" do
-      begin; @context.pending(&@block1); rescue StandardError => err; end
+      begin; context1.pending(&block1); rescue StandardError => err; end
       assert_kind_of Assert::Result::TestSkipped, err
       assert_includes "Pending fail", err.message
 
-      assert_equal 0, @test_results.size # it halted before the pending pass
+      assert_equal 0, test_results1.size # it halted before the pending pass
     end
   end
 
   class WithBacktraceTests < UnitTests
     desc "`with_backtrace` method"
-    setup do
-      @from_bt    = ["called_from_here", Factory.string]
-      @from_block = proc { ignore; fail; pass; skip "todo"; }
-    end
+
+    let(:from_bt1)    { ["called_from_here", Factory.string] }
+    let(:from_block1) { proc { ignore; fail; pass; skip "todo"; } }
 
     should "alter non-error block results' bt with given bt's first line" do
-      @context.fail "not affected"
+      context1.fail "not affected"
       begin
-        @context.with_backtrace(@from_bt, &@from_block)
+        context1.with_backtrace(from_bt1, &from_block1)
       rescue Assert::Result::TestSkipped => e
-        @test_results << Assert::Result::Skip.for_test(@test, e)
+        test_results1 << Assert::Result::Skip.for_test(test1, e)
       end
 
-      assert_equal 5, @test_results.size
-      norm_fail, with_ignore, with_fail, with_pass, _with_skip = @test_results
+      assert_equal 5, test_results1.size
+      norm_fail, with_ignore, with_fail, with_pass, _with_skip = test_results1
 
       assert_not_with_bt_set norm_fail
 
-      exp = [@from_bt.first]
+      exp = [from_bt1.first]
       assert_with_bt_set exp, with_ignore
       assert_with_bt_set exp, with_fail
       assert_with_bt_set exp, with_pass
@@ -356,28 +349,30 @@ class Assert::Context
 
   class WithNestedBacktraceTests < UnitTests
     desc "`with_backtrace` method nested"
-    setup do
-      @from_bt1            = ["called_from_here 1", Factory.string]
-      @from_bt2 = from_bt2 = ["called_from_here 2", Factory.string]
 
-      from_block2  = proc { ignore; fail; pass; skip "todo"; }
-      @from_block1 = proc { with_backtrace(from_bt2, &from_block2) }
-    end
+    let(:from_bt1)    { ["called_from_here 1", Factory.string] }
+    let(:from_bt2)    { ["called_from_here 2", Factory.string] }
+    let(:from_block2) { proc { ignore; fail; pass; skip "todo"; } }
+    let(:from_block1) {
+      from_bt    = from_bt2
+      from_block = from_block2
+      proc { with_backtrace(from_bt, &from_block) }
+    }
 
     should "alter non-error block results' bt with nested wbt accrued first lines" do
-      @context.fail "not affected"
+      context1.fail "not affected"
       begin
-        @context.with_backtrace(@from_bt1, &@from_block1)
+        context1.with_backtrace(from_bt1, &from_block1)
       rescue Assert::Result::TestSkipped => e
-        @test_results << Assert::Result::Skip.for_test(@test, e)
+        test_results1 << Assert::Result::Skip.for_test(test1, e)
       end
 
-      assert_equal 5, @test_results.size
-      norm_fail, with_ignore, with_fail, with_pass, with_skip = @test_results
+      assert_equal 5, test_results1.size
+      norm_fail, with_ignore, with_fail, with_pass, _with_skip = test_results1
 
       assert_not_with_bt_set norm_fail
 
-      exp = [@from_bt1.first, @from_bt2.first]
+      exp = [from_bt1.first, from_bt2.first]
       assert_with_bt_set exp, with_ignore
       assert_with_bt_set exp, with_fail
       assert_with_bt_set exp, with_pass
@@ -387,14 +382,13 @@ class Assert::Context
 
   class InspectTests < UnitTests
     desc "inspect method"
-    setup do
-      @expected = "#<#{@context.class}>"
-      @inspect = @context.inspect
-    end
-    subject{ @inspect }
+    subject { inspect1 }
+
+    let(:inspect1)  { context1.inspect }
 
     should "just show the name of the class" do
-      assert_equal @expected, subject
+      exp = "#<#{context1.class}>"
+      assert_equal exp, subject
     end
   end
 end

--- a/test/unit/default_runner_tests.rb
+++ b/test/unit/default_runner_tests.rb
@@ -6,10 +6,7 @@ require "assert/runner"
 class Assert::DefaultRunner
   class UnitTests < Assert::Context
     desc "Assert::DefaultRunner"
-    setup do
-      @config = Factory.modes_off_config
-      @runner = Assert::DefaultRunner.new(@config)
-    end
-    subject{ @runner }
+
+    # This is tested implicitly by running Assert's test suite
   end
 end

--- a/test/unit/default_suite_tests.rb
+++ b/test/unit/default_suite_tests.rb
@@ -6,14 +6,12 @@ require "assert/suite"
 class Assert::DefaultSuite
   class UnitTests < Assert::Context
     desc "Assert::DefaultSuite"
-    setup do
-      ci = Factory.context_info(Factory.modes_off_context_class)
-      @test = Factory.test(Factory.string, ci){ }
+    subject { suite1 }
 
-      @config = Factory.modes_off_config
-      @suite  = Assert::DefaultSuite.new(@config)
-    end
-    subject{ @suite }
+    let(:ci1)     { Factory.context_info(Factory.modes_off_context_class) }
+    let(:test1)   { Factory.test(Factory.string, ci1) { } }
+    let(:config1) { Factory.modes_off_config }
+    let(:suite1)  { Assert::DefaultSuite.new(config1) }
 
     should "be a Suite" do
       assert_kind_of Assert::Suite, subject
@@ -77,7 +75,7 @@ class Assert::DefaultSuite
     end
 
     should "clear the run data on `on_start`" do
-      subject.before_test(@test)
+      subject.before_test(test1)
       subject.on_result(Factory.pass_result)
 
       assert_equal 1, subject.test_count

--- a/test/unit/factory_tests.rb
+++ b/test/unit/factory_tests.rb
@@ -6,7 +6,7 @@ require "much-factory"
 module Assert::Factory
   class UnitTests < Assert::Context
     desc "Assert::Factory"
-    subject{ Assert::Factory }
+    subject { Assert::Factory }
 
     should "include and extend MuchFactory" do
       assert_includes MuchFactory, subject

--- a/test/unit/file_line_tests.rb
+++ b/test/unit/file_line_tests.rb
@@ -4,32 +4,31 @@ require "assert/file_line"
 class Assert::FileLine
   class UnitTests < Assert::Context
     desc "Assert::FileLine"
-    setup do
-      @file = "#{Factory.path}_tests.rb"
-      @line = Factory.integer.to_s
-    end
-    subject{ Assert::FileLine }
+    subject { Assert::FileLine }
+
+    let(:file1) { "#{Factory.path}_tests.rb" }
+    let(:line1) { Factory.integer.to_s }
 
     should have_imeths :parse
 
     should "know how to parse and init from a file line path string" do
       file_line_path = [
-        "#{@file}:#{@line}",
-        "#{@file}:#{@line} #{Factory.string}"
+        "#{file1}:#{line1}",
+        "#{file1}:#{line1} #{Factory.string}"
       ].sample
       file_line = subject.parse(file_line_path)
 
-      assert_equal @file, file_line.file
-      assert_equal @line, file_line.line
+      assert_equal file1, file_line.file
+      assert_equal line1, file_line.line
     end
 
     should "handle parsing bad data gracefully" do
-      file_line = subject.parse(@file)
-      assert_equal @file, file_line.file
+      file_line = subject.parse(file1)
+      assert_equal file1, file_line.file
       assert_equal "",    file_line.line
 
-      file_line = subject.parse(@line)
-      assert_equal @line, file_line.file
+      file_line = subject.parse(line1)
+      assert_equal line1, file_line.file
       assert_equal "",    file_line.line
 
       file_line = subject.parse("")
@@ -44,19 +43,18 @@ class Assert::FileLine
 
   class InitTests < UnitTests
     desc "when init"
-    setup do
-      @file_line = Assert::FileLine.new(@file, @line)
-    end
-    subject{ @file_line }
+    subject { file_line1 }
+
+    let(:file_line1) { Assert::FileLine.new(file1, line1) }
 
     should have_readers :file, :line
 
     should "know its file and line" do
-      assert_equal @file, subject.file
-      assert_equal @line, subject.line
+      assert_equal file1, subject.file
+      assert_equal line1, subject.line
 
-      file_line = Assert::FileLine.new(@file)
-      assert_equal @file, file_line.file
+      file_line = Assert::FileLine.new(file1)
+      assert_equal file1, file_line.file
       assert_equal "",    file_line.line
 
       file_line = Assert::FileLine.new
@@ -69,7 +67,7 @@ class Assert::FileLine
     end
 
     should "know if it is equal to another file line" do
-      yes = Assert::FileLine.new(@file, @line)
+      yes = Assert::FileLine.new(file1, line1)
       no = Assert::FileLine.new("#{Factory.path}_tests.rb", Factory.integer.to_s)
 
       assert_equal     yes, subject

--- a/test/unit/macro_tests.rb
+++ b/test/unit/macro_tests.rb
@@ -4,10 +4,9 @@ require "assert/macro"
 class Assert::Macro
   class UnitTests < Assert::Context
     desc "Assert::Macro"
-    setup do
-      @macro = Assert::Macro.new {}
-    end
-    subject { @macro }
+    subject { macro1 }
+
+    let(:macro1) { Assert::Macro.new {} }
 
     should "have an accessor for its (optional) name" do
       assert_respond_to :name, subject

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -10,7 +10,7 @@ require "assert/view"
 class Assert::Runner
   class UnitTests < Assert::Context
     desc "Assert::Runner"
-    subject{ Assert::Runner }
+    subject { Assert::Runner }
 
     should "include the config helpers" do
       assert_includes Assert::ConfigHelpers, subject
@@ -19,14 +19,15 @@ class Assert::Runner
 
   class InitTests < UnitTests
     desc "when init"
-    setup do
-      @config = Factory.modes_off_config
-      @config.suite Assert::DefaultSuite.new(@config)
-      @config.view  Assert::View.new(@config, StringIO.new("", "w+"))
+    subject { runner1 }
 
-      @runner = Assert::Runner.new(@config)
+    setup do
+      config1.suite Assert::DefaultSuite.new(config1)
+      config1.view  Assert::View.new(config1, StringIO.new("", "w+"))
     end
-    subject{ @runner }
+
+    let(:config1) { Factory.modes_off_config }
+    let(:runner1) { Assert::Runner.new(config1) }
 
     should have_readers :config
     should have_imeths :runner, :run
@@ -35,7 +36,7 @@ class Assert::Runner
     should have_imeths :before_test, :after_test, :on_result
 
     should "know its config" do
-      assert_equal @config, subject.config
+      assert_equal config1, subject.config
     end
 
     should "override the config helper's runner value with itself" do
@@ -45,25 +46,24 @@ class Assert::Runner
 
   class RunTests < InitTests
     desc "and run"
-    setup do
-      @runner_class = Class.new(Assert::Runner) do
-        include CallbackMixin
-      end
-      suite_class  = Class.new(Assert::DefaultSuite){ include CallbackMixin }
-      view_class   = Class.new(Assert::View){ include CallbackMixin }
 
+    setup do
       @view_output = ""
 
-      @config.suite suite_class.new(@config)
-      @config.view  view_class.new(@config, StringIO.new(@view_output, "w+"))
+      suite_class = Class.new(Assert::DefaultSuite){ include CallbackMixin }
+      view_class  = Class.new(Assert::View){ include CallbackMixin }
 
-      @ci = Factory.context_info(Factory.modes_off_context_class)
-      @test = Factory.test("should pass", @ci){ assert(1==1) }
-      @config.suite.on_test(@test)
+      config1.suite suite_class.new(config1)
+      config1.view  view_class.new(config1, StringIO.new(@view_output, "w+"))
+      config1.suite.on_test(test1)
 
-      @runner = @runner_class.new(@config)
-      @result = @runner.run
+      @result = subject.run
     end
+
+    let(:runner_class1) { Class.new(Assert::Runner) { include CallbackMixin } }
+    let(:ci1) { Factory.context_info(Factory.modes_off_context_class) }
+    let(:test1) { Factory.test("should pass", ci1){ assert(1==1) } }
+    let(:runner1) { runner_class1.new(config1) }
 
     should "return the fail+error result count as an integer exit code" do
       assert_equal 0, @result
@@ -72,8 +72,8 @@ class Assert::Runner
       error_count = Factory.integer
       Assert.stub(subject, :fail_result_count){ fail_count }
       Assert.stub(subject, :error_result_count){ error_count }
-      Assert.stub(@test, :run){ } # no-op
-      result = @runner.run
+      Assert.stub(test1, :run){ } # no-op
+      result = runner1.run
 
       exp = fail_count + error_count
       assert_equal exp, result
@@ -82,25 +82,25 @@ class Assert::Runner
     should "run all callbacks on itself, the suite and the view" do
       # itself
       assert_true subject.on_start_called
-      assert_equal [@test], subject.before_test_called
+      assert_equal [test1], subject.before_test_called
       assert_instance_of Assert::Result::Pass, subject.on_result_called.last
-      assert_equal [@test], subject.after_test_called
+      assert_equal [test1], subject.after_test_called
       assert_true subject.on_finish_called
 
       # suite
-      suite = @config.suite
+      suite = config1.suite
       assert_true suite.on_start_called
-      assert_equal [@test], suite.before_test_called
+      assert_equal [test1], suite.before_test_called
       assert_instance_of Assert::Result::Pass, suite.on_result_called.last
-      assert_equal [@test], suite.after_test_called
+      assert_equal [test1], suite.after_test_called
       assert_true suite.on_finish_called
 
       # view
-      view = @config.view
+      view = config1.view
       assert_true view.on_start_called
-      assert_equal [@test], view.before_test_called
+      assert_equal [test1], view.before_test_called
       assert_instance_of Assert::Result::Pass, view.on_result_called.last
-      assert_equal [@test], view.after_test_called
+      assert_equal [test1], view.after_test_called
       assert_true view.on_finish_called
     end
 
@@ -110,35 +110,35 @@ class Assert::Runner
       assert_includes exp, @view_output
 
       @view_output.gsub!(/./, "")
-      @config.suite.clear_tests_to_run
+      config1.suite.clear_tests_to_run
       subject.run
       assert_not_includes exp, @view_output
     end
 
     should "run only a single test if a single test is configured" do
-      test = Factory.test("should pass", @ci){ assert(1==1) }
-      @config.suite.clear_tests_to_run
-      @config.suite.on_test(test)
-      @config.single_test test.file_line.to_s
+      test = Factory.test("should pass", ci1){ assert(1==1) }
+      config1.suite.clear_tests_to_run
+      config1.suite.on_test(test)
+      config1.single_test test.file_line.to_s
 
-      runner = @runner_class.new(@config).tap(&:run)
+      runner = runner_class1.new(config1).tap(&:run)
       assert_equal [test], runner.before_test_called
     end
 
     should "not run any tests if a single test is configured but can't be found" do
-      test = Factory.test("should pass", @ci){ assert(1==1) }
-      @config.suite.clear_tests_to_run
-      @config.suite.on_test(test)
-      @config.single_test Factory.string
+      test = Factory.test("should pass", ci1){ assert(1==1) }
+      config1.suite.clear_tests_to_run
+      config1.suite.on_test(test)
+      config1.single_test Factory.string
 
-      runner = @runner_class.new(@config).tap(&:run)
+      runner = runner_class1.new(config1).tap(&:run)
       assert_nil runner.before_test_called
     end
 
     should "describe running only a single test if a single test is configured" do
-      @config.suite.clear_tests_to_run
-      @config.suite.on_test(@test)
-      @config.single_test @test.file_line.to_s
+      config1.suite.clear_tests_to_run
+      config1.suite.on_test(test1)
+      config1.single_test test1.file_line.to_s
       @view_output.gsub!(/./, "")
       subject.run
 

--- a/test/unit/test_tests.rb
+++ b/test/unit/test_tests.rb
@@ -8,54 +8,53 @@ require "assert/result"
 class Assert::Test
   class UnitTests < Assert::Context
     desc "Assert::Test"
-    setup do
-      @context_class = Factory.modes_off_context_class{ desc "context class" }
-      @context_info  = Factory.context_info(@context_class)
-      @config        = Factory.modes_off_config
-      @test_code     = proc{ assert(true) }
-    end
-    subject{ Assert::Test }
+    subject { Assert::Test }
+
+    let(:context_class1) { Factory.modes_off_context_class { desc "context class" } }
+    let(:context_info1)  { Factory.context_info(context_class1) }
+    let(:config1)        { Factory.modes_off_config }
+    let(:test_code1)     { proc { assert(true) } }
 
     should have_imeths :name_file_line_context_data, :for_block, :for_method
 
     should "know how to build the name and file line given context" do
       test_name = Factory.string
-      data = subject.name_file_line_context_data(@context_info, test_name)
+      data = subject.name_file_line_context_data(context_info1, test_name)
 
-      exp = @context_info.test_name(test_name)
+      exp = context_info1.test_name(test_name)
       assert_equal exp, data[:name]
 
-      exp = @context_info.called_from
+      exp = context_info1.called_from
       assert_equal exp, data[:file_line]
     end
 
     should "build tests for a block" do
       name = Factory.string
-      test = subject.for_block(name, @context_info, @config, &@test_code)
+      test = subject.for_block(name, context_info1, config1, &test_code1)
 
-      exp = Assert::FileLine.parse(@context_info.called_from)
+      exp = Assert::FileLine.parse(context_info1.called_from)
       assert_equal exp, test.file_line
 
-      exp = @context_info.test_name(name)
+      exp = context_info1.test_name(name)
       assert_equal exp, test.name
 
-      assert_equal @context_info, test.context_info
-      assert_equal @config,       test.config
-      assert_equal @test_code,    test.code
+      assert_equal context_info1, test.context_info
+      assert_equal config1,       test.config
+      assert_equal test_code1,    test.code
     end
 
     should "build tests for a method" do
       meth = "a_test_method"
-      test = subject.for_method(meth, @context_info, @config)
+      test = subject.for_method(meth, context_info1, config1)
 
-      exp = Assert::FileLine.parse(@context_info.called_from)
+      exp = Assert::FileLine.parse(context_info1.called_from)
       assert_equal exp, test.file_line
 
-      exp = @context_info.test_name(meth)
+      exp = context_info1.test_name(meth)
       assert_equal exp, test.name
 
-      assert_equal @context_info, test.context_info
-      assert_equal @config,       test.config
+      assert_equal context_info1, test.context_info
+      assert_equal config1,       test.config
 
       assert_kind_of Proc, test.code
       self.instance_eval(&test.code)
@@ -69,38 +68,39 @@ class Assert::Test
 
   class InitWithDataTests < UnitTests
     desc "when init with data"
-    setup do
-      @file_line = Assert::FileLine.new(Factory.string, Factory.integer.to_s)
-      @meta_data = {
-        :file_line => @file_line.to_s,
+    subject { test1 }
+
+    let(:file_line1) { Assert::FileLine.new(Factory.string, Factory.integer.to_s) }
+    let(:meta_data1) {
+      {
+        :file_line => file_line1.to_s,
         :name      => Factory.string,
         :output    => Factory.string,
         :run_time  => Factory.float(1.0),
       }
-
-      @run_data = {
-        :context_info => @context_info,
-        :config       => @config,
-        :code         => @test_code
+    }
+    let(:run_data1) {
+      {
+        :context_info => context_info1,
+        :config       => config1,
+        :code         => test_code1
       }
-
-      @test = Assert::Test.new(@meta_data.merge(@run_data))
-    end
-    subject{ @test }
+    }
+    let(:test1) { Assert::Test.new(meta_data1.merge(run_data1)) }
 
     should have_imeths :file_line, :file_name, :line_num
     should have_imeths :name, :output, :run_time
     should have_imeths :context_info, :context_class, :config, :code, :run
 
     should "use any given attrs" do
-      assert_equal @file_line,             subject.file_line
-      assert_equal @meta_data[:name],      subject.name
-      assert_equal @meta_data[:output],    subject.output
-      assert_equal @meta_data[:run_time],  subject.run_time
+      assert_equal file_line1,             subject.file_line
+      assert_equal meta_data1[:name],      subject.name
+      assert_equal meta_data1[:output],    subject.output
+      assert_equal meta_data1[:run_time],  subject.run_time
 
-      assert_equal @context_info, subject.context_info
-      assert_equal @config,       subject.config
-      assert_equal @test_code,    subject.code
+      assert_equal context_info1, subject.context_info
+      assert_equal config1,       subject.config
+      assert_equal test_code1,    subject.code
     end
 
     should "default its attrs" do
@@ -117,7 +117,7 @@ class Assert::Test
     end
 
     should "know its context class" do
-      assert_equal @context_class, subject.context_class
+      assert_equal context_class1, subject.context_class
     end
 
     should "know its file line attrs" do
@@ -137,25 +137,29 @@ class Assert::Test
   class PassFailIgnoreHandlingTests < UnitTests
     include Assert::Test::TestHelpers
 
+    subject { test1 }
+
     setup do
-      @test = Factory.test("pass fail ignore test", @context_info) do
+      subject.context_class.setup do
         ignore("something")
         assert(true)
         assert(false)
       end
-      @test.context_class.setup do
+      subject.context_class.teardown do
         ignore("something")
         assert(true)
         assert(false)
       end
-      @test.context_class.teardown do
-        ignore("something")
-        assert(true)
-        assert(false)
-      end
-      @test.run(&test_run_callback)
+      subject.run(&test_run_callback)
     end
-    subject{ @test }
+
+    let(:test1) {
+      Factory.test("pass fail ignore test", context_info1) do
+        ignore("something")
+        assert(true)
+        assert(false)
+      end
+    }
 
     should "capture results in the test and any setups/teardowns" do
       assert_equal 9, test_run_results.size
@@ -192,7 +196,7 @@ class Assert::Test
     desc "when in halt-on-fail mode"
 
     should "capture fail results" do
-      test = Factory.test("halt-on-fail test", @context_info) do
+      test = Factory.test("halt-on-fail test", context_info1) do
         raise Assert::Result::TestFailure
       end
       test.run(&test_run_callback)
@@ -201,7 +205,7 @@ class Assert::Test
     end
 
     should "capture fails in the context setup" do
-      test = Factory.test("setup halt-on-fail test", @context_info){ }
+      test = Factory.test("setup halt-on-fail test", context_info1){ }
       test.context_class.setup{ raise Assert::Result::TestFailure }
       test.run(&test_run_callback)
 
@@ -209,7 +213,7 @@ class Assert::Test
     end
 
     should "capture fails in the context teardown" do
-      test = Factory.test("teardown halt-on-fail test", @context_info){ }
+      test = Factory.test("teardown halt-on-fail test", context_info1){ }
       test.context_class.teardown{ raise Assert::Result::TestFailure }
       test.run(&test_run_callback)
 
@@ -232,14 +236,14 @@ class Assert::Test
     include Assert::Test::TestHelpers
 
     should "capture skip results" do
-      test = Factory.test("skip test", @context_info){ skip }
+      test = Factory.test("skip test", context_info1){ skip }
       test.run(&test_run_callback)
 
       assert_skipped(test)
     end
 
     should "capture skips in the context setup" do
-      test = Factory.test("setup skip test", @context_info){ }
+      test = Factory.test("setup skip test", context_info1){ }
       test.context_class.setup{ skip }
       test.run(&test_run_callback)
 
@@ -247,7 +251,7 @@ class Assert::Test
     end
 
     should "capture skips in the context teardown" do
-      test = Factory.test("teardown skip test", @context_info){ }
+      test = Factory.test("teardown skip test", context_info1){ }
       test.context_class.teardown{ skip }
       test.run(&test_run_callback)
 
@@ -270,7 +274,7 @@ class Assert::Test
     include Assert::Test::TestHelpers
 
     should "capture error results" do
-      test = Factory.test("error test", @context_info) do
+      test = Factory.test("error test", context_info1) do
         raise StandardError, "WHAT"
       end
       test.run(&test_run_callback)
@@ -279,7 +283,7 @@ class Assert::Test
     end
 
     should "capture errors in the context setup" do
-      test = Factory.test("setup error test", @context_info){ }
+      test = Factory.test("setup error test", context_info1){ }
       test.context_class.setup{ raise "an error" }
       test.run(&test_run_callback)
 
@@ -287,7 +291,7 @@ class Assert::Test
     end
 
     should "capture errors in the context teardown" do
-      test = Factory.test("teardown error test", @context_info){ }
+      test = Factory.test("teardown error test", context_info1){ }
       test.context_class.teardown{ raise "an error" }
       test.run(&test_run_callback)
 
@@ -307,9 +311,8 @@ class Assert::Test
   end
 
   class SignalExceptionHandlingTests < UnitTests
-
     should "raise any signal exceptions and not capture as an error" do
-      test = Factory.test("signal test", @context_info) do
+      test = Factory.test("signal test", context_info1) do
         raise SignalException, "USR1"
       end
 
@@ -317,14 +320,14 @@ class Assert::Test
     end
 
     should "raises signal exceptions in the context setup" do
-      test = Factory.test("setup signal test", @context_info){ }
+      test = Factory.test("setup signal test", context_info1){ }
       test.context_class.setup{ raise SignalException, "INT" }
 
       assert_raises(SignalException){ test.run }
     end
 
     should "raises signal exceptions in the context teardown" do
-      test = Factory.test("teardown signal test", @context_info){ }
+      test = Factory.test("teardown signal test", context_info1){ }
       test.context_class.teardown{ raise SignalException, "TERM" }
 
       assert_raises(SignalException){ test.run }
@@ -333,65 +336,70 @@ class Assert::Test
 
   class ComparingTests < UnitTests
     desc "<=> another test"
-    setup do
-      @test = Factory.test("mmm")
-    end
-    subject{ @test }
+    subject { test1 }
+
+    let(:test1) { Factory.test("mmm") }
 
     should "return 1 with a test named 'aaa' (greater than it)" do
-      result = @test <=> Factory.test("aaa")
+      result = test1 <=> Factory.test("aaa")
       assert_equal(1, result)
     end
 
     should "return 0 with a test named the same" do
-      result = @test <=> Factory.test(@test.name)
+      result = test1 <=> Factory.test(test1.name)
       assert_equal(0, result)
     end
 
     should "return -1 with a test named 'zzz' (less than it)" do
-      result = @test <=> Factory.test("zzz")
+      result = test1 <=> Factory.test("zzz")
       assert_equal(-1, result)
     end
   end
 
   class CaptureOutTests < UnitTests
     desc "when capturing std out"
-    setup do
-      @capture_config = Assert::Config.new(:capture_output => true)
-      @test = Factory.test("stdout", @capture_config) do
+
+    let(:capture_config1) { Assert::Config.new(:capture_output => true) }
+    let(:test1) {
+      Factory.test("stdout", capture_config1) do
         puts "std out from the test"
         assert true
       end
-    end
+    }
 
     should "capture any io from the test" do
-      @test.run
-      assert_equal "std out from the test\n", @test.output
+      test1.run
+      assert_equal "std out from the test\n", test1.output
     end
   end
 
   class FullCaptureOutTests < CaptureOutTests
     desc "across setup, teardown, and meth calls"
+
     setup do
-      @test = Factory.test("fullstdouttest", @capture_config) do
-        puts "std out from the test"
-        assert a_method_an_assert_calls
-      end
-      @test.context_class.setup{ puts "std out from the setup" }
-      @test.context_class.teardown{ puts "std out from the teardown" }
-      @test.context_class.send(:define_method, "a_method_an_assert_calls") do
+      test1.context_class.setup{ puts "std out from the setup" }
+      test1.context_class.teardown{ puts "std out from the teardown" }
+      test1.context_class.send(:define_method, "a_method_an_assert_calls") do
         puts "std out from a method an assert called"
       end
     end
 
-    should "collect all stdout in the output accessor" do
-      @test.run
+    let(:test1) {
+      Factory.test("fullstdouttest", capture_config1) do
+        puts "std out from the test"
+        assert a_method_an_assert_calls
+      end
+    }
 
-      exp_out = "std out from the setup\n"\
-                "std out from the test\n"\
-                "std out from a method an assert called\n"\
-                "std out from the teardown\n"
-      assert_equal(exp_out, @test.output)
+    should "collect all stdout in the output accessor" do
+      test1.run
+
+      exp_out =
+        "std out from the setup\n"\
+        "std out from the test\n"\
+        "std out from a method an assert called\n"\
+        "std out from the teardown\n"
+      assert_equal(exp_out, test1.output)
     end
   end
 end

--- a/test/unit/utils_tests.rb
+++ b/test/unit/utils_tests.rb
@@ -7,10 +7,9 @@ require "assert/config"
 module Assert::Utils
   class UnitTests < Assert::Context
     desc "Assert::Utils"
-    subject{ Assert::Utils }
-    setup do
-      @objs = [1, "hi there", Hash.new, [:a, :b]]
-    end
+    subject { Assert::Utils }
+
+    let(:objs1) { [1, "hi there", Hash.new, [:a, :b]] }
 
     should have_imeths :show, :show_for_diff
     should have_imeths :tempfile
@@ -20,41 +19,41 @@ module Assert::Utils
 
   class ShowTests < UnitTests
     desc "`show`"
-    setup do
-      @pp_config = Assert::Config.new({
+
+    let(:pp_config1) {
+      Assert::Config.new({
         :pp_objects => true,
         :pp_proc => Proc.new{ |input| "herp derp" }
       })
-    end
+    }
 
     should "use `inspect` to show objs when `pp_objects` setting is false" do
-      @objs.each do |obj|
+      objs1.each do |obj|
         assert_equal obj.inspect, subject.show(obj, Factory.modes_off_config)
       end
     end
 
     should "use `pp_proc` to show objs when `pp_objects` setting is true" do
-      @objs.each do |obj|
-        assert_equal @pp_config.pp_proc.call(obj), subject.show(obj, @pp_config)
+      objs1.each do |obj|
+        assert_equal pp_config1.pp_proc.call(obj), subject.show(obj, pp_config1)
       end
     end
   end
 
   class ShowForDiffTests < ShowTests
     desc "`show_for_diff`"
-    setup do
-      @w_newlines = { :string => "herp derp, derp herp\nherpderpedia" }
-      @w_obj_id = Class.new.new
-    end
+
+    let(:w_newlines1) { { :string => "herp derp, derp herp\nherpderpedia" } }
+    let(:w_obj_id1) { Class.new.new }
 
     should "call show, escaping newlines" do
       exp_out = "{:string=>\"herp derp, derp herp\nherpderpedia\"}"
-      assert_equal exp_out, subject.show_for_diff(@w_newlines, Factory.modes_off_config)
+      assert_equal exp_out, subject.show_for_diff(w_newlines1, Factory.modes_off_config)
     end
 
     should "make any obj ids generic" do
       exp_out = "#<#<Class:0xXXXXXX>:0xXXXXXX>"
-      assert_equal exp_out, subject.show_for_diff(@w_obj_id, Factory.modes_off_config)
+      assert_equal exp_out, subject.show_for_diff(w_obj_id1, Factory.modes_off_config)
     end
   end
 
@@ -77,63 +76,60 @@ module Assert::Utils
     desc "`stdlib_pp_proc`"
 
     should "build a pp proc that uses stdlib `PP.pp` to pretty print objects" do
-      exp_obj_pps = @objs.map{ |o| PP.pp(o, "", 79).strip }
-      act_obj_pps = @objs.map{ |o| subject.stdlib_pp_proc.call(o) }
+      exp_obj_pps = objs1.map{ |o| PP.pp(o, "", 79).strip }
+      act_obj_pps = objs1.map{ |o| subject.stdlib_pp_proc.call(o) }
       assert_equal exp_obj_pps, act_obj_pps
 
       cust_width = 1
-      exp_obj_pps = @objs.map{ |o| PP.pp(o, "", cust_width).strip }
-      act_obj_pps = @objs.map{ |o| subject.stdlib_pp_proc(cust_width).call(o) }
+      exp_obj_pps = objs1.map{ |o| PP.pp(o, "", cust_width).strip }
+      act_obj_pps = objs1.map{ |o| subject.stdlib_pp_proc(cust_width).call(o) }
       assert_equal exp_obj_pps, act_obj_pps
     end
   end
 
   class DefaultUseDiffProcTests < UnitTests
     desc "`default_use_diff_proc`"
-    setup do
-      @longer = "i am a really long string output; use diff when working with me"
-      @newlines = "i have\n newlines"
-    end
+
+    let(:longer1)   { "i am a really long string output; use diff when working with me" }
+    let(:newlines1) { "i have\n newlines" }
 
     should "be true if either output has newlines or is bigger than 29 chars" do
       proc = subject.default_use_diff_proc
 
       assert_not proc.call("", "")
-      assert proc.call(@longer, "")
-      assert proc.call(@newlines, "")
-      assert proc.call("", @longer)
-      assert proc.call("", @newlines)
-      assert proc.call(@longer, @newlines)
+      assert proc.call(longer1, "")
+      assert proc.call(newlines1, "")
+      assert proc.call("", longer1)
+      assert proc.call("", newlines1)
+      assert proc.call(longer1, newlines1)
     end
   end
 
   class SyscmdDiffProc < UnitTests
     desc "`syscmd_diff_proc`"
-    setup do
-      @diff_a_file = File.join(ROOT_PATH, "test/support/diff_a.txt")
-      @diff_b_file = File.join(ROOT_PATH, "test/support/diff_b.txt")
 
-      @diff_a = File.read(@diff_a_file)
-      @diff_b = File.read(@diff_b_file)
-    end
+    let(:diff_a_file1) { File.join(ROOT_PATH, "test/support/diff_a.txt") }
+    let(:diff_b_file1) { File.join(ROOT_PATH, "test/support/diff_b.txt") }
+    let(:diff_a1)      { File.read(diff_a_file1) }
+    let(:diff_b1)      { File.read(diff_b_file1) }
 
     should "use the diff syscmd to output the diff between the exp/act show output" do
-      exp_diff_out = `diff --unified=-1 #{@diff_a_file} #{@diff_b_file}`.strip.tap do |out|
+      exp_diff_out = `diff --unified=-1 #{diff_a_file1} #{diff_b_file1}`.strip.tap do |out|
         out.sub!(/^\-\-\- .+/, "--- expected")
         out.sub!(/^\+\+\+ .+/, "+++ actual")
       end
 
-      assert_equal exp_diff_out, subject.syscmd_diff_proc.call(@diff_a, @diff_b)
+      assert_equal exp_diff_out, subject.syscmd_diff_proc.call(diff_a1, diff_b1)
     end
 
     should "allow you to specify a custom syscmd" do
       cust_syscmd = "diff"
-      exp_diff_out = `#{cust_syscmd} #{@diff_a_file} #{@diff_b_file}`.strip.tap do |out|
+      exp_diff_out = `#{cust_syscmd} #{diff_a_file1} #{diff_b_file1}`.strip.tap do |out|
         out.sub!(/^\-\-\- .+/, "--- expected")
         out.sub!(/^\+\+\+ .+/, "+++ actual")
       end
 
-      assert_equal exp_diff_out, subject.syscmd_diff_proc(cust_syscmd).call(@diff_a, @diff_b)
+      assert_equal exp_diff_out, subject.syscmd_diff_proc(cust_syscmd).call(diff_a1, diff_b1)
     end
   end
 end

--- a/test/unit/view_helpers_tests.rb
+++ b/test/unit/view_helpers_tests.rb
@@ -10,9 +10,12 @@ require "assert/view"
 module Assert::ViewHelpers
   class UnitTests < Assert::Context
     desc "Assert::ViewHelpers"
-    setup do
-      test_opt_val = @test_opt_val = Factory.string
-      @helpers_class = Class.new do
+    subject { helpers_class1 }
+
+    let(:test_opt_val1) { Factory.string }
+    let(:helpers_class1) {
+      test_opt_val = test_opt_val1
+      Class.new do
         include Assert::ViewHelpers
 
         option "test_opt", test_opt_val
@@ -23,8 +26,7 @@ module Assert::ViewHelpers
           @config ||= [Assert.config, Assert::Config.new].sample
         end
       end
-    end
-    subject{ @helpers_class }
+    }
 
     should have_imeths :option
 
@@ -33,8 +35,8 @@ module Assert::ViewHelpers
     end
 
     should "write option values" do
-      helpers = @helpers_class.new
-      assert_equal @test_opt_val, helpers.test_opt
+      helpers = helpers_class1.new
+      assert_equal test_opt_val1, helpers.test_opt
 
       new_val = Factory.integer
       helpers.test_opt new_val
@@ -48,10 +50,9 @@ module Assert::ViewHelpers
 
   class InitTests < UnitTests
     desc "when init"
-    setup do
-      @helpers = @helpers_class.new
-    end
-    subject{ @helpers }
+    subject { helpers1 }
+
+    let(:helpers1) { helpers_class1.new }
 
     should have_imeths :captured_output, :re_run_test_cmd
     should have_imeths :tests_to_run_count_statement, :result_count_statement
@@ -134,7 +135,7 @@ module Assert::ViewHelpers
 
   class AnsiTests < UnitTests
     desc "Ansi"
-    subject{ Ansi }
+    subject { Ansi }
 
     should have_imeths :code_for
 
@@ -157,11 +158,10 @@ module Assert::ViewHelpers
 
   class AnsiInitTests < UnitTests
     desc "when mixed in on a view"
-    setup do
-      view_class = Class.new(Assert::View){ include Ansi }
-      @view = view_class.new(Factory.modes_off_config, StringIO.new("", "w+"))
-    end
-    subject{ @view }
+    subject { view1 }
+
+    let(:view_class1) { Class.new(Assert::View){ include Ansi } }
+    let(:view1) { view_class1.new(Factory.modes_off_config, StringIO.new("", "w+")) }
 
     should have_imeths :ansi_styled_msg
 

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -24,13 +24,11 @@ class Assert::View
 
   class InitTests < UnitTests
     desc "when init"
-    setup do
-      @io     = StringIO.new("", "w+")
-      @config = Factory.modes_off_config
+    subject { view1 }
 
-      @view = Assert::View.new(@config, @io)
-    end
-    subject{ @view }
+    let(:io1)     { StringIO.new("", "w+") }
+    let(:config1) { Factory.modes_off_config }
+    let(:view1)   { Assert::View.new(config1, io1) }
 
     should have_readers :config
     should have_imeths :view, :is_tty?
@@ -57,7 +55,7 @@ class Assert::View
     end
 
     should "know its config" do
-      assert_equal @config, subject.config
+      assert_equal config1, subject.config
     end
 
     should "override the config helper's view value with itself" do
@@ -65,7 +63,7 @@ class Assert::View
     end
 
     should "know if it is a tty" do
-      assert_equal !!@io.isatty, subject.is_tty?
+      assert_equal !!io1.isatty, subject.is_tty?
     end
   end
 end


### PR DESCRIPTION
This adds a `let` DSL method for declaring test input values. These
create local methods to instance_eval the block and memoize its
return value.

The benefit of using lets instead of manually defining methods
for test inputs is that lets auto-memoize for you and put the value
declarations at the beginning of the test context definition.

The benefit of using lets instead of e.g. setting an instance
variable in a `setup` block, is that they are late-bound and the
value is only memoized if the let method is called.

# Other Changes

### rewrite Assert's test suite to use lets

Now that this feature is available, switch to using it in the
test suite. This implicitly tests using lets in a rich varied set
of circumstances. This also slightly improves the performance of
running the test suite due to the late-bound nature of lets.

### add Assert::Context::MethodMissing mix-in

This moves the `method_missing` logic out of Assert::Assertions
and into its own dedicated mix-in as the method missing handling
on a context isn't really specific to assertions.