### PR TITLE
add `assert_that` assertion helper; add `Assert::ActualValue`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ require "assert"
 
 class MyTests < Assert::Context
   test "something" do
-    assert_equal 1, 1
+    assert_that(1).equals(1)
   end
 end
 ```

--- a/lib/assert/actual_value.rb
+++ b/lib/assert/actual_value.rb
@@ -1,0 +1,127 @@
+require "much-stub"
+
+module Assert; end
+class Assert::ActualValue
+  def initialize(value, context:)
+    @value = value
+    @context = context
+  end
+
+  def returns_true(*args)
+    @context.assert_block(*args, &@value)
+  end
+
+  def does_not_return_true(*args)
+    @context.assert_not_block(*args, &@value)
+  end
+
+  def raises(*expected_exceptions)
+    @context.assert_raises(*expected_exceptions, &@value)
+  end
+
+  def does_not_raise(*expected_exceptions)
+    @context.assert_nothing_raised(*expected_exceptions, &@value)
+  end
+
+  def is_a_kind_of(expected_class, *args)
+    @context.assert_kind_of(expected_class, @value, *args)
+  end
+  alias_method :is_kind_of, :is_a_kind_of
+
+  def is_not_a_kind_of(expected_class, *args)
+    @context.assert_not_kind_of(expected_class, @value, *args)
+  end
+  alias_method :is_not_kind_of, :is_not_a_kind_of
+
+  def is_an_instance_of(expected_class, *args)
+    @context.assert_instance_of(expected_class, @value, *args)
+  end
+  alias_method :is_instance_of, :is_an_instance_of
+
+  def is_not_an_instance_of(expected_class, *args)
+    @context.assert_not_instance_of(expected_class, @value, *args)
+  end
+  alias_method :is_not_instance_of, :is_not_an_instance_of
+
+  def responds_to(expected_method_name, *args)
+    @context.assert_responds_to(expected_method_name, @value, *args)
+  end
+
+  def does_not_respond_to(expected_method_name, *args)
+    @context.assert_not_responds_to(expected_method_name, @value, *args)
+  end
+
+  def is_the_same_as(expected_object, *args)
+    @context.assert_same(expected_object, @value, *args)
+  end
+
+  def is_not_the_same_as(expected_object, *args)
+    @context.assert_not_same(expected_object, @value, *args)
+  end
+
+  def equals(expected_value, *args)
+    @context.assert_equal(expected_value, @value, *args)
+  end
+  alias_method :is_equal_to, :equals
+
+  def does_not_equal(expected_value, *args)
+    @context.assert_not_equal(expected_value, @value, *args)
+  end
+  alias_method :is_not_equal_to, :does_not_equal
+
+  def matches(expected_regex, *args)
+    @context.assert_match(expected_regex, @value, *args)
+  end
+
+  def does_not_match(expected_regex, *args)
+    @context.assert_not_match(expected_regex, @value, *args)
+  end
+
+  def is_empty(*args)
+    @context.assert_empty(@value, *args)
+  end
+
+  def is_not_empty(*args)
+    @context.assert_not_empty(@value, *args)
+  end
+
+  def includes(object, *args)
+    @context.assert_includes(object, @value, *args)
+  end
+
+  def does_not_include(object, *args)
+    @context.assert_not_includes(object, @value, *args)
+  end
+
+  def is_nil(*args)
+    @context.assert_nil(@value, *args)
+  end
+
+  def is_not_nil(*args)
+    @context.assert_not_nil(@value, *args)
+  end
+
+  def is_true(*args)
+    @context.assert_true(@value, *args)
+  end
+
+  def is_not_true(*args)
+    @context.assert_not_true(@value, *args)
+  end
+
+  def is_false(*args)
+    @context.assert_false(@value, *args)
+  end
+
+  def is_not_false(*args)
+    @context.assert_not_false(@value, *args)
+  end
+
+  def is_a_file(*args)
+    @context.assert_file_exists(@value, *args)
+  end
+
+  def is_not_a_file(*args)
+    @context.assert_not_file_exists(@value, *args)
+  end
+end

--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -34,7 +34,7 @@ module Assert
     alias_method :refute_empty, :assert_not_empty
 
     def assert_equal(exp, act, desc = nil)
-      assert(exp == act, desc) do
+      assert(act == exp, desc) do
         c = __assert_config__
         exp_show = Assert::U.show_for_diff(exp, c)
         act_show = Assert::U.show_for_diff(act, c)
@@ -49,7 +49,7 @@ module Assert
     end
 
     def assert_not_equal(exp, act, desc = nil)
-      assert(exp != act, desc) do
+      assert(act != exp, desc) do
         c = __assert_config__
         exp_show = Assert::U.show_for_diff(exp, c)
         act_show = Assert::U.show_for_diff(act, c)

--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -1,3 +1,4 @@
+require "assert/actual_value"
 require "assert/assertions"
 require "assert/context/let_dsl"
 require "assert/context/method_missing"
@@ -65,9 +66,8 @@ module Assert
       end
     end
 
-    # check if the assertion is a truthy value, if so create a new pass result,
-    # otherwise create a new fail result with the desc and what failed msg.
-    # all other assertion helpers use this one in the end
+    # Check if the result is true. If so, create a new pass result,  Otherwise
+    # create a new fail result with the desc and fail msg.
     def assert(assertion, desc = nil)
       if assertion
         pass
@@ -82,8 +82,8 @@ module Assert
       end
     end
 
-    # the opposite of assert, check if the assertion is a false value, if so create a new pass
-    # result, otherwise create a new fail result with the desc and fail msg
+    # The opposite of assert. Check if the result is false. If so, create a new
+    # pass result. Otherwise create a new fail result with the desc and fail msg.
     def assert_not(assertion, fail_desc = nil)
       assert(!assertion, fail_desc) do
         "Failed assert_not: assertion was "\
@@ -91,6 +91,10 @@ module Assert
       end
     end
     alias_method :refute, :assert_not
+
+    def assert_that(actual_value)
+      Assert::ActualValue.new(actual_value, context: self)
+    end
 
     # adds a Pass result to the end of the test's results
     # does not break test execution

--- a/lib/assert/macros/methods.rb
+++ b/lib/assert/macros/methods.rb
@@ -102,28 +102,28 @@ module Assert::Macros
           self.class._methods_macro_instance_methods.each do |(method, called_from)|
             msg = "#{subject.class.name} does not have instance method ##{method}"
             with_backtrace([called_from]) do
-              assert_respond_to method, subject, msg
+              assert_that(subject).responds_to(method, msg)
             end
           end
 
           self.class._methods_macro_class_methods.each do |(method, called_from)|
             msg = "#{subject.class.name} does not have class method ##{method}"
             with_backtrace([called_from]) do
-              assert_respond_to method, subject.class, msg
+              assert_that(subject.class).responds_to(method, msg)
             end
           end
 
           self.class._methods_macro_not_instance_methods.each do |(method, called_from)|
             msg = "#{subject.class.name} has instance method ##{method}"
             with_backtrace([called_from]) do
-              assert_not_respond_to method, subject, msg
+              assert_that(subject).does_not_respond_to(method, msg)
             end
           end
 
           self.class._methods_macro_not_class_methods.each do |(method, called_from)|
             msg = "#{subject.class.name} has class method ##{method}"
             with_backtrace([called_from]) do
-              assert_not_respond_to method, subject.class, msg
+              assert_that(subject.class).does_not_respond_to(method, msg)
             end
           end
         end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -86,6 +86,15 @@ module Factory
     end
   end
 
+  def self.modes_off_context(&result_block)
+    test = Factory.test
+    Factory.modes_off_context_class.new(
+      test,
+      test.config,
+      result_block || proc { |r| }
+    )
+  end
+
   def self.backtrace
     assert_lib_path =
       File.join(ROOT_PATH, "lib/#{Factory.string}:#{Factory.integer}")

--- a/test/system/stub_tests.rb
+++ b/test/system/stub_tests.rb
@@ -30,54 +30,53 @@ class Assert::Stub
     let(:instance1) { TestClass.new }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal "none", subject.noargs
+      assert_that(subject.noargs).equals("none")
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal "one",     subject.withargs(1)
-      assert_equal "default", subject.withargs(2)
+      assert_that(subject.withargs(2)).equals("default")
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal "default", subject.anyargs
-      assert_equal "default", subject.anyargs(1)
-      assert_equal "one-two", subject.anyargs(1, 2)
+      assert_that(subject.anyargs).equals("default")
+      assert_that(subject.anyargs(1)).equals("default")
+      assert_that(subject.anyargs(1, 2)).equals("one-two")
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal "one-two",       subject.minargs(1, 2)
-      assert_equal "one-two-three", subject.minargs(1, 2, 3)
-      assert_equal "default",       subject.minargs(1, 2, 4)
-      assert_equal "default",       subject.minargs(1, 2, 3, 4)
+      assert_that(subject.minargs(1, 2)).equals("one-two")
+      assert_that(subject.minargs(1, 2, 3)).equals("one-two-three")
+      assert_that(subject.minargs(1, 2, 4)).equals("default")
+      assert_that(subject.minargs(1, 2, 3, 4)).equals("default")
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal "default", subject.withblock
-      assert_equal "default", subject.withblock{ "my-block" }
+      assert_that(subject.withblock).equals("default")
+      assert_that(subject.withblock{ "my-block" }).equals("default")
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_raises{ Assert.stub(subject, :noargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withargs).with{ } }
-      assert_raises{ Assert.stub(subject, :withargs).with(1, 2){ } }
+      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :minargs).with{ } }
-      assert_raises{ Assert.stub(subject, :minargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withblock).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_raises{ subject.noargs(1) }
+      assert_that(-> { subject.noargs(1) }).raises
 
-      assert_raises{ subject.withargs }
-      assert_raises{ subject.withargs(1, 2) }
+      assert_that(-> { subject.withargs }).raises
+      assert_that(-> { subject.withargs(1, 2) }).raises
 
-      assert_raises{ subject.minargs }
-      assert_raises{ subject.minargs(1) }
+      assert_that(-> { subject.minargs }).raises
+      assert_that(-> { subject.minargs(1) }).raises
 
-      assert_raises{ subject.withblock(1) }
+      assert_that(-> { subject.withblock(1) }).raises
     end
   end
 
@@ -105,54 +104,54 @@ class Assert::Stub
     let(:class1) { TestClass }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal "none", subject.noargs
+      assert_that(subject.noargs).equals("none")
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal "one",     subject.withargs(1)
-      assert_equal "default", subject.withargs(2)
+      assert_that(subject.withargs(1)).equals("one")
+      assert_that(subject.withargs(2)).equals("default")
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal "default", subject.anyargs
-      assert_equal "default", subject.anyargs(1)
-      assert_equal "one-two", subject.anyargs(1, 2)
+      assert_that(subject.anyargs).equals("default")
+      assert_that(subject.anyargs(1)).equals("default")
+      assert_that(subject.anyargs(1, 2)).equals("one-two")
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal "one-two",       subject.minargs(1, 2)
-      assert_equal "one-two-three", subject.minargs(1, 2, 3)
-      assert_equal "default",       subject.minargs(1, 2, 4)
-      assert_equal "default",       subject.minargs(1, 2, 3, 4)
+      assert_that(subject.minargs(1, 2)).equals("one-two")
+      assert_that(subject.minargs(1, 2, 3)).equals("one-two-three")
+      assert_that(subject.minargs(1, 2, 4)).equals("default")
+      assert_that(subject.minargs(1, 2, 3, 4)).equals("default")
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal "default", subject.withblock
-      assert_equal "default", subject.withblock{ "my-block" }
+      assert_that(subject.withblock).equals("default")
+      assert_that(subject.withblock{ "my-block" }).equals("default")
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_raises{ Assert.stub(subject, :noargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withargs).with{ } }
-      assert_raises{ Assert.stub(subject, :withargs).with(1, 2){ } }
+      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :minargs).with{ } }
-      assert_raises{ Assert.stub(subject, :minargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withblock).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_raises{ subject.noargs(1) }
+      assert_that(-> { subject.noargs(1) }).raises
 
-      assert_raises{ subject.withargs }
-      assert_raises{ subject.withargs(1, 2) }
+      assert_that(-> { subject.withargs }).raises
+      assert_that(-> { subject.withargs(1, 2) }).raises
 
-      assert_raises{ subject.minargs }
-      assert_raises{ subject.minargs(1) }
+      assert_that(-> { subject.minargs }).raises
+      assert_that(-> { subject.minargs(1) }).raises
 
-      assert_raises{ subject.withblock(1) }
+      assert_that(-> { subject.withblock(1) }).raises
     end
   end
 
@@ -180,54 +179,54 @@ class Assert::Stub
     let(:module1) { TestModule }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal "none", subject.noargs
+      assert_that(subject.noargs).equals("none")
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal "one",     subject.withargs(1)
-      assert_equal "default", subject.withargs(2)
+      assert_that(subject.withargs(1)).equals("one")
+      assert_that(subject.withargs(2)).equals("default")
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal "default", subject.anyargs
-      assert_equal "default", subject.anyargs(1)
-      assert_equal "one-two", subject.anyargs(1, 2)
+      assert_that(subject.anyargs).equals("default")
+      assert_that(subject.anyargs(1)).equals("default")
+      assert_that(subject.anyargs(1, 2)).equals("one-two")
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal "one-two",       subject.minargs(1, 2)
-      assert_equal "one-two-three", subject.minargs(1, 2, 3)
-      assert_equal "default",       subject.minargs(1, 2, 4)
-      assert_equal "default",       subject.minargs(1, 2, 3, 4)
+      assert_that(subject.minargs(1, 2)).equals("one-two")
+      assert_that(subject.minargs(1, 2, 3)).equals("one-two-three")
+      assert_that(subject.minargs(1, 2, 4)).equals("default")
+      assert_that(subject.minargs(1, 2, 3, 4)).equals("default")
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal "default", subject.withblock
-      assert_equal "default", subject.withblock{ "my-block" }
+      assert_that(subject.withblock).equals("default")
+      assert_that(subject.withblock{ "my-block" }).equals("default")
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_raises{ Assert.stub(subject, :noargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withargs).with{ } }
-      assert_raises{ Assert.stub(subject, :withargs).with(1, 2){ } }
+      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :minargs).with{ } }
-      assert_raises{ Assert.stub(subject, :minargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withblock).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_raises{ subject.noargs(1) }
+      assert_that(-> { subject.noargs(1) }).raises
 
-      assert_raises{ subject.withargs }
-      assert_raises{ subject.withargs(1, 2) }
+      assert_that(-> { subject.withargs }).raises
+      assert_that(-> { subject.withargs(1, 2) }).raises
 
-      assert_raises{ subject.minargs }
-      assert_raises{ subject.minargs(1) }
+      assert_that(-> { subject.minargs }).raises
+      assert_that(-> { subject.minargs(1) }).raises
 
-      assert_raises{ subject.withblock(1) }
+      assert_that(-> { subject.withblock(1) }).raises
     end
   end
 
@@ -255,54 +254,54 @@ class Assert::Stub
     let(:class1) { Class.new{ extend TestMixin } }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal "none", subject.noargs
+      assert_that(subject.noargs).equals("none")
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal "one",     subject.withargs(1)
-      assert_equal "default", subject.withargs(2)
+      assert_that(subject.withargs(1)).equals("one")
+      assert_that(subject.withargs(2)).equals("default")
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal "default", subject.anyargs
-      assert_equal "default", subject.anyargs(1)
-      assert_equal "one-two", subject.anyargs(1, 2)
+      assert_that(subject.anyargs).equals("default")
+      assert_that(subject.anyargs(1)).equals("default")
+      assert_that(subject.anyargs(1, 2)).equals("one-two")
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal "one-two",       subject.minargs(1, 2)
-      assert_equal "one-two-three", subject.minargs(1, 2, 3)
-      assert_equal "default",       subject.minargs(1, 2, 4)
-      assert_equal "default",       subject.minargs(1, 2, 3, 4)
+      assert_that(subject.minargs(1, 2)).equals("one-two")
+      assert_that(subject.minargs(1, 2, 3)).equals("one-two-three")
+      assert_that(subject.minargs(1, 2, 4)).equals("default")
+      assert_that(subject.minargs(1, 2, 3, 4)).equals("default")
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal "default", subject.withblock
-      assert_equal "default", subject.withblock{ "my-block" }
+      assert_that(subject.withblock).equals("default")
+      assert_that(subject.withblock{ "my-block" }).equals("default")
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_raises{ Assert.stub(subject, :noargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withargs).with{ } }
-      assert_raises{ Assert.stub(subject, :withargs).with(1, 2){ } }
+      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :minargs).with{ } }
-      assert_raises{ Assert.stub(subject, :minargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withblock).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_raises{ subject.noargs(1) }
+      assert_that(-> { subject.noargs(1) }).raises
 
-      assert_raises{ subject.withargs }
-      assert_raises{ subject.withargs(1, 2) }
+      assert_that(-> { subject.withargs }).raises
+      assert_that(-> { subject.withargs(1, 2) }).raises
 
-      assert_raises{ subject.minargs }
-      assert_raises{ subject.minargs(1) }
+      assert_that(-> { subject.minargs }).raises
+      assert_that(-> { subject.minargs(1) }).raises
 
-      assert_raises{ subject.withblock(1) }
+      assert_that(-> { subject.withblock(1) }).raises
     end
   end
 
@@ -330,54 +329,54 @@ class Assert::Stub
     let(:instance1) { Class.new { include TestMixin }.new }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal "none", subject.noargs
+      assert_that(subject.noargs).equals("none")
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal "one",     subject.withargs(1)
-      assert_equal "default", subject.withargs(2)
+      assert_that(subject.withargs(1)).equals("one")
+      assert_that(subject.withargs(2)).equals("default")
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal "default", subject.anyargs
-      assert_equal "default", subject.anyargs(1)
-      assert_equal "one-two", subject.anyargs(1, 2)
+      assert_that(subject.anyargs).equals("default")
+      assert_that(subject.anyargs(1)).equals("default")
+      assert_that(subject.anyargs(1, 2)).equals("one-two")
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal "one-two",       subject.minargs(1, 2)
-      assert_equal "one-two-three", subject.minargs(1, 2, 3)
-      assert_equal "default",       subject.minargs(1, 2, 4)
-      assert_equal "default",       subject.minargs(1, 2, 3, 4)
+      assert_that(subject.minargs(1, 2)).equals("one-two")
+      assert_that(subject.minargs(1, 2, 3)).equals("one-two-three")
+      assert_that(subject.minargs(1, 2, 4)).equals("default")
+      assert_that(subject.minargs(1, 2, 3, 4)).equals("default")
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal "default", subject.withblock
-      assert_equal "default", subject.withblock{ "my-block" }
+      assert_that(subject.withblock).equals("default")
+      assert_that(subject.withblock{ "my-block" }).equals("default")
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_raises{ Assert.stub(subject, :noargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withargs).with{ } }
-      assert_raises{ Assert.stub(subject, :withargs).with(1, 2){ } }
+      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :minargs).with{ } }
-      assert_raises{ Assert.stub(subject, :minargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withblock).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_raises{ subject.noargs(1) }
+      assert_that(-> { subject.noargs(1) }).raises
 
-      assert_raises{ subject.withargs }
-      assert_raises{ subject.withargs(1, 2) }
+      assert_that(-> { subject.withargs }).raises
+      assert_that(-> { subject.withargs(1, 2) }).raises
 
-      assert_raises{ subject.minargs }
-      assert_raises{ subject.minargs(1) }
+      assert_that(-> { subject.minargs }).raises
+      assert_that(-> { subject.minargs(1) }).raises
 
-      assert_raises{ subject.withblock(1) }
+      assert_that(-> { subject.withblock(1) }).raises
     end
   end
 
@@ -405,54 +404,54 @@ class Assert::Stub
     let(:class1) { Class.new(TestClass) }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal "none", subject.noargs
+      assert_that(subject.noargs).equals("none")
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal "one",     subject.withargs(1)
-      assert_equal "default", subject.withargs(2)
+      assert_that(subject.withargs(1)).equals("one")
+      assert_that(subject.withargs(2)).equals("default")
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal "default", subject.anyargs
-      assert_equal "default", subject.anyargs(1)
-      assert_equal "one-two", subject.anyargs(1, 2)
+      assert_that(subject.anyargs).equals("default")
+      assert_that(subject.anyargs(1)).equals("default")
+      assert_that(subject.anyargs(1, 2)).equals("one-two")
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal "one-two",       subject.minargs(1, 2)
-      assert_equal "one-two-three", subject.minargs(1, 2, 3)
-      assert_equal "default",       subject.minargs(1, 2, 4)
-      assert_equal "default",       subject.minargs(1, 2, 3, 4)
+      assert_that(subject.minargs(1, 2)).equals("one-two")
+      assert_that(subject.minargs(1, 2, 3)).equals("one-two-three")
+      assert_that(subject.minargs(1, 2, 4)).equals("default")
+      assert_that(subject.minargs(1, 2, 3, 4)).equals("default")
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal "default", subject.withblock
-      assert_equal "default", subject.withblock{ "my-block" }
+      assert_that(subject.withblock).equals("default")
+      assert_that(subject.withblock{ "my-block" }).equals("default")
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_raises{ Assert.stub(subject, :noargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withargs).with{ } }
-      assert_raises{ Assert.stub(subject, :withargs).with(1, 2){ } }
+      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :minargs).with{ } }
-      assert_raises{ Assert.stub(subject, :minargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withblock).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_raises{ subject.noargs(1) }
+      assert_that(-> { subject.noargs(1) }).raises
 
-      assert_raises{ subject.withargs }
-      assert_raises{ subject.withargs(1, 2) }
+      assert_that(-> { subject.withargs }).raises
+      assert_that(-> { subject.withargs(1, 2) }).raises
 
-      assert_raises{ subject.minargs }
-      assert_raises{ subject.minargs(1) }
+      assert_that(-> { subject.minargs }).raises
+      assert_that(-> { subject.minargs(1) }).raises
 
-      assert_raises{ subject.withblock(1) }
+      assert_that(-> { subject.withblock(1) }).raises
     end
   end
 
@@ -480,54 +479,54 @@ class Assert::Stub
     let(:instance1) { Class.new(TestClass).new }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal "none", subject.noargs
+      assert_that(subject.noargs).equals("none")
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal "one",     subject.withargs(1)
-      assert_equal "default", subject.withargs(2)
+      assert_that(subject.withargs(1)).equals("one")
+      assert_that(subject.withargs(2)).equals("default")
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal "default", subject.anyargs
-      assert_equal "default", subject.anyargs(1)
-      assert_equal "one-two", subject.anyargs(1, 2)
+      assert_that(subject.anyargs).equals("default")
+      assert_that(subject.anyargs(1)).equals("default")
+      assert_that(subject.anyargs(1, 2)).equals("one-two")
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal "one-two",       subject.minargs(1, 2)
-      assert_equal "one-two-three", subject.minargs(1, 2, 3)
-      assert_equal "default",       subject.minargs(1, 2, 4)
-      assert_equal "default",       subject.minargs(1, 2, 3, 4)
+      assert_that(subject.minargs(1, 2)).equals("one-two")
+      assert_that(subject.minargs(1, 2, 3)).equals("one-two-three")
+      assert_that(subject.minargs(1, 2, 4)).equals("default")
+      assert_that(subject.minargs(1, 2, 3, 4)).equals("default")
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal "default", subject.withblock
-      assert_equal "default", subject.withblock{ "my-block" }
+      assert_that(subject.withblock).equals("default")
+      assert_that(subject.withblock{ "my-block" }).equals("default")
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_raises{ Assert.stub(subject, :noargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withargs).with{ } }
-      assert_raises{ Assert.stub(subject, :withargs).with(1, 2){ } }
+      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :minargs).with{ } }
-      assert_raises{ Assert.stub(subject, :minargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
+      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
 
-      assert_raises{ Assert.stub(subject, :withblock).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_raises{ subject.noargs(1) }
+      assert_that(-> { subject.noargs(1) }).raises
 
-      assert_raises{ subject.withargs }
-      assert_raises{ subject.withargs(1, 2) }
+      assert_that(-> { subject.withargs }).raises
+      assert_that(-> { subject.withargs(1, 2) }).raises
 
-      assert_raises{ subject.minargs }
-      assert_raises{ subject.minargs(1) }
+      assert_that(-> { subject.minargs }).raises
+      assert_that(-> { subject.minargs(1) }).raises
 
-      assert_raises{ subject.withblock(1) }
+      assert_that(-> { subject.withblock(1) }).raises
     end
   end
 
@@ -555,54 +554,54 @@ class Assert::Stub
     let(:class1) { DelegateClass }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal "none", subject.noargs
+      assert_that(subject.noargs).equals("none")
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal "one",     subject.withargs(1)
-      assert_equal "default", subject.withargs(2)
+      assert_that(subject.withargs(1)).equals("one")
+      assert_that(subject.withargs(2)).equals("default")
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal "default", subject.anyargs
-      assert_equal "default", subject.anyargs(1)
-      assert_equal "one-two", subject.anyargs(1, 2)
+      assert_that(subject.anyargs).equals("default")
+      assert_that(subject.anyargs(1)).equals("default")
+      assert_that(subject.anyargs(1, 2)).equals("one-two")
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal "one-two",       subject.minargs(1, 2)
-      assert_equal "one-two-three", subject.minargs(1, 2, 3)
-      assert_equal "default",       subject.minargs(1, 2, 4)
-      assert_equal "default",       subject.minargs(1, 2, 3, 4)
+      assert_that(subject.minargs(1, 2)).equals("one-two")
+      assert_that(subject.minargs(1, 2, 3)).equals("one-two-three")
+      assert_that(subject.minargs(1, 2, 4)).equals("default")
+      assert_that(subject.minargs(1, 2, 3, 4)).equals("default")
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal "default", subject.withblock
-      assert_equal "default", subject.withblock{ "my-block" }
+      assert_that(subject.withblock).equals("default")
+      assert_that(subject.withblock{ "my-block" }).equals("default")
     end
 
     should "allow stubbing methods with invalid arity" do
-      assert_nothing_raised{ Assert.stub(subject, :noargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).does_not_raise
 
-      assert_nothing_raised{ Assert.stub(subject, :withargs).with{ } }
-      assert_nothing_raised{ Assert.stub(subject, :withargs).with(1, 2){ } }
+      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).does_not_raise
+      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).does_not_raise
 
-      assert_nothing_raised{ Assert.stub(subject, :minargs).with{ } }
-      assert_nothing_raised{ Assert.stub(subject, :minargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).does_not_raise
+      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).does_not_raise
 
-      assert_nothing_raised{ Assert.stub(subject, :withblock).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).does_not_raise
     end
 
     should "allow calling methods with invalid arity" do
-      assert_nothing_raised{ subject.noargs(1) }
+      assert_that(-> { subject.noargs(1) }).does_not_raise
 
-      assert_nothing_raised{ subject.withargs }
-      assert_nothing_raised{ subject.withargs(1, 2) }
+      assert_that(-> { subject.withargs }).does_not_raise
+      assert_that(-> { subject.withargs(1, 2) }).does_not_raise
 
-      assert_nothing_raised{ subject.minargs }
-      assert_nothing_raised{ subject.minargs(1) }
+      assert_that(-> { subject.minargs }).does_not_raise
+      assert_that(-> { subject.minargs(1) }).does_not_raise
 
-      assert_nothing_raised{ subject.withblock(1) }
+      assert_that(-> { subject.withblock(1) }).does_not_raise
     end
   end
 
@@ -630,54 +629,54 @@ class Assert::Stub
     let(:instance1) { DelegateClass.new }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal "none", subject.noargs
+      assert_that(subject.noargs).equals("none")
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal "one",     subject.withargs(1)
-      assert_equal "default", subject.withargs(2)
+      assert_that(subject.withargs(1)).equals("one")
+      assert_that(subject.withargs(2)).equals("default")
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal "default", subject.anyargs
-      assert_equal "default", subject.anyargs(1)
-      assert_equal "one-two", subject.anyargs(1, 2)
+      assert_that(subject.anyargs).equals("default")
+      assert_that(subject.anyargs(1)).equals("default")
+      assert_that(subject.anyargs(1, 2)).equals("one-two")
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal "one-two",       subject.minargs(1, 2)
-      assert_equal "one-two-three", subject.minargs(1, 2, 3)
-      assert_equal "default",       subject.minargs(1, 2, 4)
-      assert_equal "default",       subject.minargs(1, 2, 3, 4)
+      assert_that(subject.minargs(1, 2)).equals("one-two")
+      assert_that(subject.minargs(1, 2, 3)).equals("one-two-three")
+      assert_that(subject.minargs(1, 2, 4)).equals("default")
+      assert_that(subject.minargs(1, 2, 3, 4)).equals("default")
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal "default", subject.withblock
-      assert_equal "default", subject.withblock{ "my-block" }
+      assert_that(subject.withblock).equals("default")
+      assert_that(subject.withblock{ "my-block" }).equals("default")
     end
 
     should "allow stubbing methods with invalid arity" do
-      assert_nothing_raised{ Assert.stub(subject, :noargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).does_not_raise
 
-      assert_nothing_raised{ Assert.stub(subject, :withargs).with{ } }
-      assert_nothing_raised{ Assert.stub(subject, :withargs).with(1, 2){ } }
+      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).does_not_raise
+      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).does_not_raise
 
-      assert_nothing_raised{ Assert.stub(subject, :minargs).with{ } }
-      assert_nothing_raised{ Assert.stub(subject, :minargs).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).does_not_raise
+      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).does_not_raise
 
-      assert_nothing_raised{ Assert.stub(subject, :withblock).with(1){ } }
+      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).does_not_raise
     end
 
     should "allow calling methods with invalid arity" do
-      assert_nothing_raised{ subject.noargs(1) }
+      assert_that(-> { subject.noargs(1) }).does_not_raise
 
-      assert_nothing_raised{ subject.withargs }
-      assert_nothing_raised{ subject.withargs(1, 2) }
+      assert_that(-> { subject.withargs }).does_not_raise
+      assert_that(-> { subject.withargs(1, 2) }).does_not_raise
 
-      assert_nothing_raised{ subject.minargs }
-      assert_nothing_raised{ subject.minargs(1) }
+      assert_that(-> { subject.minargs }).does_not_raise
+      assert_that(-> { subject.minargs(1) }).does_not_raise
 
-      assert_nothing_raised{ subject.withblock(1) }
+      assert_that(-> { subject.withblock(1) }).does_not_raise
     end
   end
 
@@ -692,8 +691,8 @@ class Assert::Stub
     let(:child_class) { Class.new(parent_class) }
 
     should "allow stubbing the methods individually" do
-      assert_equal "parent", parent_class.new
-      assert_equal "child", child_class.new
+      assert_that(parent_class.new).equals("parent")
+      assert_that(child_class.new).equals("child")
     end
   end
 

--- a/test/system/test_tests.rb
+++ b/test/system/test_tests.rb
@@ -19,7 +19,7 @@ class Assert::Test
     let(:test1) { Factory.test }
 
     should "generate 0 results" do
-      assert_equal 0, test_run_result_count
+      assert_that(test_run_result_count).equals(0)
     end
   end
 
@@ -29,11 +29,11 @@ class Assert::Test
     let(:test1) { Factory.test{ assert(1 == 1) } }
 
     should "generate 1 result" do
-      assert_equal 1, test_run_result_count
+      assert_that(test_run_result_count).equals(1)
     end
 
     should "generate 1 pass result" do
-      assert_equal 1, test_run_result_count(:pass)
+      assert_that(test_run_result_count(:pass)).equals(1)
     end
   end
 
@@ -43,11 +43,11 @@ class Assert::Test
     let(:test1) { Factory.test{ assert(1 == 0) } }
 
     should "generate 1 result" do
-      assert_equal 1, test_run_result_count
+      assert_that(test_run_result_count).equals(1)
     end
 
     should "generate 1 fail result" do
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count(:fail)).equals(1)
     end
   end
 
@@ -57,11 +57,11 @@ class Assert::Test
     let(:test1) { Factory.test{ skip } }
 
     should "generate 1 result" do
-      assert_equal 1, test_run_result_count
+      assert_that(test_run_result_count).equals(1)
     end
 
     should "generate 1 skip result" do
-      assert_equal 1, test_run_result_count(:skip)
+      assert_that(test_run_result_count(:skip)).equals(1)
     end
   end
 
@@ -71,11 +71,11 @@ class Assert::Test
     let(:test1) { Factory.test{ raise("WHAT") } }
 
     should "generate 1 result" do
-      assert_equal 1, test_run_result_count
+      assert_that(test_run_result_count).equals(1)
     end
 
     should "generate 1 error result" do
-      assert_equal 1, test_run_result_count(:error)
+      assert_that(test_run_result_count(:error)).equals(1)
     end
   end
 
@@ -90,15 +90,15 @@ class Assert::Test
     }
 
     should "generate 2 total results" do
-      assert_equal 2, test_run_result_count
+      assert_that(test_run_result_count).equals(2)
     end
 
     should "generate 1 pass result" do
-      assert_equal 1, test_run_result_count(:pass)
+      assert_that(test_run_result_count(:pass)).equals(1)
     end
 
     should "generate 1 fail result" do
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count(:fail)).equals(1)
     end
   end
 
@@ -114,23 +114,23 @@ class Assert::Test
     }
 
     should "generate 2 total results" do
-      assert_equal 2, test_run_result_count
+      assert_that(test_run_result_count).equals(2)
     end
 
     should "generate a skip for its last result" do
-      assert_kind_of Assert::Result::Skip, last_test_run_result
+      assert_that(last_test_run_result).is_kind_of(Assert::Result::Skip)
     end
 
     should "generate 1 pass result" do
-      assert_equal 1, test_run_result_count(:pass)
+      assert_that(test_run_result_count(:pass)).equals(1)
     end
 
     should "generate 1 skip result" do
-      assert_equal 1, test_run_result_count(:skip)
+      assert_that(test_run_result_count(:skip)).equals(1)
     end
 
     should "generate 0 fail results" do
-      assert_equal 0, test_run_result_count(:fail)
+      assert_that(test_run_result_count(:fail)).equals(0)
     end
   end
 
@@ -146,23 +146,23 @@ class Assert::Test
     }
 
     should "generate 2 total results" do
-      assert_equal 2, test_run_result_count
+      assert_that(test_run_result_count).equals(2)
     end
 
     should "generate an error for its last result" do
-      assert_kind_of Assert::Result::Error, last_test_run_result
+      assert_that(last_test_run_result).is_kind_of(Assert::Result::Error)
     end
 
     should "generate 1 pass result" do
-      assert_equal 1, test_run_result_count(:pass)
+      assert_that(test_run_result_count(:pass)).equals(1)
     end
 
     should "generate 1 error result" do
-      assert_equal 1, test_run_result_count(:error)
+      assert_that(test_run_result_count(:error)).equals(1)
     end
 
     should "generate 0 fail results" do
-      assert_equal 0, test_run_result_count(:fail)
+      assert_that(test_run_result_count(:fail)).equals(0)
     end
   end
 
@@ -178,19 +178,19 @@ class Assert::Test
     }
 
     should "generate 3 total results" do
-      assert_equal 3, test_run_result_count
+      assert_that(test_run_result_count).equals(3)
     end
 
     should "generate a fail for its last result" do
-      assert_kind_of Assert::Result::Fail, last_test_run_result
+      assert_that(last_test_run_result).is_kind_of(Assert::Result::Fail)
     end
 
     should "generate 2 pass results" do
-      assert_equal 2, test_run_result_count(:pass)
+      assert_that(test_run_result_count(:pass)).equals(2)
     end
 
     should "generate 1 fail result" do
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count(:fail)).equals(1)
     end
   end
 
@@ -206,19 +206,19 @@ class Assert::Test
     }
 
     should "generate 3 total results" do
-      assert_equal 3, test_run_result_count
+      assert_that(test_run_result_count).equals(3)
     end
 
     should "generate a pass for its last result" do
-      assert_kind_of Assert::Result::Pass, last_test_run_result
+      assert_that(last_test_run_result).is_kind_of(Assert::Result::Pass)
     end
 
     should "generate 1 pass result" do
-      assert_equal 1, test_run_result_count(:pass)
+      assert_that(test_run_result_count(:pass)).equals(1)
     end
 
     should "generate 2 fail results" do
-      assert_equal 2, test_run_result_count(:fail)
+      assert_that(test_run_result_count(:fail)).equals(2)
     end
   end
 
@@ -234,19 +234,19 @@ class Assert::Test
     }
 
     should "generate 3 total results" do
-      assert_equal 3, test_run_result_count
+      assert_that(test_run_result_count).equals(3)
     end
 
     should "generate a pass for its last result" do
-      assert_kind_of Assert::Result::Pass, last_test_run_result
+      assert_that(last_test_run_result).is_kind_of(Assert::Result::Pass)
     end
 
     should "generate 1 pass results" do
-      assert_equal 1, test_run_result_count(:pass)
+      assert_that(test_run_result_count(:pass)).equals(1)
     end
 
     should "generate 2 fail results" do
-      assert_equal 2, test_run_result_count(:fail)
+      assert_that(test_run_result_count(:fail)).equals(2)
     end
   end
 
@@ -266,10 +266,10 @@ class Assert::Test
     }
 
     should "execute all setup logic when run" do
-      assert_equal 3, test_run_result_count(:pass)
+      assert_that(test_run_result_count(:pass)).equals(3)
 
       exp = ["assert style setup", "test/unit style setup", "TEST"]
-      assert_equal exp, test_run_result_messages
+      assert_that(test_run_result_messages).equals(exp)
     end
   end
 
@@ -289,10 +289,10 @@ class Assert::Test
     }
 
     should "execute all teardown logic when run" do
-      assert_equal 3, test_run_result_count(:pass)
+      assert_that(test_run_result_count(:pass)).equals(3)
 
       exp = ["TEST", "assert style teardown", "test/unit style teardown"]
-      assert_equal exp, test_run_result_messages
+      assert_that(test_run_result_messages).equals(exp)
     end
   end
 
@@ -333,7 +333,7 @@ class Assert::Test
     }
 
     should "run the arounds outside of the setups/teardowns/test" do
-      assert_equal 13, test_run_result_count(:pass)
+      assert_that(test_run_result_count(:pass)).equals(13)
 
       exp = [
         "parent around start", "child around1 start", "child around2 start",
@@ -341,7 +341,7 @@ class Assert::Test
         "child teardown1", "child teardown2", "parent teardown",
         "child around2 end", "child around1 end", "parent around end"
       ]
-      assert_equal exp, test_run_result_messages
+      assert_that(test_run_result_messages).equals(exp)
     end
   end
 end

--- a/test/unit/actual_value_tests.rb
+++ b/test/unit/actual_value_tests.rb
@@ -1,0 +1,335 @@
+require "assert"
+require "assert/actual_value"
+
+class Assert::ActualValue
+  class UnitTests < Assert::Context
+    desc "Assert::ActualValue"
+    subject { unit_class }
+
+    let(:unit_class) { Assert::ActualValue }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new(actual_value1, context: context1) }
+
+    let(:actual_value1) { Factory.string }
+    let(:context1) { Factory.modes_off_context }
+
+    should have_imeths :returns_true, :does_not_return_true
+    should have_imeths :raises, :does_not_raise
+    should have_imeths :is_a_kind_of, :is_not_a_kind_of
+    should have_imeths :is_kind_of, :is_not_kind_of
+    should have_imeths :is_an_instance_of, :is_not_an_instance_of
+    should have_imeths :is_instance_of, :is_not_instance_of
+    should have_imeths :responds_to, :does_not_respond_to
+    should have_imeths :is_the_same_as, :is_not_the_same_as
+    should have_imeths :equals, :does_not_equal
+    should have_imeths :is_equal_to, :is_not_equal_to
+    should have_imeths :matches, :does_not_match
+    should have_imeths :is_empty, :is_not_empty
+    should have_imeths :includes, :does_not_include
+    should have_imeths :is_nil, :is_not_nil
+    should have_imeths :is_true, :is_not_true
+    should have_imeths :is_false, :is_not_false
+    should have_imeths :is_a_file, :is_not_a_file
+  end
+
+  class MethodsTests < InitTests
+    desc "methods"
+
+    let(:args1) { Factory.integer(3).times.map { Factory.string } }
+    let(:capture_last_call_block) { ->(call) { @last_call = call } }
+
+    should "call to their equivalent context methods" do
+      assert_calls(
+        :assert_block,
+        when_calling: :returns_true,
+        on_value: -> {}
+      ) do |value, call|
+        assert_equal args1, call.args
+        assert_equal value, call.block
+      end
+
+      assert_calls(
+        :assert_not_block,
+        when_calling: :does_not_return_true,
+        on_value: -> {}
+      ) do |value, call|
+        assert_equal args1, call.args
+        assert_equal value, call.block
+      end
+
+      assert_calls(
+        :assert_raises,
+        when_calling: :raises,
+        on_value: -> {}
+      ) do |value, call|
+        assert_equal args1, call.args
+        assert_equal value, call.block
+      end
+
+      assert_calls(
+        :assert_nothing_raised,
+        when_calling: :does_not_raise,
+        on_value: -> {}
+      ) do |value, call|
+        assert_equal args1, call.args
+        assert_equal value, call.block
+      end
+
+      assert_calls(
+        :assert_kind_of,
+        when_calling: [:is_a_kind_of, String],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [String, value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_kind_of,
+        when_calling: [:is_kind_of, String],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [String, value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_kind_of,
+        when_calling: [:is_not_a_kind_of, String],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [String, value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_kind_of,
+        when_calling: [:is_not_kind_of, String],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [String, value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_instance_of,
+        when_calling: [:is_an_instance_of, String],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [String, value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_instance_of,
+        when_calling: [:is_instance_of, String],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [String, value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_instance_of,
+        when_calling: [:is_not_an_instance_of, String],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [String, value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_instance_of,
+        when_calling: [:is_not_instance_of, String],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [String, value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_responds_to,
+        when_calling: [:responds_to, :method],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [:method, value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_responds_to,
+        when_calling: [:does_not_respond_to, :method],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [:method, value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_same,
+        when_calling: [:is_the_same_as, "something"],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal ["something", value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_same,
+        when_calling: [:is_not_the_same_as, "something"],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal ["something", value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_equal,
+        when_calling: [:equals, "something"],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal ["something", value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_equal,
+        when_calling: [:is_equal_to, "something"],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal ["something", value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_equal,
+        when_calling: [:does_not_equal, "something"],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal ["something", value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_equal,
+        when_calling: [:is_not_equal_to, "something"],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal ["something", value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_match,
+        when_calling: [:matches, "something"],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal ["something", value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_match,
+        when_calling: [:does_not_match, "something"],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal ["something", value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_empty,
+        when_calling: :is_empty,
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_empty,
+        when_calling: :is_not_empty,
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_includes,
+        when_calling: [:includes, "something"],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal ["something", value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_includes,
+        when_calling: [:does_not_include, "something"],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal ["something", value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_nil,
+        when_calling: :is_nil,
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_nil,
+        when_calling: :is_not_nil,
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_true,
+        when_calling: :is_true,
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_true,
+        when_calling: :is_not_true,
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_false,
+        when_calling: :is_false,
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_false,
+        when_calling: :is_not_false,
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_file_exists,
+        when_calling: :is_a_file,
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_file_exists,
+        when_calling: :is_not_a_file,
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal [value, *args1], call.args
+      end
+    end
+
+    private
+
+    def assert_calls(context_method, when_calling:, on_value:)
+      @last_call = nil
+      Assert.stub(context1, context_method).on_call(&capture_last_call_block)
+
+      unit_class.new(on_value, context: context1).public_send(*[*when_calling, *args1])
+      yield(on_value, @last_call)
+
+      Assert.unstub(context1, context_method)
+      @last_call = nil
+    end
+  end
+end

--- a/test/unit/assertions/assert_block_tests.rb
+++ b/test/unit/assertions/assert_block_tests.rb
@@ -20,12 +20,12 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp = "#{desc1}\nExpected block to return a true value."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -47,12 +47,12 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp = "#{desc1}\nExpected block to not return a true value."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 end

--- a/test/unit/assertions/assert_empty_tests.rb
+++ b/test/unit/assertions/assert_empty_tests.rb
@@ -24,13 +24,13 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to be empty."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -54,13 +54,13 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to not be empty."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 end

--- a/test/unit/assertions/assert_equal_tests.rb
+++ b/test/unit/assertions/assert_equal_tests.rb
@@ -24,14 +24,14 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)}"\
         " to be equal to #{Assert::U.show(args1[0], config1)}."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -55,14 +55,14 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)}"\
         " to not be equal to #{Assert::U.show(args1[0], config1)}."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -78,8 +78,8 @@ module Assert::Assertions
     let(:is_not1) { is_not_class.new }
 
     should "use the equality operator of the exp value" do
-      assert_equal is1, is_not1
-      assert_not_equal is_not1, is1
+      assert_that(is1).equals(is_not1)
+      assert_that(is_not1).does_not_equal(is1)
     end
   end
 
@@ -118,7 +118,7 @@ module Assert::Assertions
       exp =
         "Expected does not equal actual, diff:\n"\
         "#{Assert::U.syscmd_diff_proc.call(exp_obj_show1, act_obj_show1)}"
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -139,7 +139,7 @@ module Assert::Assertions
       exp =
         "Expected equals actual, diff:\n"\
         "#{Assert::U.syscmd_diff_proc.call(exp_obj_show1, exp_obj_show1)}"
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 end

--- a/test/unit/assertions/assert_file_exists_tests.rb
+++ b/test/unit/assertions/assert_file_exists_tests.rb
@@ -25,12 +25,12 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to exist."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -54,12 +54,12 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to not exist."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 end

--- a/test/unit/assertions/assert_includes_tests.rb
+++ b/test/unit/assertions/assert_includes_tests.rb
@@ -24,15 +24,15 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\n"\
         "Expected #{Assert::U.show(args1[1], config1)}"\
         " to include #{Assert::U.show(args1[0], config1)}."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -56,15 +56,15 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\n"\
         "Expected #{Assert::U.show(args1[1], config1)}"\
         " to not include #{Assert::U.show(args1[0], config1)}."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 end

--- a/test/unit/assertions/assert_instance_of_tests.rb
+++ b/test/unit/assertions/assert_instance_of_tests.rb
@@ -24,14 +24,14 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)} (#{args1[1].class})"\
         " to be an instance of #{args1[0]}."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -55,14 +55,14 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)} (#{args1[1].class})"\
         " to not be an instance of #{args1[0]}."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 end

--- a/test/unit/assertions/assert_kind_of_tests.rb
+++ b/test/unit/assertions/assert_kind_of_tests.rb
@@ -24,14 +24,14 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)} (#{args1[1].class})"\
         " to be a kind of #{args1[0]}."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -55,14 +55,14 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)} (#{args1[1].class})"\
         " to not be a kind of #{args1[0]}."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 end

--- a/test/unit/assertions/assert_match_tests.rb
+++ b/test/unit/assertions/assert_match_tests.rb
@@ -24,14 +24,14 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)}"\
         " to match #{Assert::U.show(args1[0], config1)}."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -55,14 +55,14 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\nExpected #{Assert::U.show(args1[1], config1)}"\
         " to not match #{Assert::U.show(args1[0], config1)}."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 end

--- a/test/unit/assertions/assert_nil_tests.rb
+++ b/test/unit/assertions/assert_nil_tests.rb
@@ -24,12 +24,12 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to be nil."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -53,12 +53,12 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to not be nil."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 end

--- a/test/unit/assertions/assert_raises_tests.rb
+++ b/test/unit/assertions/assert_raises_tests.rb
@@ -23,9 +23,9 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 5, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 4, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(5)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(4)
 
       exp =
         [ "#{desc1}\nStandardError or RuntimeError exception expected, not:",
@@ -34,7 +34,7 @@ module Assert::Assertions
           "#{desc1}\nAn exception expected but nothing raised."
         ]
       messages = test_run_results(:fail).map(&:message)
-      messages.each_with_index{ |msg, n| assert_match(/^#{exp[n]}/, msg) }
+      messages.each_with_index{ |msg, n| assert_that(msg).matches(/^#{exp[n]}/) }
     end
 
     should "return any raised exception instance" do
@@ -47,14 +47,14 @@ module Assert::Assertions
         end
       test.run
 
-      assert_not_nil error
-      assert_kind_of RuntimeError, error
-      assert_equal error_msg, error.message
+      assert_that(error).is_not_nil
+      assert_that(error).is_kind_of(RuntimeError)
+      assert_that(error.message).equals(error_msg)
 
       test = Factory.test { error = assert_raises(RuntimeError) {} }
       test.run
 
-      assert_nil error
+      assert_that(error).is_nil
     end
   end
 
@@ -78,16 +78,16 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 4, test_run_result_count
-      assert_equal 2, test_run_result_count(:pass)
-      assert_equal 2, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(4)
+      assert_that(test_run_result_count(:pass)).equals(2)
+      assert_that(test_run_result_count(:fail)).equals(2)
 
       exp =
         [ "#{desc1}\nStandardError or RuntimeError exception not expected, but raised:",
           "#{desc1}\nAn exception not expected, but raised:"
         ]
       messages = test_run_results(:fail).map(&:message)
-      messages.each_with_index{ |msg, n| assert_match(/^#{exp[n]}/, msg) }
+      messages.each_with_index{ |msg, n| assert_that(msg).matches(/^#{exp[n]}/) }
     end
   end
 end

--- a/test/unit/assertions/assert_respond_to_tests.rb
+++ b/test/unit/assertions/assert_respond_to_tests.rb
@@ -24,15 +24,15 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\n"\
         "Expected #{Assert::U.show(args1[1], config1)} (#{args1[1].class})"\
         " to respond to `#{args1[0]}`."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -56,15 +56,15 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\n"\
         "Expected #{Assert::U.show(args1[1], config1)} (#{args1[1].class})"\
         " to not respond to `#{args1[0]}`."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 end

--- a/test/unit/assertions/assert_same_tests.rb
+++ b/test/unit/assertions/assert_same_tests.rb
@@ -27,9 +27,9 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\n"\
@@ -37,7 +37,7 @@ module Assert::Assertions
         " (#<#{args1[1].class}:#{"0x0%x" % (args1[1].object_id << 1)}>)"\
         " to be the same as #{Assert::U.show(args1[0], config1)}"\
         " (#<#{args1[0].class}:#{"0x0%x" % (args1[0].object_id << 1)}>)."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -65,9 +65,9 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp =
         "#{args1[2]}\n"\
@@ -75,7 +75,7 @@ module Assert::Assertions
         " (#<#{args1[1].class}:#{"0x0%x" % (args1[1].object_id << 1)}>)"\
         " to not be the same as #{Assert::U.show(args1[0], config1)}"\
         " (#<#{args1[0].class}:#{"0x0%x" % (args1[0].object_id << 1)}>)."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -116,7 +116,7 @@ module Assert::Assertions
         " #<#{exp_obj1.class}:#{"0x0%x" % (exp_obj1.object_id << 1)}>"\
         ", diff:\n"\
         "#{Assert::U.syscmd_diff_proc.call(exp_obj_show1, act_obj_show1)}"
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -140,7 +140,7 @@ module Assert::Assertions
         " #<#{act_obj1.class}:#{"0x0%x" % (act_obj1.object_id << 1)}>"\
         ", diff:\n"\
         "#{Assert::U.syscmd_diff_proc.call(act_obj_show1, act_obj_show1)}"
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 end

--- a/test/unit/assertions/assert_true_false_tests.rb
+++ b/test/unit/assertions/assert_true_false_tests.rb
@@ -24,12 +24,12 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to be true."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -53,12 +53,12 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to not be true."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -82,12 +82,12 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to be false."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 
@@ -111,12 +111,12 @@ module Assert::Assertions
     should "produce results as expected" do
       subject.run(&test_run_callback)
 
-      assert_equal 2, test_run_result_count
-      assert_equal 1, test_run_result_count(:pass)
-      assert_equal 1, test_run_result_count(:fail)
+      assert_that(test_run_result_count).equals(2)
+      assert_that(test_run_result_count(:pass)).equals(1)
+      assert_that(test_run_result_count(:fail)).equals(1)
 
       exp = "#{args1[1]}\nExpected #{Assert::U.show(args1[0], config1)} to not be false."
-      assert_equal exp, test_run_results(:fail).first.message
+      assert_that(test_run_results(:fail).first.message).equals(exp)
     end
   end
 end

--- a/test/unit/assertions_tests.rb
+++ b/test/unit/assertions_tests.rb
@@ -50,10 +50,10 @@ module Assert::Assertions
 
     should "have an ignored result for each helper in the constant" do
       exp = Assert::Assertions::IGNORED_ASSERTION_HELPERS.size
-      assert_equal exp, test_run_result_count
+      assert_that(test_run_result_count).equals(exp)
 
       test_run_results.each do |result|
-        assert_kind_of Assert::Result::Ignore, result
+        assert_that(result).is_kind_of(Assert::Result::Ignore)
       end
     end
 
@@ -62,7 +62,7 @@ module Assert::Assertions
         "The assertion `#{helper}` is not supported."\
         " Please use another assertion or the basic `assert`."
       end
-      assert_equal exp, test_run_results.collect(&:message)
+      assert_that(test_run_results.collect(&:message)).equals(exp)
     end
   end
 end

--- a/test/unit/assertions_tests.rb
+++ b/test/unit/assertions_tests.rb
@@ -10,7 +10,7 @@ module Assert::Assertions
 
     let(:context_class1) { Factory.modes_off_context_class }
     let(:test1) { Factory.test }
-    let(:context1) { context_class1.new(test1, test1.config, proc{ |r| }) }
+    let(:context1) { context_class1.new(test1, test1.config, proc { |r| }) }
 
     should have_imeths :assert_block, :assert_not_block, :refute_block
     should have_imeths :assert_raises, :assert_not_raises

--- a/test/unit/config_helpers_tests.rb
+++ b/test/unit/config_helpers_tests.rb
@@ -35,67 +35,67 @@ module Assert::ConfigHelpers
     should have_imeths :ocurring_result_types
 
     should "know the config's runner, suite and view" do
-      assert_equal subject.config.runner, subject.runner
-      assert_equal subject.config.suite,  subject.suite
-      assert_equal subject.config.view,   subject.view
+      assert_that(subject.runner).equals(subject.config.runner)
+      assert_that(subject.suite).equals(subject.config.suite)
+      assert_that(subject.view).equals(subject.config.view)
     end
 
     should "know its runner seed" do
-      assert_equal subject.config.runner_seed, subject.runner_seed
+      assert_that(subject.runner_seed).equals(subject.config.runner_seed)
     end
 
     should "know if it is in single test mode" do
       Assert.stub(subject.config, :single_test?){ true }
-      assert_true subject.single_test?
+      assert_that(subject.single_test?).is_true
 
       Assert.stub(subject.config, :single_test?){ false }
-      assert_false subject.single_test?
+      assert_that(subject.single_test?).is_false
     end
 
     should "know its single test file line" do
       exp = subject.config.single_test_file_line
-      assert_equal exp, subject.single_test_file_line
+      assert_that(subject.single_test_file_line).equals(exp)
     end
 
     should "know its tests-to-run attrs" do
       exp = subject.config.suite.tests_to_run?
-      assert_equal exp, subject.tests_to_run?
+      assert_that(subject.tests_to_run?).equals(exp)
 
       exp = subject.config.suite.tests_to_run_count
-      assert_equal exp, subject.tests_to_run_count
+      assert_that(subject.tests_to_run_count).equals(exp)
     end
 
     should "know its test/result counts" do
       exp = subject.config.suite.test_count
-      assert_equal exp, subject.test_count
+      assert_that(subject.test_count).equals(exp)
 
       exp = subject.config.suite.result_count
-      assert_equal exp, subject.result_count
+      assert_that(subject.result_count).equals(exp)
 
       exp = subject.config.suite.pass_result_count
-      assert_equal exp, subject.pass_result_count
+      assert_that(subject.pass_result_count).equals(exp)
 
       exp = subject.config.suite.fail_result_count
-      assert_equal exp, subject.fail_result_count
+      assert_that(subject.fail_result_count).equals(exp)
 
       exp = subject.config.suite.error_result_count
-      assert_equal exp, subject.error_result_count
+      assert_that(subject.error_result_count).equals(exp)
 
       exp = subject.config.suite.skip_result_count
-      assert_equal exp, subject.skip_result_count
+      assert_that(subject.skip_result_count).equals(exp)
 
       exp = subject.config.suite.ignore_result_count
-      assert_equal exp, subject.ignore_result_count
+      assert_that(subject.ignore_result_count).equals(exp)
     end
 
     should "know if all tests are passing or not" do
       result_count = Factory.integer
       Assert.stub(subject, :result_count){ result_count }
       Assert.stub(subject, :pass_result_count){ result_count }
-      assert_true subject.all_pass?
+      assert_that(subject.all_pass?).is_true
 
       Assert.stub(subject, :pass_result_count){ Factory.integer }
-      assert_false subject.all_pass?
+      assert_that(subject.all_pass?).is_false
     end
 
     should "know its formatted run time, test rate and result rate" do
@@ -103,39 +103,39 @@ module Assert::ConfigHelpers
 
       run_time = Factory.float
       exp = format % run_time
-      assert_equal exp, subject.formatted_run_time(run_time, format)
-      assert_equal exp, subject.formatted_run_time(run_time)
+      assert_that(subject.formatted_run_time(run_time, format)).equals(exp)
+      assert_that(subject.formatted_run_time(run_time)).equals(exp)
 
       test_rate = Factory.float
       exp = format % test_rate
-      assert_equal exp, subject.formatted_result_rate(test_rate, format)
-      assert_equal exp, subject.formatted_result_rate(test_rate)
+      assert_that(subject.formatted_result_rate(test_rate, format)).equals(exp)
+      assert_that(subject.formatted_result_rate(test_rate)).equals(exp)
 
       result_rate = Factory.float
       exp = format % result_rate
-      assert_equal exp, subject.formatted_result_rate(result_rate, format)
-      assert_equal exp, subject.formatted_result_rate(result_rate)
+      assert_that(subject.formatted_result_rate(result_rate, format)).equals(exp)
+      assert_that(subject.formatted_result_rate(result_rate)).equals(exp)
     end
 
     should "know its formatted suite run time, test rate and result rate" do
       format = "%.6f"
 
       exp = format % subject.config.suite.run_time
-      assert_equal exp, subject.formatted_suite_run_time(format)
+      assert_that(subject.formatted_suite_run_time(format)).equals(exp)
 
       exp = format % subject.config.suite.test_rate
-      assert_equal exp, subject.formatted_suite_test_rate(format)
+      assert_that(subject.formatted_suite_test_rate(format)).equals(exp)
 
       exp = format % subject.config.suite.result_rate
-      assert_equal exp, subject.formatted_suite_result_rate(format)
+      assert_that(subject.formatted_suite_result_rate(format)).equals(exp)
     end
 
     should "know whether to show test profile info" do
-      assert_equal !!subject.config.profile, subject.show_test_profile_info?
+      assert_that(subject.show_test_profile_info?).equals(!!subject.config.profile)
     end
 
     should "know whether to show verbose info" do
-      assert_equal !!subject.config.verbose, subject.show_test_verbose_info?
+      assert_that(subject.show_test_verbose_info?).equals(!!subject.config.verbose)
     end
 
     should "know what result types occur in a suite's results" do
@@ -146,7 +146,7 @@ module Assert::ConfigHelpers
       exp = result_types.select do |type_sym|
         subject.send("#{type_sym}_result_count") > 0
       end
-      assert_equal exp, subject.ocurring_result_types
+      assert_that(subject.ocurring_result_types).equals(exp)
     end
   end
 end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -24,73 +24,73 @@ class Assert::Config
     should have_imeths :single_test_file_line, :single_test_file_path
 
     should "default the view, suite, and runner" do
-      assert_kind_of Assert::DefaultView,   subject.view
-      assert_kind_of Assert::DefaultSuite,  subject.suite
-      assert_kind_of Assert::DefaultRunner, subject.runner
+      assert_that(subject.view).is_kind_of(Assert::DefaultView)
+      assert_that(subject.suite).is_kind_of(Assert::DefaultSuite)
+      assert_that(subject.runner).is_kind_of(Assert::DefaultRunner)
     end
 
     should "default the test dir/helper/suffixes" do
-      assert_equal "test",                    subject.test_dir
-      assert_equal "helper.rb",               subject.test_helper
-      assert_equal ["_tests.rb", "_test.rb"], subject.test_file_suffixes
+      assert_that(subject.test_dir).equals("test")
+      assert_that(subject.test_helper).equals("helper.rb")
+      assert_that(subject.test_file_suffixes).equals(["_tests.rb", "_test.rb"])
     end
 
     should "default the procs" do
-      assert_not_nil subject.changed_proc
-      assert_not_nil subject.pp_proc
-      assert_not_nil subject.use_diff_proc
-      assert_not_nil subject.run_diff_proc
+      assert_that(subject.changed_proc).is_not_nil
+      assert_that(subject.pp_proc).is_not_nil
+      assert_that(subject.use_diff_proc).is_not_nil
+      assert_that(subject.run_diff_proc).is_not_nil
     end
 
     should "default the option settings" do
-      assert_not_nil subject.runner_seed
-      assert_not     subject.changed_only
-      assert_empty   subject.changed_ref
-      assert_empty   subject.single_test
-      assert_not     subject.pp_objects
-      assert_not     subject.capture_output
-      assert         subject.halt_on_fail
-      assert_not     subject.profile
-      assert_not     subject.verbose
-      assert_not     subject.list
-      assert_not     subject.debug
+      assert_that(subject.runner_seed).is_not_nil
+      assert_that(subject.changed_only).is_false
+      assert_that(subject.changed_ref).is_empty
+      assert_that(subject.single_test).is_empty
+      assert_that(subject.pp_objects).is_false
+      assert_that(subject.capture_output).is_false
+      assert_that(subject.halt_on_fail).is_true
+      assert_that(subject.profile).is_false
+      assert_that(subject.verbose).is_false
+      assert_that(subject.list).is_false
+      assert_that(subject.debug).is_false
     end
 
     should "apply settings given from a hash" do
       assert subject.halt_on_fail
       subject.apply(:halt_on_fail => false)
-      assert_not subject.halt_on_fail
+      assert_that(subject.halt_on_fail).is_false
 
-      assert Assert::Config.new.halt_on_fail
-      assert_not Assert::Config.new(:halt_on_fail => false).halt_on_fail
+      assert_that(Assert::Config.new.halt_on_fail).is_true
+      assert_that(Assert::Config.new(:halt_on_fail => false).halt_on_fail).is_false
     end
 
     should "know if it is in single test mode" do
-      assert_false subject.single_test?
+      assert_that(subject.single_test?).is_false
 
       subject.apply(:single_test => Factory.string)
-      assert_true subject.single_test?
+      assert_that(subject.single_test?).is_true
     end
 
     should "know its single test file line" do
       exp = Assert::FileLine.parse(File.expand_path("", Dir.pwd))
-      assert_equal exp, subject.single_test_file_line
+      assert_that(subject.single_test_file_line).equals(exp)
 
       file_line_path = "#{Factory.path}_tests.rb:#{Factory.integer}"
       subject.apply(:single_test => file_line_path)
 
       exp = Assert::FileLine.parse(File.expand_path(file_line_path, Dir.pwd))
-      assert_equal exp, subject.single_test_file_line
+      assert_that(subject.single_test_file_line).equals(exp)
     end
 
     should "know its single test file path" do
       exp = Assert::FileLine.parse(File.expand_path("", Dir.pwd)).file
-      assert_equal exp, subject.single_test_file_path
+      assert_that(subject.single_test_file_path).equals(exp)
 
       path = "#{Factory.path}_tests.rb"
       file_line_path = "#{path}:#{Factory.integer}"
       subject.apply(:single_test => file_line_path)
-      assert_equal File.expand_path(path, Dir.pwd), subject.single_test_file_path
+      assert_that(subject.single_test_file_path).equals(File.expand_path(path, Dir.pwd))
     end
   end
 end

--- a/test/unit/context/setup_dsl_tests.rb
+++ b/test/unit/context/setup_dsl_tests.rb
@@ -17,8 +17,8 @@ module Assert::Context::SetupDSL
       subject.setup_once(&block1)
       subject.teardown_once(&block1)
 
-      assert_includes block1, subject.suite.send(:setups)
-      assert_includes block1, subject.suite.send(:teardowns)
+      assert_that(subject.suite.send(:setups)).includes(block1)
+      assert_that(subject.suite.send(:teardowns)).includes(block1)
     end
   end
 
@@ -29,8 +29,8 @@ module Assert::Context::SetupDSL
       subject.setup(&block1)
       subject.teardown(&block1)
 
-      assert_includes block1, subject.send(:setups)
-      assert_includes block1, subject.send(:teardowns)
+      assert_that(subject.send(:setups)).includes(block1)
+      assert_that(subject.send(:teardowns)).includes(block1)
     end
   end
 
@@ -43,8 +43,8 @@ module Assert::Context::SetupDSL
       subject.setup(method_name1)
       subject.teardown(method_name1)
 
-      assert_includes method_name1, subject.send(:setups)
-      assert_includes method_name1, subject.send(:teardowns)
+      assert_that(subject.send(:setups)).includes(method_name1)
+      assert_that(subject.send(:teardowns)).includes(method_name1)
     end
   end
 
@@ -82,10 +82,10 @@ module Assert::Context::SetupDSL
       subject.teardown(&context_teardown_block1)
 
       subject.send("run_setups", obj = test_status_class.new)
-      assert_equal "the setup has been run with something", obj.setup_status
+      assert_that(obj.setup_status).equals("the setup has been run with something")
 
       subject.send("run_teardowns", obj = test_status_class.new)
-      assert_equal "with something has been run the teardown", obj.teardown_status
+      assert_that(obj.teardown_status).equals("with something has been run the teardown")
     end
   end
 
@@ -122,7 +122,7 @@ module Assert::Context::SetupDSL
         "p-around start, c-around1 start, c-around2 start, "\
         "TEST, "\
         "c-around2 end, c-around1 end, p-around end."
-      assert_equal exp, obj.out_status
+      assert_that(obj.out_status).equals(exp)
     end
   end
 end

--- a/test/unit/context/subject_dsl_tests.rb
+++ b/test/unit/context/subject_dsl_tests.rb
@@ -19,7 +19,7 @@ module Assert::Context::SubjectDSL
       subject.desc("and the description for this context")
 
       exp = "parent description and the description for this context"
-      assert_equal exp, subject.description
+      assert_that(subject.description).equals(exp)
     end
   end
 
@@ -29,7 +29,7 @@ module Assert::Context::SubjectDSL
     should "set the subject block on the context class" do
       subject.subject(&subject_block1)
 
-      assert_equal subject_block1, subject.subject
+      assert_that(subject.subject).equals(subject_block1)
     end
   end
 
@@ -39,7 +39,7 @@ module Assert::Context::SubjectDSL
     should "default to its parents subject block" do
       parent_class1.subject(&subject_block1)
 
-      assert_equal subject_block1, subject.subject
+      assert_that(subject.subject).equals(subject_block1)
     end
   end
 end

--- a/test/unit/context/suite_dsl_tests.rb
+++ b/test/unit/context/suite_dsl_tests.rb
@@ -13,12 +13,12 @@ module Assert::Context::SuiteDSL
     let(:custom_suite1)  { Factory.modes_off_suite }
 
     should "use `Assert.suite` by default" do
-      assert_equal Assert.suite, subject.suite
+      assert_that(subject.suite).equals(Assert.suite)
     end
 
     should "use any given custom suite" do
       subject.suite(custom_suite1)
-      assert_equal custom_suite1, subject.suite
+      assert_that(subject.suite).equals(custom_suite1)
     end
   end
 
@@ -32,12 +32,12 @@ module Assert::Context::SuiteDSL
     let(:custom_suite2) { Factory.modes_off_suite }
 
     should "default to its parent's suite" do
-      assert_equal custom_suite1, subject.suite
+      assert_that(subject.suite).equals(custom_suite1)
     end
 
     should "use any given custom suite" do
       subject.suite(custom_suite2)
-      assert_equal custom_suite2, subject.suite
+      assert_that(subject.suite).equals(custom_suite2)
     end
   end
 end

--- a/test/unit/context/test_dsl_tests.rb
+++ b/test/unit/context/test_dsl_tests.rb
@@ -12,22 +12,22 @@ module Assert::Context::TestDSL
       d, b = test_desc1, test_block1
       context, test = build_eval_context{ test(d, &b) }
 
-      assert_equal 1, context.class.suite.tests_to_run_count
+      assert_that(context.class.suite.tests_to_run_count).equals(1)
 
-      assert_kind_of Assert::Test, test
-      assert_equal test_desc1,  test.name
-      assert_equal test_block1, test.code
+      assert_that(test).is_kind_of(Assert::Test)
+      assert_that(test.name).equals(test_desc1)
+      assert_that(test.code).equals(test_block1)
     end
 
     should "build a test using `should` with a desc and code block" do
       d, b = test_desc1, test_block1
       context, test = build_eval_context{ should(d, &b) }
 
-      assert_equal 1, context.class.suite.tests_to_run_count
+      assert_that(context.class.suite.tests_to_run_count).equals(1)
 
-      assert_kind_of Assert::Test, test
-      assert_equal "should #{test_desc1}", test.name
-      assert_equal test_block1, test.code
+      assert_that(test).is_kind_of(Assert::Test)
+      assert_that(test.name).equals("should #{test_desc1}")
+      assert_that(test.code).equals(test_block1)
     end
 
     should "build a test that skips with no msg when `test_eventually` called" do
@@ -37,9 +37,9 @@ module Assert::Context::TestDSL
         context.instance_eval(&test.code)
       end
 
-      assert_equal 1,      context.class.suite.tests_to_run_count
-      assert_equal "TODO", err.message
-      assert_equal 1,      err.backtrace.size
+      assert_that(context.class.suite.tests_to_run_count).equals(1)
+      assert_that(err.message).equals("TODO")
+      assert_that(err.backtrace.size).equals(1)
     end
 
     should "build a test that skips with no msg  when `should_eventually` called" do
@@ -49,9 +49,9 @@ module Assert::Context::TestDSL
         context.instance_eval(&test.code)
       end
 
-      assert_equal 1,      context.class.suite.tests_to_run_count
-      assert_equal "TODO", err.message
-      assert_equal 1,      err.backtrace.size
+      assert_that(context.class.suite.tests_to_run_count).equals(1)
+      assert_that(err.message).equals("TODO")
+      assert_that(err.backtrace.size).equals(1)
     end
 
     should "skip with the msg \"TODO\" when `test` called with no block" do
@@ -61,9 +61,9 @@ module Assert::Context::TestDSL
         context.instance_eval(&test.code)
       end
 
-      assert_equal 1,      context.class.suite.tests_to_run_count
-      assert_equal "TODO", err.message
-      assert_equal 1,      err.backtrace.size
+      assert_that(context.class.suite.tests_to_run_count).equals(1)
+      assert_that(err.message).equals("TODO")
+      assert_that(err.backtrace.size).equals(1)
     end
 
     should "skip with the msg \"TODO\" when `should` called with no block" do
@@ -73,9 +73,9 @@ module Assert::Context::TestDSL
         context.instance_eval(&test.code)
       end
 
-      assert_equal 1,      context.class.suite.tests_to_run_count
-      assert_equal "TODO", err.message
-      assert_equal 1,      err.backtrace.size
+      assert_that(context.class.suite.tests_to_run_count).equals(1)
+      assert_that(err.message).equals("TODO")
+      assert_that(err.backtrace.size).equals(1)
     end
 
     should "skip with the msg \"TODO\" when `test_eventually` called with no block" do
@@ -85,9 +85,9 @@ module Assert::Context::TestDSL
         context.instance_eval(&test.code)
       end
 
-      assert_equal 1,      context.class.suite.tests_to_run_count
-      assert_equal "TODO", err.message
-      assert_equal 1,      err.backtrace.size
+      assert_that(context.class.suite.tests_to_run_count).equals(1)
+      assert_that(err.message).equals("TODO")
+      assert_that(err.backtrace.size).equals(1)
     end
 
     should "skip with the msg \"TODO\" when `should_eventually` called with no block" do
@@ -97,9 +97,9 @@ module Assert::Context::TestDSL
         context.instance_eval(&test.code)
       end
 
-      assert_equal 1,      context.class.suite.tests_to_run_count
-      assert_equal "TODO", err.message
-      assert_equal 1,      err.backtrace.size
+      assert_that(context.class.suite.tests_to_run_count).equals(1)
+      assert_that(err.message).equals("TODO")
+      assert_that(err.backtrace.size).equals(1)
     end
 
     should "build a test from a macro using `test`" do
@@ -107,7 +107,7 @@ module Assert::Context::TestDSL
       m = Assert::Macro.new{ test(d, &b); test(d, &b) }
       context_class = Factory.modes_off_context_class{ test(m) }
 
-      assert_equal 2, context_class.suite.tests_to_run_count
+      assert_that(context_class.suite.tests_to_run_count).equals(2)
     end
 
     should "build a test from a macro using `should`" do
@@ -115,7 +115,7 @@ module Assert::Context::TestDSL
       m = Assert::Macro.new{ should(d, &b); should(d, &b) }
       context_class = Factory.modes_off_context_class{ should(m) }
 
-      assert_equal 2, context_class.suite.tests_to_run_count
+      assert_that(context_class.suite.tests_to_run_count).equals(2)
     end
 
     should "build a test that skips from a macro using `test_eventually`" do
@@ -123,10 +123,9 @@ module Assert::Context::TestDSL
       m = Assert::Macro.new{ test(d, &b); test(d, &b) }
       context, test = build_eval_context{ test_eventually(m) }
 
-      assert_equal 1, context.class.suite.tests_to_run_count
-      assert_raises(Assert::Result::TestSkipped) do
-        context.instance_eval(&test.code)
-      end
+      assert_that(context.class.suite.tests_to_run_count).equals(1)
+      assert_that(-> { context.instance_eval(&test.code) }).
+        raises(Assert::Result::TestSkipped)
     end
 
     should "build a test that skips from a macro using `should_eventually`" do
@@ -134,10 +133,9 @@ module Assert::Context::TestDSL
       m = Assert::Macro.new{ should(d, &b); should(d, &b) }
       context, test = build_eval_context{ should_eventually(m) }
 
-      assert_equal 1, context.class.suite.tests_to_run_count
-      assert_raises(Assert::Result::TestSkipped) do
-        context.instance_eval(&test.code)
-      end
+      assert_that(context.class.suite.tests_to_run_count).equals(1)
+      assert_that(-> { context.instance_eval(&test.code) }).
+        raises(Assert::Result::TestSkipped)
     end
 
     private

--- a/test/unit/context_info_tests.rb
+++ b/test/unit/context_info_tests.rb
@@ -18,36 +18,36 @@ class Assert::ContextInfo
     should have_imeths :test_name
 
     should "set its klass on init" do
-      assert_equal context1, subject.klass
+      assert_that(subject.klass).equals(context1)
     end
 
     should "set its called_from to the called_from or first caller on init" do
       info = Assert::ContextInfo.new(context1, @caller.first, nil)
-      assert_equal @caller.first, info.called_from
+      assert_that(info.called_from).equals(@caller.first)
 
       info = Assert::ContextInfo.new(context1, nil, @caller.first)
-      assert_equal @caller.first, info.called_from
+      assert_that(info.called_from).equals(@caller.first)
     end
 
     should "set its file from caller info on init" do
-      assert_equal @caller.first.gsub(/\:[0-9]+.*$/, ""), subject.file
+      assert_that(subject.file).equals(@caller.first.gsub(/\:[0-9]+.*$/, ""))
     end
 
     should "not have any file info if no caller is given" do
       info = Assert::ContextInfo.new(context1)
-      assert_nil info.file
+      assert_that(info.file).is_nil
     end
 
     should "know how to build the contextual test name for a given name" do
       desc = Factory.string
       name = Factory.string
 
-      assert_equal name, subject.test_name(name)
-      assert_equal "",   subject.test_name("")
-      assert_equal "",   subject.test_name(nil)
+      assert_that(subject.test_name(name)).equals(name)
+      assert_that(subject.test_name("")).equals("")
+      assert_that(subject.test_name(nil)).equals("")
 
       Assert.stub(subject.klass, :description){ desc }
-      assert_equal "#{desc} #{name}", subject.test_name(name)
+      assert_that(subject.test_name(name)).equals("#{desc} #{name}")
     end
   end
 end

--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -25,7 +25,7 @@ class Assert::Context
     let(:msg1) { Factory.string }
 
     # DSL methods
-    should have_cmeths :description, :desc, :describe, :subject, :suite
+    should have_cmeths :description, :desc, :describe, :subject, :suite, :let
     should have_cmeths :setup_once, :before_once, :startup
     should have_cmeths :teardown_once, :after_once, :shutdown
     should have_cmeths :setup, :before, :setups, :run_setups
@@ -34,7 +34,7 @@ class Assert::Context
     should have_cmeths :test, :test_eventually, :test_skip
     should have_cmeths :should, :should_eventually, :should_skip
 
-    should have_imeths :assert, :assert_not, :refute
+    should have_imeths :assert, :assert_not, :refute, :assert_that
     should have_imeths :pass, :ignore, :fail, :flunk, :skip
     should have_imeths :pending, :with_backtrace, :subject
 
@@ -43,6 +43,7 @@ class Assert::Context
       assert_match(/test\/unit\/context_tests.rb$/, test.context_info.file)
       assert_equal self.class, test.context_info.klass
     end
+
     private
 
     ASSERT_TEST_PATH_REGEX = /\A#{File.join(ROOT_PATH, "test", "")}/
@@ -258,6 +259,24 @@ class Assert::Context
 
     should "return a pass result given a `nil` assertion" do
       assert_kind_of Assert::Result::Pass, subject.assert_not(nil)
+    end
+  end
+
+  class AssertThatTests < UnitTests
+    desc "`assert_that` method"
+
+    setup do
+      Assert.stub_tap_on_call(Assert::ActualValue, :new) { |_, call|
+        @actual_value_new_call = call
+      }
+    end
+
+    let(:actual_value) { Factory.string }
+
+    should "build an Assert::ActualValue" do
+      assert_instance_of(Assert::ActualValue, subject.assert_that(actual_value))
+      assert_equal [actual_value], @actual_value_new_call.pargs
+      assert_equal({ context: subject}, @actual_value_new_call.kargs)
     end
   end
 

--- a/test/unit/context_tests.rb
+++ b/test/unit/context_tests.rb
@@ -40,8 +40,8 @@ class Assert::Context
 
     should "collect context info" do
       test = @__assert_running_test__
-      assert_match(/test\/unit\/context_tests.rb$/, test.context_info.file)
-      assert_equal self.class, test.context_info.klass
+      assert_that(test.context_info.file).matches(/test\/unit\/context_tests.rb$/)
+      assert_that(test.context_info.klass).equals(self.class)
     end
 
     private
@@ -50,20 +50,20 @@ class Assert::Context
 
     def assert_with_bt_set(exp_with_bt, result)
       with_backtrace(caller) do
-        assert_true result.with_bt_set?
+        assert_that(result.with_bt_set?).is_true
 
         exp = Assert::Result::Backtrace.to_s(exp_with_bt+[(result.backtrace.filtered.first)])
-        assert_equal exp,               result.trace
-        assert_equal exp_with_bt.first, result.src_line
+        assert_that(result.trace).equals(exp)
+        assert_that(result.src_line).equals(exp_with_bt.first)
       end
     end
 
     def assert_not_with_bt_set(result)
       with_backtrace(caller) do
-        assert_false result.with_bt_set?
+        assert_that(result.with_bt_set?).is_false
 
-        assert_equal result.src_line,                      result.trace
-        assert_equal result.backtrace.filtered.first.to_s, result.src_line
+        assert_that(result.trace).equals(result.src_line)
+        assert_that(result.src_line).equals(result.backtrace.filtered.first.to_s)
       end
     end
   end
@@ -78,22 +78,22 @@ class Assert::Context
     end
 
     should "raise a test skipped exception and set its message" do
-      assert_kind_of Assert::Result::TestSkipped, @exception
-      assert_equal msg1, @exception.message
-      assert_equal msg1, subject.message
+      assert_that(@exception).is_kind_of(Assert::Result::TestSkipped)
+      assert_that(@exception.message).equals(msg1)
+      assert_that(subject.message).equals(msg1)
     end
 
     should "not call the result callback" do
-      assert_nil @callback_result
+      assert_that(@callback_result).is_nil
     end
 
     should "use any given called from arg as the exception backtrace" do
-      assert_not_equal 1, @exception.backtrace.size
+      assert_that(@exception.backtrace.size).does_not_equal(1)
 
       called_from = Factory.string
       begin; context1.skip(msg1, called_from); rescue StandardError => exception; end
-      assert_equal 1,           exception.backtrace.size
-      assert_equal called_from, exception.backtrace.first
+      assert_that(exception.backtrace.size).equals(1)
+      assert_that(exception.backtrace.first).equals(called_from)
     end
   end
 
@@ -106,12 +106,12 @@ class Assert::Context
     end
 
     should "create an ignore result and set its message" do
-      assert_kind_of Assert::Result::Ignore, subject
-      assert_equal msg1, subject.message
+      assert_that(subject).is_kind_of(Assert::Result::Ignore)
+      assert_that(subject.message).equals(msg1)
     end
 
     should "call the result callback" do
-      assert_equal @result, @callback_result
+      assert_that(@callback_result).equals(@result)
     end
   end
 
@@ -124,12 +124,12 @@ class Assert::Context
     end
 
     should "create a pass result and set its message" do
-      assert_kind_of Assert::Result::Pass, subject
-      assert_equal msg1, subject.message
+      assert_that(subject).is_kind_of(Assert::Result::Pass)
+      assert_that(subject.message).equals(msg1)
     end
 
     should "call the result callback" do
-      assert_equal @result, @callback_result
+      assert_that(@callback_result).equals(@result)
     end
   end
 
@@ -142,12 +142,12 @@ class Assert::Context
     end
 
     should "create a fail result and set its message" do
-      assert_kind_of Assert::Result::Fail, subject
-      assert_equal msg1, subject.message
+      assert_that(subject).is_kind_of(Assert::Result::Fail)
+      assert_that(subject.message).equals(msg1)
     end
 
     should "call the result callback" do
-      assert_equal @result, @callback_result
+      assert_that(@callback_result).equals(@result)
     end
   end
 
@@ -160,18 +160,18 @@ class Assert::Context
     end
 
     should "create a fail result and set its backtrace" do
-      assert_kind_of Assert::Result::Fail, subject
-      assert_equal subject.backtrace.filtered.first.to_s, subject.trace
-      assert_kind_of Array, subject.backtrace
+      assert_that(subject).is_kind_of(Assert::Result::Fail)
+      assert_that(subject.trace).equals(subject.backtrace.filtered.first.to_s)
+      assert_that(subject.backtrace).is_kind_of(Array)
     end
 
     should "set any given result message" do
       result = context1.fail(msg1)
-      assert_equal msg1, result.message
+      assert_that(result.message).equals(msg1)
     end
 
     should "call the result callback" do
-      assert_equal @result, @callback_result
+      assert_that(@callback_result).equals(@result)
     end
   end
 
@@ -183,15 +183,15 @@ class Assert::Context
 
     should "raise an exception with the failure's message" do
       begin; context1.fail(msg1); rescue StandardError => err; end
-      assert_kind_of Assert::Result::TestFailure, err
-      assert_equal msg1, err.message
+      assert_that(err).is_kind_of(Assert::Result::TestFailure)
+      assert_that(err.message).equals(msg1)
 
       result = Assert::Result::Fail.for_test(Factory.test("something"), err)
-      assert_equal msg1, result.message
+      assert_that(result.message).equals(msg1)
     end
 
     should "not call the result callback" do
-      assert_nil @callback_result
+      assert_that(@callback_result).is_nil
     end
   end
 
@@ -202,33 +202,33 @@ class Assert::Context
 
     should "return a pass result given a `true` assertion" do
       result = subject.assert(true, msg1){ what_failed }
-      assert_kind_of Assert::Result::Pass, result
-      assert_equal "", result.message
+      assert_that(result).is_kind_of(Assert::Result::Pass)
+      assert_that(result.message).equals("")
     end
 
     should "return a fail result given a `false` assertion" do
       result = subject.assert(false, msg1){ what_failed }
-      assert_kind_of Assert::Result::Fail, result
+      assert_that(result).is_kind_of(Assert::Result::Fail)
     end
 
     should "pp the assertion value in the fail message by default" do
       exp_def_what = "Failed assert: assertion was `#{Assert::U.show(false, test1.config)}`."
       result = subject.assert(false, msg1)
 
-      assert_equal [msg1, exp_def_what].join("\n"), result.message
+      assert_that(result.message).equals([msg1, exp_def_what].join("\n"))
     end
 
     should "use a custom fail message if one is given" do
       result = subject.assert(false, msg1){ what_failed }
-      assert_equal [msg1, what_failed].join("\n"), result.message
+      assert_that(result.message).equals([msg1, what_failed].join("\n"))
     end
 
     should "return a pass result given a \"truthy\" assertion" do
-      assert_kind_of Assert::Result::Pass, subject.assert(34)
+      assert_that(subject.assert(34)).is_kind_of(Assert::Result::Pass)
     end
 
     should "return a fail result gievn a `nil` assertion" do
-      assert_kind_of Assert::Result::Fail, subject.assert(nil)
+      assert_that(subject.assert(nil)).is_kind_of(Assert::Result::Fail)
     end
   end
 
@@ -237,28 +237,28 @@ class Assert::Context
 
     should "return a pass result given a `false` assertion" do
       result = subject.assert_not(false, msg1)
-      assert_kind_of Assert::Result::Pass, result
-      assert_equal "", result.message
+      assert_that(result).is_kind_of(Assert::Result::Pass)
+      assert_that(result.message).equals("")
     end
 
     should "return a fail result given a `true` assertion" do
       result = subject.assert_not(true, msg1)
-      assert_kind_of Assert::Result::Fail, result
+      assert_that(result).is_kind_of(Assert::Result::Fail)
     end
 
     should "pp the assertion value in the fail message by default" do
       exp_def_what = "Failed assert_not: assertion was `#{Assert::U.show(true, test1.config)}`."
       result = subject.assert_not(true, msg1)
 
-      assert_equal [msg1, exp_def_what].join("\n"), result.message
+      assert_that(result.message).equals([msg1, exp_def_what].join("\n"))
     end
 
     should "return a fail result given a \"truthy\" assertion" do
-      assert_kind_of Assert::Result::Fail, subject.assert_not(34)
+      assert_that(subject.assert_not(34)).is_kind_of(Assert::Result::Fail)
     end
 
     should "return a pass result given a `nil` assertion" do
-      assert_kind_of Assert::Result::Pass, subject.assert_not(nil)
+      assert_that(subject.assert_not(nil)).is_kind_of(Assert::Result::Pass)
     end
   end
 
@@ -274,9 +274,9 @@ class Assert::Context
     let(:actual_value) { Factory.string }
 
     should "build an Assert::ActualValue" do
-      assert_instance_of(Assert::ActualValue, subject.assert_that(actual_value))
+      assert_instance_of Assert::ActualValue, subject.assert_that(actual_value)
       assert_equal [actual_value], @actual_value_new_call.pargs
-      assert_equal({ context: subject}, @actual_value_new_call.kargs)
+      assert_equal({ context: context1 },  @actual_value_new_call.kargs)
     end
   end
 
@@ -295,7 +295,7 @@ class Assert::Context
     let(:expected1) { Factory.string }
 
     should "instance evaluate the block set with the class setup method" do
-      assert_equal expected1, subject
+      assert_that(subject).equals(expected1)
     end
   end
 
@@ -310,17 +310,17 @@ class Assert::Context
       context1.pass
       context1.pending(&block1)
 
-      assert_equal 4, test_results1.size
+      assert_that(test_results1.size).equals(4)
       norm_fail, norm_pass, pending_fail, pending_pass = test_results1
 
-      assert_kind_of Assert::Result::Fail, norm_fail
-      assert_kind_of Assert::Result::Pass, norm_pass
+      assert_that(norm_fail).is_kind_of(Assert::Result::Fail)
+      assert_that(norm_pass).is_kind_of(Assert::Result::Pass)
 
-      assert_kind_of Assert::Result::Skip, pending_fail
-      assert_includes "Pending fail", pending_fail.message
+      assert_that(pending_fail).is_kind_of(Assert::Result::Skip)
+      assert_that(pending_fail.message).includes("Pending fail")
 
-      assert_kind_of Assert::Result::Fail, pending_pass
-      assert_includes "Pending pass", pending_pass.message
+      assert_that(pending_pass).is_kind_of(Assert::Result::Fail)
+      assert_that(pending_pass.message).includes("Pending pass")
     end
   end
 
@@ -332,10 +332,10 @@ class Assert::Context
 
     should "make fails skips and stop the test" do
       begin; context1.pending(&block1); rescue StandardError => err; end
-      assert_kind_of Assert::Result::TestSkipped, err
-      assert_includes "Pending fail", err.message
+      assert_that(err).is_kind_of(Assert::Result::TestSkipped)
+      assert_that(err.message).includes("Pending fail")
 
-      assert_equal 0, test_results1.size # it halted before the pending pass
+      assert_that(test_results1.size).equals(0) # it halted before the pending pass
     end
   end
 
@@ -353,7 +353,7 @@ class Assert::Context
         test_results1 << Assert::Result::Skip.for_test(test1, e)
       end
 
-      assert_equal 5, test_results1.size
+      assert_that(test_results1.size).equals(5)
       norm_fail, with_ignore, with_fail, with_pass, _with_skip = test_results1
 
       assert_not_with_bt_set norm_fail
@@ -386,7 +386,7 @@ class Assert::Context
         test_results1 << Assert::Result::Skip.for_test(test1, e)
       end
 
-      assert_equal 5, test_results1.size
+      assert_that(test_results1.size).equals(5)
       norm_fail, with_ignore, with_fail, with_pass, _with_skip = test_results1
 
       assert_not_with_bt_set norm_fail
@@ -407,7 +407,7 @@ class Assert::Context
 
     should "just show the name of the class" do
       exp = "#<#{context1.class}>"
-      assert_equal exp, subject
+      assert_that(subject).equals(exp)
     end
   end
 end

--- a/test/unit/default_suite_tests.rb
+++ b/test/unit/default_suite_tests.rb
@@ -14,79 +14,79 @@ class Assert::DefaultSuite
     let(:suite1)  { Assert::DefaultSuite.new(config1) }
 
     should "be a Suite" do
-      assert_kind_of Assert::Suite, subject
+      assert_that(subject).is_kind_of(Assert::Suite)
     end
 
     should "default its test/result counts" do
-      assert_equal 0, subject.test_count
-      assert_equal 0, subject.result_count
-      assert_equal 0, subject.pass_result_count
-      assert_equal 0, subject.fail_result_count
-      assert_equal 0, subject.error_result_count
-      assert_equal 0, subject.skip_result_count
-      assert_equal 0, subject.ignore_result_count
+      assert_that(subject.test_count).equals(0)
+      assert_that(subject.result_count).equals(0)
+      assert_that(subject.pass_result_count).equals(0)
+      assert_that(subject.fail_result_count).equals(0)
+      assert_that(subject.error_result_count).equals(0)
+      assert_that(subject.skip_result_count).equals(0)
+      assert_that(subject.ignore_result_count).equals(0)
     end
 
     should "increment its test count on `before_test`" do
       subject.before_test(@test)
-      assert_equal 1, subject.test_count
+      assert_that(subject.test_count).equals(1)
     end
 
     should "increment its result counts on `on_result`" do
       subject.on_result(Factory.pass_result)
-      assert_equal 1, subject.result_count
-      assert_equal 1, subject.pass_result_count
-      assert_equal 0, subject.fail_result_count
-      assert_equal 0, subject.error_result_count
-      assert_equal 0, subject.skip_result_count
-      assert_equal 0, subject.ignore_result_count
+      assert_that(subject.result_count).equals(1)
+      assert_that(subject.pass_result_count).equals(1)
+      assert_that(subject.fail_result_count).equals(0)
+      assert_that(subject.error_result_count).equals(0)
+      assert_that(subject.skip_result_count).equals(0)
+      assert_that(subject.ignore_result_count).equals(0)
 
       subject.on_result(Factory.fail_result)
-      assert_equal 2, subject.result_count
-      assert_equal 1, subject.pass_result_count
-      assert_equal 1, subject.fail_result_count
-      assert_equal 0, subject.error_result_count
-      assert_equal 0, subject.skip_result_count
-      assert_equal 0, subject.ignore_result_count
+      assert_that(subject.result_count).equals(2)
+      assert_that(subject.pass_result_count).equals(1)
+      assert_that(subject.fail_result_count).equals(1)
+      assert_that(subject.error_result_count).equals(0)
+      assert_that(subject.skip_result_count).equals(0)
+      assert_that(subject.ignore_result_count).equals(0)
 
       subject.on_result(Factory.error_result)
-      assert_equal 3, subject.result_count
-      assert_equal 1, subject.pass_result_count
-      assert_equal 1, subject.fail_result_count
-      assert_equal 1, subject.error_result_count
-      assert_equal 0, subject.skip_result_count
-      assert_equal 0, subject.ignore_result_count
+      assert_that(subject.result_count).equals(3)
+      assert_that(subject.pass_result_count).equals(1)
+      assert_that(subject.fail_result_count).equals(1)
+      assert_that(subject.error_result_count).equals(1)
+      assert_that(subject.skip_result_count).equals(0)
+      assert_that(subject.ignore_result_count).equals(0)
 
       subject.on_result(Factory.skip_result)
-      assert_equal 4, subject.result_count
-      assert_equal 1, subject.pass_result_count
-      assert_equal 1, subject.fail_result_count
-      assert_equal 1, subject.error_result_count
-      assert_equal 1, subject.skip_result_count
-      assert_equal 0, subject.ignore_result_count
+      assert_that(subject.result_count).equals(4)
+      assert_that(subject.pass_result_count).equals(1)
+      assert_that(subject.fail_result_count).equals(1)
+      assert_that(subject.error_result_count).equals(1)
+      assert_that(subject.skip_result_count).equals(1)
+      assert_that(subject.ignore_result_count).equals(0)
 
       subject.on_result(Factory.ignore_result)
-      assert_equal 5, subject.result_count
-      assert_equal 1, subject.pass_result_count
-      assert_equal 1, subject.fail_result_count
-      assert_equal 1, subject.error_result_count
-      assert_equal 1, subject.skip_result_count
-      assert_equal 1, subject.ignore_result_count
+      assert_that(subject.result_count).equals(5)
+      assert_that(subject.pass_result_count).equals(1)
+      assert_that(subject.fail_result_count).equals(1)
+      assert_that(subject.error_result_count).equals(1)
+      assert_that(subject.skip_result_count).equals(1)
+      assert_that(subject.ignore_result_count).equals(1)
     end
 
     should "clear the run data on `on_start`" do
       subject.before_test(test1)
       subject.on_result(Factory.pass_result)
 
-      assert_equal 1, subject.test_count
-      assert_equal 1, subject.result_count
-      assert_equal 1, subject.pass_result_count
+      assert_that(subject.test_count).equals(1)
+      assert_that(subject.result_count).equals(1)
+      assert_that(subject.pass_result_count).equals(1)
 
       subject.on_start
 
-      assert_equal 0, subject.test_count
-      assert_equal 0, subject.result_count
-      assert_equal 0, subject.pass_result_count
+      assert_that(subject.test_count).equals(0)
+      assert_that(subject.result_count).equals(0)
+      assert_that(subject.pass_result_count).equals(0)
     end
   end
 end

--- a/test/unit/factory_tests.rb
+++ b/test/unit/factory_tests.rb
@@ -9,10 +9,10 @@ module Assert::Factory
     subject { Assert::Factory }
 
     should "include and extend MuchFactory" do
-      assert_includes MuchFactory, subject
+      assert_that(subject).includes(MuchFactory)
 
       # https://stackoverflow.com/questions/5197166/ruby-get-a-list-of-extended-modules
-      assert_includes MuchFactory, subject_metaclass.included_modules
+      assert_that(subject_metaclass.included_modules).includes(MuchFactory)
     end
 
     private

--- a/test/unit/file_line_tests.rb
+++ b/test/unit/file_line_tests.rb
@@ -18,26 +18,26 @@ class Assert::FileLine
       ].sample
       file_line = subject.parse(file_line_path)
 
-      assert_equal file1, file_line.file
-      assert_equal line1, file_line.line
+      assert_that(file_line.file).equals(file1)
+      assert_that(file_line.line).equals(line1)
     end
 
     should "handle parsing bad data gracefully" do
       file_line = subject.parse(file1)
-      assert_equal file1, file_line.file
-      assert_equal "",    file_line.line
+      assert_that(file_line.file).equals(file1)
+      assert_that(file_line.line).equals("")
 
       file_line = subject.parse(line1)
-      assert_equal line1, file_line.file
-      assert_equal "",    file_line.line
+      assert_that(file_line.file).equals(line1)
+      assert_that(file_line.line).equals("")
 
       file_line = subject.parse("")
-      assert_equal "", file_line.file
-      assert_equal "", file_line.line
+      assert_that(file_line.file).equals("")
+      assert_that(file_line.line).equals("")
 
       file_line = subject.parse(nil)
-      assert_equal "", file_line.file
-      assert_equal "", file_line.line
+      assert_that(file_line.file).equals("")
+      assert_that(file_line.line).equals("")
     end
   end
 
@@ -50,27 +50,27 @@ class Assert::FileLine
     should have_readers :file, :line
 
     should "know its file and line" do
-      assert_equal file1, subject.file
-      assert_equal line1, subject.line
+      assert_that(subject.file).equals(file1)
+      assert_that(subject.line).equals(line1)
 
       file_line = Assert::FileLine.new(file1)
-      assert_equal file1, file_line.file
-      assert_equal "",    file_line.line
+      assert_that(file_line.file).equals(file1)
+      assert_that(file_line.line).equals("")
 
       file_line = Assert::FileLine.new
-      assert_equal "", file_line.file
-      assert_equal "", file_line.line
+      assert_that(file_line.file).equals("")
+      assert_that(file_line.line).equals("")
     end
 
     should "know its string representation" do
-      assert_equal "#{subject.file}:#{subject.line}", subject.to_s
+      assert_that(subject.to_s).equals("#{subject.file}:#{subject.line}")
     end
 
     should "know if it is equal to another file line" do
       yes = Assert::FileLine.new(file1, line1)
       no = Assert::FileLine.new("#{Factory.path}_tests.rb", Factory.integer.to_s)
 
-      assert_equal     yes, subject
+      assert_that(subject).equals(yes)
       assert_not_equal no,  subject
     end
   end

--- a/test/unit/macro_tests.rb
+++ b/test/unit/macro_tests.rb
@@ -9,24 +9,24 @@ class Assert::Macro
     let(:macro1) { Assert::Macro.new {} }
 
     should "have an accessor for its (optional) name" do
-      assert_respond_to :name, subject
-      assert_respond_to :name=, subject
+      assert_that(subject).responds_to(:name)
+      assert_that(subject).responds_to(:name=)
     end
 
     should "default its name if no given" do
-      assert_equal "run this macro", (Assert::Macro.new {}).name
+      assert_that((Assert::Macro.new {}).name).equals("run this macro")
     end
 
     should "initialize with a given name" do
-      assert_equal "test", (Assert::Macro.new("test") {}).name
+      assert_that((Assert::Macro.new("test") {}).name).equals("test")
     end
 
     should "be a Proc" do
-      assert_kind_of ::Proc, subject
+      assert_that(subject).is_kind_of(::Proc)
     end
 
     should "complain if you create a macro without a block" do
-      assert_raises(ArgumentError) { Assert::Macro.new }
+      assert_that(-> { Assert::Macro.new }).raises(ArgumentError)
     end
   end
 

--- a/test/unit/result_tests.rb
+++ b/test/unit/result_tests.rb
@@ -20,15 +20,15 @@ module Assert::Result
         :skip   => Skip,
         :error  => Error
       }
-      assert_equal exp, subject.types
+      assert_that(subject.types).equals(exp)
 
-      assert_equal Base, subject.types[Factory.string]
+      assert_that(subject.types[Factory.string]).equals(Base)
     end
 
     should "create results from data hashes" do
       type = Assert::Result.types.keys.sample
       exp  = Assert::Result.types[type].new(:type => type)
-      assert_equal exp, Assert::Result.new(:type => type)
+      assert_that(Assert::Result.new(:type => type)).equals(exp)
     end
   end
 
@@ -60,8 +60,8 @@ module Assert::Result
     should have_imeths :to_sym, :to_s
 
     should "know its class-level type/name" do
-      assert_equal :unknown, subject.class.type
-      assert_equal "",       subject.class.name
+      assert_that(subject.class.type).equals(:unknown)
+      assert_that(subject.class.name).equals("")
     end
 
     should "know how to build a result for a given test" do
@@ -72,44 +72,44 @@ module Assert::Result
       exp_backtrace = Backtrace.new(bt)
       exp_trace     = exp_backtrace.filtered.first.to_s
 
-      assert_equal test1.name,           result.test_name
-      assert_equal test1.file_line.to_s, result.test_id
+      assert_that(result.test_name).equals(test1.name)
+      assert_that(result.test_id).equals(test1.file_line.to_s)
 
-      assert_equal message,       result.message
-      assert_equal exp_backtrace, result.backtrace
-      assert_equal exp_trace,     result.trace
+      assert_that(result.message).equals(message)
+      assert_that(result.backtrace).equals(exp_backtrace)
+      assert_that(result.trace).equals(exp_trace)
 
-      assert_false result.with_bt_set?
+      assert_that(result.with_bt_set?).is_false
     end
 
     should "use any given attrs" do
-      assert_equal given_data1[:type].to_sym,    subject.type
-      assert_equal given_data1[:name],           subject.name
-      assert_equal given_data1[:test_name],      subject.test_name
-      assert_equal given_data1[:test_file_line], subject.test_file_line
-      assert_equal given_data1[:message],        subject.message
-      assert_equal given_data1[:output],         subject.output
-      assert_equal given_data1[:backtrace],      subject.backtrace
+      assert_that(subject.type).equals(given_data1[:type].to_sym)
+      assert_that(subject.name).equals(given_data1[:name])
+      assert_that(subject.test_name).equals(given_data1[:test_name])
+      assert_that(subject.test_file_line).equals(given_data1[:test_file_line])
+      assert_that(subject.message).equals(given_data1[:message])
+      assert_that(subject.output).equals(given_data1[:output])
+      assert_that(subject.backtrace).equals(given_data1[:backtrace])
     end
 
     should "default its attrs" do
       result = Base.new({})
 
-      assert_equal :unknown,                   result.type
-      assert_equal "",                         result.name
-      assert_equal "",                         result.test_name
-      assert_equal Assert::FileLine.parse(""), result.test_file_line
-      assert_equal "",                         result.message
-      assert_equal "",                         result.output
-      assert_equal Backtrace.new([]),          result.backtrace
-      assert_equal "",                         result.trace
+      assert_that(result.type).equals(:unknown)
+      assert_that(result.name).equals("")
+      assert_that(result.test_name).equals("")
+      assert_that(result.test_file_line).equals(Assert::FileLine.parse(""))
+      assert_that(result.message).equals("")
+      assert_that(result.output).equals("")
+      assert_that(result.backtrace).equals(Backtrace.new([]))
+      assert_that(result.trace).equals("")
     end
 
     should "know its test file line attrs" do
       exp = given_data1[:test_file_line]
-      assert_equal exp.file,      subject.test_file_name
-      assert_equal exp.line.to_i, subject.test_line_num
-      assert_equal exp.to_s,      subject.test_id
+      assert_that(subject.test_file_name).equals(exp.file)
+      assert_that(subject.test_line_num).equals(exp.line.to_i)
+      assert_that(subject.test_id).equals(exp.to_s)
     end
 
     should "allow setting a new backtrace" do
@@ -117,8 +117,8 @@ module Assert::Result
       exp_backtrace = Backtrace.new(new_bt)
       exp_trace     = exp_backtrace.filtered.first.to_s
       subject.set_backtrace(new_bt)
-      assert_equal exp_backtrace, subject.backtrace
-      assert_equal exp_trace,     subject.trace
+      assert_that(subject.backtrace).equals(exp_backtrace)
+      assert_that(subject.trace).equals(exp_trace)
 
       # test that the first bt line is used if filtered is empty
       assert_lib_path = File.join(ROOT_PATH, "lib/#{Factory.string}:#{Factory.integer}")
@@ -126,24 +126,24 @@ module Assert::Result
       exp_backtrace   = Backtrace.new(new_bt)
       exp_trace       = exp_backtrace.first.to_s
       subject.set_backtrace(new_bt)
-      assert_equal exp_backtrace, subject.backtrace
-      assert_equal exp_trace,     subject.trace
+      assert_that(subject.backtrace).equals(exp_backtrace)
+      assert_that(subject.trace).equals(exp_trace)
     end
 
     should "allow setting a with bt backtrace and know if one has been set" do
-      assert_false subject.with_bt_set?
+      assert_that(subject.with_bt_set?).is_false
 
       orig_backtrace = subject.backtrace
       with_bt        = Factory.backtrace
 
       subject.set_with_bt(with_bt)
 
-      assert_true subject.with_bt_set?
-      assert_equal orig_backtrace, subject.backtrace
-      assert_equal with_bt.first,  subject.src_line
+      assert_that(subject.with_bt_set?).is_true
+      assert_that(subject.backtrace).equals(orig_backtrace)
+      assert_that(subject.src_line).equals(with_bt.first)
 
       exp = Backtrace.to_s(with_bt + [orig_backtrace.filtered.first])
-      assert_equal exp, subject.trace
+      assert_that(subject.trace).equals(exp)
     end
 
     should "know its src/file line attrs" do
@@ -151,21 +151,21 @@ module Assert::Result
       subject.set_backtrace(new_bt)
 
       exp = Backtrace.new(new_bt).filtered.first.to_s
-      assert_equal exp, subject.src_line
+      assert_that(subject.src_line).equals(exp)
 
       exp = Assert::FileLine.parse(subject.src_line)
-      assert_equal exp,           subject.file_line
-      assert_equal exp.file,      subject.file_name
-      assert_equal exp.line.to_i, subject.line_num
+      assert_that(subject.file_line).equals(exp)
+      assert_that(subject.file_name).equals(exp.file)
+      assert_that(subject.line_num).equals(exp.line.to_i)
 
       # test you get the same file line attrs using `set_with_bt`
       subject.set_with_bt(new_bt)
-      assert_equal new_bt.first.to_s, subject.src_line
+      assert_that(subject.src_line).equals(new_bt.first.to_s)
 
       exp = Assert::FileLine.parse(subject.src_line)
-      assert_equal exp,           subject.file_line
-      assert_equal exp.file,      subject.file_name
-      assert_equal exp.line.to_i, subject.line_num
+      assert_that(subject.file_line).equals(exp)
+      assert_that(subject.file_name).equals(exp.file)
+      assert_that(subject.line_num).equals(exp.line.to_i)
 
       # test that the first bt line is used if filtered is empty
       assert_lib_path = File.join(ROOT_PATH, "lib/#{Factory.string}:#{Factory.integer}")
@@ -173,45 +173,45 @@ module Assert::Result
       subject.set_backtrace(new_bt)
 
       exp = new_bt.first.to_s
-      assert_equal exp, subject.src_line
+      assert_that(subject.src_line).equals(exp)
 
       exp = Assert::FileLine.parse(subject.src_line)
-      assert_equal exp,           subject.file_line
-      assert_equal exp.file,      subject.file_name
-      assert_equal exp.line.to_i, subject.line_num
+      assert_that(subject.file_line).equals(exp)
+      assert_that(subject.file_name).equals(exp.file)
+      assert_that(subject.line_num).equals(exp.line.to_i)
     end
 
     should "know if it is a certain type of result" do
       Assert::Result.types.keys.each do |type|
-        assert_false subject.send("#{type}?")
+        assert_that(subject.send("#{type}?")).is_false
         Assert.stub(subject, :type){ type }
-        assert_true subject.send("#{type}?")
+        assert_that(subject.send("#{type}?")).is_true
       end
     end
 
     should "know its symbol representation" do
-      assert_equal subject.type, subject.to_sym
+      assert_that(subject.to_sym).equals(subject.type)
     end
 
     should "know its string representation" do
       str = subject.to_s
 
-      assert_includes subject.name.upcase, str
-      assert_includes subject.test_name,   str
-      assert_includes subject.message,     str
-      assert_includes subject.trace,       str
+      assert_that(str).includes(subject.name.upcase)
+      assert_that(str).includes(subject.test_name)
+      assert_that(str).includes(subject.message)
+      assert_that(str).includes(subject.trace)
 
-      assert_equal 3, str.split("\n").count
+      assert_that(str.split("\n").count).equals(3)
 
       Assert.stub(subject, :message){ "" }
       Assert.stub(subject, :trace){ "" }
 
-      assert_equal 1, subject.to_s.split("\n").count
+      assert_that(subject.to_s.split("\n").count).equals(1)
     end
 
     should "know if it is equal to another result" do
       other = Assert::Result::Base.new(given_data1)
-      assert_equal other, subject
+      assert_that(subject).equals(other)
 
       Assert.stub(other, [:type, :message].sample){ Factory.string }
       assert_not_equal other, subject
@@ -222,7 +222,7 @@ module Assert::Result
             "@message=#{subject.message.inspect} "\
             "@file_line=#{subject.file_line.to_s.inspect} "\
             "@test_file_line=#{subject.test_file_line.to_s.inspect}>"
-      assert_equal exp, subject.inspect
+      assert_that(subject.inspect).equals(exp)
     end
   end
 
@@ -233,9 +233,9 @@ module Assert::Result
     let(:result1) { Pass.new({}) }
 
     should "know its type/name" do
-      assert_equal :pass,  subject.type
-      assert_equal :pass,  subject.class.type
-      assert_equal "Pass", subject.class.name
+      assert_that(subject.type).equals(:pass)
+      assert_that(subject.class.type).equals(:pass)
+      assert_that(subject.class.name).equals("Pass")
     end
   end
 
@@ -246,9 +246,9 @@ module Assert::Result
     let(:result1) { Ignore.new({}) }
 
     should "know its type/name" do
-      assert_equal :ignore,  subject.type
-      assert_equal :ignore,  subject.class.type
-      assert_equal "Ignore", subject.class.name
+      assert_that(subject.type).equals(:ignore)
+      assert_that(subject.class.type).equals(:ignore)
+      assert_that(subject.class.name).equals("Ignore")
     end
   end
 
@@ -259,7 +259,7 @@ module Assert::Result
     should have_accessors :assert_with_bt
 
     should "be a runtime error" do
-      assert_kind_of RuntimeError, subject
+      assert_that(subject).is_kind_of(RuntimeError)
     end
   end
 
@@ -268,7 +268,7 @@ module Assert::Result
     subject { TestFailure }
 
     should "be a halting test result error" do
-      assert_kind_of HaltingTestResultError, subject.new
+      assert_that(subject.new).is_kind_of(HaltingTestResultError)
     end
   end
 
@@ -279,9 +279,9 @@ module Assert::Result
     let(:result1) { Fail.new({}) }
 
     should "know its type/name" do
-      assert_equal :fail,  subject.type
-      assert_equal :fail,  subject.class.type
-      assert_equal "Fail", subject.class.name
+      assert_that(subject.type).equals(:fail)
+      assert_that(subject.class.type).equals(:fail)
+      assert_that(subject.class.name).equals("Fail")
     end
 
     should "allow creating for a test with TestFailure exceptions" do
@@ -289,25 +289,25 @@ module Assert::Result
       err.set_backtrace(Factory.backtrace)
       result = Fail.for_test(test1, err)
 
-      assert_equal err.message, result.message
+      assert_that(result.message).equals(err.message)
 
       err_backtrace = Backtrace.new(err.backtrace)
-      assert_equal err_backtrace, result.backtrace
+      assert_that(result.backtrace).equals(err_backtrace)
 
       # test assert with bt errors
       err.assert_with_bt = Factory.backtrace
       result = Fail.for_test(test1, err)
 
-      assert_equal err.message,              result.message
-      assert_equal err.backtrace,            result.backtrace
-      assert_equal err.assert_with_bt.first, result.src_line
+      assert_that(result.message).equals(err.message)
+      assert_that(result.backtrace).equals(err.backtrace)
+      assert_that(result.src_line).equals(err.assert_with_bt.first)
 
       exp = Backtrace.to_s(err.assert_with_bt + [err_backtrace.filtered.first])
-      assert_equal exp, result.trace
+      assert_that(result.trace).equals(exp)
     end
 
     should "not allow creating for a test with non-TestFailure exceptions" do
-      assert_raises(ArgumentError){ Fail.for_test(test1, RuntimeError.new) }
+      assert_that(-> { Fail.for_test(test1, RuntimeError.new) }).raises(ArgumentError)
     end
   end
 
@@ -316,7 +316,7 @@ module Assert::Result
     subject { TestSkipped }
 
     should "be a halting test result error" do
-      assert_kind_of HaltingTestResultError, subject.new
+      assert_that(subject.new).is_kind_of(HaltingTestResultError)
     end
   end
 
@@ -327,9 +327,9 @@ module Assert::Result
     let(:result1) { Skip.new({}) }
 
     should "know its type/name" do
-      assert_equal :skip,  subject.type
-      assert_equal :skip,  subject.class.type
-      assert_equal "Skip", subject.class.name
+      assert_that(subject.type).equals(:skip)
+      assert_that(subject.class.type).equals(:skip)
+      assert_that(subject.class.name).equals("Skip")
     end
 
     should "allow creating for a test with TestSkipped exceptions" do
@@ -337,25 +337,25 @@ module Assert::Result
       err.set_backtrace(Factory.backtrace)
       result = Skip.for_test(test1, err)
 
-      assert_equal err.message, result.message
+      assert_that(result.message).equals(err.message)
 
       err_backtrace = Backtrace.new(err.backtrace)
-      assert_equal err_backtrace, result.backtrace
+      assert_that(result.backtrace).equals(err_backtrace)
 
       # test assert with bt errors
       err.assert_with_bt = Factory.backtrace
       result = Skip.for_test(test1, err)
 
-      assert_equal err.message,              result.message
-      assert_equal err.backtrace,            result.backtrace
-      assert_equal err.assert_with_bt.first, result.src_line
+      assert_that(result.message).equals(err.message)
+      assert_that(result.backtrace).equals(err.backtrace)
+      assert_that(result.src_line).equals(err.assert_with_bt.first)
 
       exp = Backtrace.to_s(err.assert_with_bt + [err_backtrace.filtered.first])
-      assert_equal exp, result.trace
+      assert_that(result.trace).equals(exp)
     end
 
     should "not allow creating for a test with non-TestSkipped exceptions" do
-      assert_raises(ArgumentError){ Skip.for_test(test1, RuntimeError.new) }
+      assert_that(-> { Skip.for_test(test1, RuntimeError.new) }).raises(ArgumentError)
     end
   end
 
@@ -366,8 +366,8 @@ module Assert::Result
     let(:result1) { Error.new({}) }
 
     should "know its class-level type/name" do
-      assert_equal :error,  subject.class.type
-      assert_equal "Error", subject.class.name
+      assert_that(subject.class.type).equals(:error)
+      assert_that(subject.class.name).equals("Error")
     end
 
     should "allow creating for a test with exceptions" do
@@ -376,15 +376,15 @@ module Assert::Result
       result = Error.for_test(test1, err)
 
       exp_msg = "#{err.message} (#{err.class.name})"
-      assert_equal exp_msg, result.message
+      assert_that(result.message).equals(exp_msg)
 
       exp_bt = Backtrace.new(err.backtrace)
-      assert_equal exp_bt,                 result.backtrace
-      assert_equal Backtrace.to_s(exp_bt), result.trace
+      assert_that(result.backtrace).equals(exp_bt)
+      assert_that(result.trace).equals(Backtrace.to_s(exp_bt))
     end
 
     should "not allow creating for a test without an exception" do
-      assert_raises(ArgumentError){ Error.for_test(test1, Factory.string) }
+      assert_that(-> { Error.for_test(test1, Factory.string) }).raises(ArgumentError)
     end
   end
 
@@ -398,27 +398,27 @@ module Assert::Result
     should have_imeths :filtered
 
     should "be parseable from its string representation" do
-      assert_equal subject, Backtrace.parse(Backtrace.to_s(subject))
+      assert_that(Backtrace.parse(Backtrace.to_s(subject))).equals(subject)
     end
 
     should "render as a string by joining on the newline" do
-      assert_equal subject.join(Backtrace::DELIM), Backtrace.to_s(subject)
+      assert_that(Backtrace.to_s(subject)).equals(subject.join(Backtrace::DELIM))
     end
 
     should "be an Array" do
-      assert_kind_of ::Array, subject
+      assert_that(subject).is_kind_of(::Array)
     end
 
     should "know its DELIM" do
-      assert_equal "\n", Backtrace::DELIM
+      assert_that(Backtrace::DELIM).equals("\n")
     end
 
     should "another backtrace when filtered" do
-      assert_kind_of Backtrace, subject
+      assert_that(subject).is_kind_of(Backtrace)
     end
 
     should "default itself when created from nil" do
-      assert_equal ["No backtrace"], Backtrace.new
+      assert_that(Backtrace.new).equals(["No backtrace"])
     end
   end
 end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -13,7 +13,7 @@ class Assert::Runner
     subject { Assert::Runner }
 
     should "include the config helpers" do
-      assert_includes Assert::ConfigHelpers, subject
+      assert_that(subject).includes(Assert::ConfigHelpers)
     end
   end
 
@@ -36,11 +36,11 @@ class Assert::Runner
     should have_imeths :before_test, :after_test, :on_result
 
     should "know its config" do
-      assert_equal config1, subject.config
+      assert_that(subject.config).equals(config1)
     end
 
     should "override the config helper's runner value with itself" do
-      assert_equal subject, subject.runner
+      assert_that(subject.runner).equals(subject)
     end
   end
 
@@ -66,7 +66,7 @@ class Assert::Runner
     let(:runner1) { runner_class1.new(config1) }
 
     should "return the fail+error result count as an integer exit code" do
-      assert_equal 0, @result
+      assert_that(@result).equals(0)
 
       fail_count  = Factory.integer
       error_count = Factory.integer
@@ -76,43 +76,43 @@ class Assert::Runner
       result = runner1.run
 
       exp = fail_count + error_count
-      assert_equal exp, result
+      assert_that(result).equals(exp)
     end
 
     should "run all callbacks on itself, the suite and the view" do
       # itself
-      assert_true subject.on_start_called
-      assert_equal [test1], subject.before_test_called
-      assert_instance_of Assert::Result::Pass, subject.on_result_called.last
-      assert_equal [test1], subject.after_test_called
-      assert_true subject.on_finish_called
+      assert_that(subject.on_start_called).is_true
+      assert_that(subject.before_test_called).equals([test1])
+      assert_that(subject.on_result_called.last).is_instance_of(Assert::Result::Pass)
+      assert_that(subject.after_test_called).equals([test1])
+      assert_that(subject.on_finish_called).is_true
 
       # suite
       suite = config1.suite
-      assert_true suite.on_start_called
-      assert_equal [test1], suite.before_test_called
-      assert_instance_of Assert::Result::Pass, suite.on_result_called.last
-      assert_equal [test1], suite.after_test_called
-      assert_true suite.on_finish_called
+      assert_that(suite.on_start_called).is_true
+      assert_that(suite.before_test_called).equals([test1])
+      assert_that(suite.on_result_called.last).is_instance_of(Assert::Result::Pass)
+      assert_that(suite.after_test_called).equals([test1])
+      assert_that(suite.on_finish_called).is_true
 
       # view
       view = config1.view
-      assert_true view.on_start_called
-      assert_equal [test1], view.before_test_called
-      assert_instance_of Assert::Result::Pass, view.on_result_called.last
-      assert_equal [test1], view.after_test_called
-      assert_true view.on_finish_called
+      assert_that(view.on_start_called).is_true
+      assert_that(view.before_test_called).equals([test1])
+      assert_that(view.on_result_called.last).is_instance_of(Assert::Result::Pass)
+      assert_that(view.after_test_called).equals([test1])
+      assert_that(view.on_finish_called).is_true
     end
 
     should "describe running the tests in random order if there are tests" do
       exp = "Running tests in random order, " \
             "seeded with \"#{subject.runner_seed}\"\n"
-      assert_includes exp, @view_output
+      assert_that(@view_output).includes(exp)
 
       @view_output.gsub!(/./, "")
       config1.suite.clear_tests_to_run
       subject.run
-      assert_not_includes exp, @view_output
+      assert_that(@view_output).does_not_include(exp)
     end
 
     should "run only a single test if a single test is configured" do
@@ -122,7 +122,7 @@ class Assert::Runner
       config1.single_test test.file_line.to_s
 
       runner = runner_class1.new(config1).tap(&:run)
-      assert_equal [test], runner.before_test_called
+      assert_that(runner.before_test_called).equals([test])
     end
 
     should "not run any tests if a single test is configured but can't be found" do
@@ -132,7 +132,7 @@ class Assert::Runner
       config1.single_test Factory.string
 
       runner = runner_class1.new(config1).tap(&:run)
-      assert_nil runner.before_test_called
+      assert_that(runner.before_test_called).is_nil
     end
 
     should "describe running only a single test if a single test is configured" do
@@ -144,7 +144,7 @@ class Assert::Runner
 
       exp = "Running test: #{subject.single_test_file_line}, " \
             "seeded with \"#{subject.runner_seed}\"\n"
-      assert_includes exp, @view_output
+      assert_that(@view_output).includes(exp)
     end
   end
 

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -12,12 +12,12 @@ class Assert::Suite
     subject { Assert::Suite }
 
     should "include the config helpers" do
-      assert_includes Assert::ConfigHelpers, subject
+      assert_that(subject).includes(Assert::ConfigHelpers)
     end
 
     should "know its test method regex" do
-      assert_match     "test#{Factory.string}", subject::TEST_METHOD_REGEX
-      assert_not_match "#{Factory.string}test", subject::TEST_METHOD_REGEX
+      assert_that(subject::TEST_METHOD_REGEX).matches("test#{Factory.string}")
+      assert_that(subject::TEST_METHOD_REGEX).does_not_match("#{Factory.string}test")
     end
   end
 
@@ -42,34 +42,34 @@ class Assert::Suite
     should have_imeths :before_test, :after_test, :on_result
 
     should "know its config" do
-      assert_equal config1, subject.config
+      assert_that(subject.config).equals(config1)
     end
 
     should "default its attrs" do
-      assert_equal [], subject.test_methods
-      assert_equal [], subject.setups
-      assert_equal [], subject.teardowns
+      assert_that(subject.test_methods).equals([])
+      assert_that(subject.setups).equals([])
+      assert_that(subject.teardowns).equals([])
 
-      assert_equal subject.start_time, subject.end_time
+      assert_that(subject.end_time).equals(subject.start_time)
     end
 
     should "override the config helper's suite value with itself" do
-      assert_equal subject, subject.suite
+      assert_that(subject.suite).equals(subject)
     end
 
     should "not provide any test/result count implementations" do
-      assert_nil subject.test_count
-      assert_nil subject.pass_result_count
-      assert_nil subject.fail_result_count
-      assert_nil subject.error_result_count
-      assert_nil subject.skip_result_count
-      assert_nil subject.ignore_result_count
+      assert_that(subject.test_count).is_nil
+      assert_that(subject.pass_result_count).is_nil
+      assert_that(subject.fail_result_count).is_nil
+      assert_that(subject.error_result_count).is_nil
+      assert_that(subject.skip_result_count).is_nil
+      assert_that(subject.ignore_result_count).is_nil
     end
 
     should "know its run time and rates" do
-      assert_equal 0, subject.run_time
-      assert_equal 0, subject.test_rate
-      assert_equal 0, subject.result_rate
+      assert_that(subject.run_time).equals(0)
+      assert_that(subject.test_rate).equals(0)
+      assert_that(subject.result_rate).equals(0)
 
       time = Factory.integer(3).to_f
       subject.end_time = subject.start_time + time
@@ -77,9 +77,9 @@ class Assert::Suite
       Assert.stub(subject, :test_count){ count }
       Assert.stub(subject, :result_count){ count }
 
-      assert_equal time, subject.run_time
-      assert_equal (subject.test_count / subject.run_time),   subject.test_rate
-      assert_equal (subject.result_count / subject.run_time), subject.result_rate
+      assert_that(subject.run_time).equals(time)
+      assert_that(subject.test_rate).equals((subject.test_count / subject.run_time))
+      assert_that(subject.result_rate).equals((subject.result_count / subject.run_time))
     end
 
     should "add setup procs" do
@@ -87,9 +87,9 @@ class Assert::Suite
       suite1.setup{ status = "setups" }
       suite1.startup{ status += " have been run" }
 
-      assert_equal 2, subject.setups.count
+      assert_that(subject.setups.count).equals(2)
       subject.setups.each(&:call)
-      assert_equal "setups have been run", status
+      assert_that(status).equals("setups have been run")
     end
 
     should "add teardown procs" do
@@ -97,9 +97,9 @@ class Assert::Suite
       suite1.teardown{ status = "teardowns" }
       suite1.shutdown{ status += " have been run" }
 
-      assert_equal 2, subject.teardowns.count
+      assert_that(subject.teardowns.count).equals(2)
       subject.teardowns.each(&:call)
-      assert_equal "teardowns have been run", status
+      assert_that(status).equals("teardowns have been run")
     end
   end
 
@@ -123,25 +123,25 @@ class Assert::Suite
     }
 
     should "know its tests-to-run attrs" do
-      assert_equal tests1.size, subject.tests_to_run_count
-      assert_true subject.tests_to_run?
+      assert_that(subject.tests_to_run_count).equals(tests1.size)
+      assert_that(subject.tests_to_run?).is_true
 
       subject.clear_tests_to_run
 
-      assert_equal 0, subject.tests_to_run_count
-      assert_false subject.tests_to_run?
+      assert_that(subject.tests_to_run_count).equals(0)
+      assert_that(subject.tests_to_run?).is_false
     end
 
     should "find a test to run given a file line" do
       test = tests1.sample
-      assert_same test, subject.find_test_to_run(test.file_line)
+      assert_that(subject.find_test_to_run(test.file_line)).is_the_same_as(test)
     end
 
     should "know its sorted tests to run" do
       sorted_tests = subject.sorted_tests_to_run{ 1 }
-      assert_equal tests1.size, sorted_tests.size
-      assert_kind_of Assert::Test, sorted_tests.first
-      assert_same sorted_tests.first, subject.sorted_tests_to_run{ 1 }.first
+      assert_that(sorted_tests.size).equals(tests1.size)
+      assert_that(sorted_tests.first).is_kind_of(Assert::Test)
+      assert_that(subject.sorted_tests_to_run{ 1 }.first).is_the_same_as(sorted_tests.first)
     end
   end
 end

--- a/test/unit/test_tests.rb
+++ b/test/unit/test_tests.rb
@@ -22,10 +22,10 @@ class Assert::Test
       data = subject.name_file_line_context_data(context_info1, test_name)
 
       exp = context_info1.test_name(test_name)
-      assert_equal exp, data[:name]
+      assert_that(data[:name]).equals(exp)
 
       exp = context_info1.called_from
-      assert_equal exp, data[:file_line]
+      assert_that(data[:file_line]).equals(exp)
     end
 
     should "build tests for a block" do
@@ -33,14 +33,14 @@ class Assert::Test
       test = subject.for_block(name, context_info1, config1, &test_code1)
 
       exp = Assert::FileLine.parse(context_info1.called_from)
-      assert_equal exp, test.file_line
+      assert_that(test.file_line).equals(exp)
 
       exp = context_info1.test_name(name)
-      assert_equal exp, test.name
+      assert_that(test.name).equals(exp)
 
-      assert_equal context_info1, test.context_info
-      assert_equal config1,       test.config
-      assert_equal test_code1,    test.code
+      assert_that(test.context_info).equals(context_info1)
+      assert_that(test.config).equals(config1)
+      assert_that(test.code).equals(test_code1)
     end
 
     should "build tests for a method" do
@@ -48,17 +48,17 @@ class Assert::Test
       test = subject.for_method(meth, context_info1, config1)
 
       exp = Assert::FileLine.parse(context_info1.called_from)
-      assert_equal exp, test.file_line
+      assert_that(test.file_line).equals(exp)
 
       exp = context_info1.test_name(meth)
-      assert_equal exp, test.name
+      assert_that(test.name).equals(exp)
 
-      assert_equal context_info1, test.context_info
-      assert_equal config1,       test.config
+      assert_that(test.context_info).equals(context_info1)
+      assert_that(test.config).equals(config1)
 
-      assert_kind_of Proc, test.code
+      assert_that(test.code).is_kind_of(Proc)
       self.instance_eval(&test.code)
-      assert_true @a_test_method_called
+      assert_that(@a_test_method_called).is_true
     end
 
     def a_test_method
@@ -93,36 +93,36 @@ class Assert::Test
     should have_imeths :context_info, :context_class, :config, :code, :run
 
     should "use any given attrs" do
-      assert_equal file_line1,             subject.file_line
-      assert_equal meta_data1[:name],      subject.name
-      assert_equal meta_data1[:output],    subject.output
-      assert_equal meta_data1[:run_time],  subject.run_time
+      assert_that(subject.file_line).equals(file_line1)
+      assert_that(subject.name).equals(meta_data1[:name])
+      assert_that(subject.output).equals(meta_data1[:output])
+      assert_that(subject.run_time).equals(meta_data1[:run_time])
 
-      assert_equal context_info1, subject.context_info
-      assert_equal config1,       subject.config
-      assert_equal test_code1,    subject.code
+      assert_that(subject.context_info).equals(context_info1)
+      assert_that(subject.config).equals(config1)
+      assert_that(subject.code).equals(test_code1)
     end
 
     should "default its attrs" do
       test = Assert::Test.new
 
-      assert_equal Assert::FileLine.parse(""), test.file_line
-      assert_equal "", test.name
-      assert_equal "", test.output
-      assert_equal 0,  test.run_time
+      assert_that(test.file_line).equals(Assert::FileLine.parse(""))
+      assert_that(test.name).equals("")
+      assert_that(test.output).equals("")
+      assert_that(test.run_time).equals(0)
 
-      assert_nil test.context_info
-      assert_nil test.config
-      assert_nil test.code
+      assert_that(test.context_info).is_nil
+      assert_that(test.config).is_nil
+      assert_that(test.code).is_nil
     end
 
     should "know its context class" do
-      assert_equal context_class1, subject.context_class
+      assert_that(subject.context_class).equals(context_class1)
     end
 
     should "know its file line attrs" do
-      assert_equal subject.file_line.file,      subject.file_name
-      assert_equal subject.file_line.line.to_i, subject.line_num
+      assert_that(subject.file_name).equals(subject.file_line.file)
+      assert_that(subject.line_num).equals(subject.file_line.line.to_i)
     end
 
     should "have a custom inspect that only shows limited attributes" do
@@ -130,7 +130,7 @@ class Assert::Test
         "@#{method}=#{subject.send(method).inspect}"
       end.join(" ")
       exp = "#<#{subject.class}:#{"0x0%x" % (subject.object_id << 1)} #{attrs}>"
-      assert_equal exp, subject.inspect
+      assert_that(subject.inspect).equals(exp)
     end
   end
 
@@ -162,30 +162,30 @@ class Assert::Test
     }
 
     should "capture results in the test and any setups/teardowns" do
-      assert_equal 9, test_run_results.size
+      assert_that(test_run_results.size).equals(9)
       test_run_results.each do |result|
-        assert_kind_of Assert::Result::Base, result
+        assert_that(result).is_kind_of(Assert::Result::Base)
       end
     end
 
     should "capture pass results in the test and any setups/teardowns" do
-      assert_equal 3, test_run_results(:pass).size
+      assert_that(test_run_results(:pass).size).equals(3)
       test_run_results(:pass).each do |result|
-        assert_kind_of Assert::Result::Pass, result
+        assert_that(result).is_kind_of(Assert::Result::Pass)
       end
     end
 
     should "capture fail results in the test and any setups/teardowns" do
-      assert_equal 3, test_run_results(:fail).size
+      assert_that(test_run_results(:fail).size).equals(3)
       test_run_results(:fail).each do |result|
-        assert_kind_of Assert::Result::Fail, result
+        assert_that(result).is_kind_of(Assert::Result::Fail)
       end
     end
 
     should "capture ignore results in the test and any setups/teardowns" do
-      assert_equal 3, test_run_results(:ignore).size
+      assert_that(test_run_results(:ignore).size).equals(3)
       test_run_results(:ignore).each do |result|
-        assert_kind_of Assert::Result::Ignore, result
+        assert_that(result).is_kind_of(Assert::Result::Ignore)
       end
     end
   end
@@ -224,9 +224,9 @@ class Assert::Test
 
     def assert_failed(test)
       with_backtrace(caller) do
-        assert_equal 1, test_run_result_count, "too many/few fail results"
+        assert_that(test_run_result_count).equals(1, "too many/few fail results")
         test_run_results.each do |result|
-          assert_kind_of Assert::Result::Fail, result, "not a fail result"
+          assert_that(result).is_kind_of(Assert::Result::Fail, "not a fail result")
         end
       end
     end
@@ -262,9 +262,9 @@ class Assert::Test
 
     def assert_skipped(test)
       with_backtrace(caller) do
-        assert_equal 1, test_run_result_count, "too many/few skip results"
+        assert_that(test_run_result_count).equals(1, "too many/few skip results")
         test_run_results.each do |result|
-          assert_kind_of Assert::Result::Skip, result, "not a skip result"
+          assert_that(result).is_kind_of(Assert::Result::Skip, "not a skip result")
         end
       end
     end
@@ -302,9 +302,9 @@ class Assert::Test
 
     def assert_errored(test)
       with_backtrace(caller) do
-        assert_equal 1, test_run_result_count, "too many/few error results"
+        assert_that(test_run_result_count).equals(1, "too many/few error results")
         test_run_results.each do |result|
-          assert_kind_of Assert::Result::Error, result, "not an error result"
+          assert_that(result).is_kind_of(Assert::Result::Error, "not an error result")
         end
       end
     end
@@ -316,21 +316,21 @@ class Assert::Test
         raise SignalException, "USR1"
       end
 
-      assert_raises(SignalException){ test.run }
+      assert_that(-> { test.run }).raises(SignalException)
     end
 
     should "raises signal exceptions in the context setup" do
       test = Factory.test("setup signal test", context_info1){ }
       test.context_class.setup{ raise SignalException, "INT" }
 
-      assert_raises(SignalException){ test.run }
+      assert_that(-> { test.run }).raises(SignalException)
     end
 
     should "raises signal exceptions in the context teardown" do
       test = Factory.test("teardown signal test", context_info1){ }
       test.context_class.teardown{ raise SignalException, "TERM" }
 
-      assert_raises(SignalException){ test.run }
+      assert_that(-> { test.run }).raises(SignalException)
     end
   end
 
@@ -342,17 +342,17 @@ class Assert::Test
 
     should "return 1 with a test named 'aaa' (greater than it)" do
       result = test1 <=> Factory.test("aaa")
-      assert_equal(1, result)
+      assert_that(result).equals(1)
     end
 
     should "return 0 with a test named the same" do
       result = test1 <=> Factory.test(test1.name)
-      assert_equal(0, result)
+      assert_that(result).equals(0)
     end
 
     should "return -1 with a test named 'zzz' (less than it)" do
       result = test1 <=> Factory.test("zzz")
-      assert_equal(-1, result)
+      assert_that(result).equals(-1)
     end
   end
 
@@ -369,7 +369,7 @@ class Assert::Test
 
     should "capture any io from the test" do
       test1.run
-      assert_equal "std out from the test\n", test1.output
+      assert_that(test1.output).equals("std out from the test\n")
     end
   end
 
@@ -399,7 +399,7 @@ class Assert::Test
         "std out from the test\n"\
         "std out from a method an assert called\n"\
         "std out from the teardown\n"
-      assert_equal(exp_out, test1.output)
+      assert_that(test1.output).equals(exp_out)
     end
   end
 end

--- a/test/unit/utils_tests.rb
+++ b/test/unit/utils_tests.rb
@@ -29,13 +29,13 @@ module Assert::Utils
 
     should "use `inspect` to show objs when `pp_objects` setting is false" do
       objs1.each do |obj|
-        assert_equal obj.inspect, subject.show(obj, Factory.modes_off_config)
+        assert_that(subject.show(obj, Factory.modes_off_config)).equals(obj.inspect)
       end
     end
 
     should "use `pp_proc` to show objs when `pp_objects` setting is true" do
       objs1.each do |obj|
-        assert_equal pp_config1.pp_proc.call(obj), subject.show(obj, pp_config1)
+        assert_that(subject.show(obj, pp_config1)).equals(pp_config1.pp_proc.call(obj))
       end
     end
   end
@@ -48,12 +48,12 @@ module Assert::Utils
 
     should "call show, escaping newlines" do
       exp_out = "{:string=>\"herp derp, derp herp\nherpderpedia\"}"
-      assert_equal exp_out, subject.show_for_diff(w_newlines1, Factory.modes_off_config)
+      assert_that(subject.show_for_diff(w_newlines1, Factory.modes_off_config)).equals(exp_out)
     end
 
     should "make any obj ids generic" do
       exp_out = "#<#<Class:0xXXXXXX>:0xXXXXXX>"
-      assert_equal exp_out, subject.show_for_diff(w_obj_id1, Factory.modes_off_config)
+      assert_that(subject.show_for_diff(w_obj_id1, Factory.modes_off_config)).equals(exp_out)
     end
   end
 
@@ -62,12 +62,12 @@ module Assert::Utils
 
     should "require tempfile, open a tempfile, write the given content, and yield it" do
       subject.tempfile("a-name", "some-content") do |tmpfile|
-        assert_equal false, (require "tempfile")
+        assert_that((require "tempfile")).equals(false)
         assert tmpfile
-        assert_kind_of Tempfile, tmpfile
+        assert_that(tmpfile).is_kind_of(Tempfile)
 
         tmpfile.pos = 0
-        assert_equal "some-content\n", tmpfile.read
+        assert_that(tmpfile.read).equals("some-content\n")
       end
     end
   end
@@ -78,12 +78,12 @@ module Assert::Utils
     should "build a pp proc that uses stdlib `PP.pp` to pretty print objects" do
       exp_obj_pps = objs1.map{ |o| PP.pp(o, "", 79).strip }
       act_obj_pps = objs1.map{ |o| subject.stdlib_pp_proc.call(o) }
-      assert_equal exp_obj_pps, act_obj_pps
+      assert_that(act_obj_pps).equals(exp_obj_pps)
 
       cust_width = 1
       exp_obj_pps = objs1.map{ |o| PP.pp(o, "", cust_width).strip }
       act_obj_pps = objs1.map{ |o| subject.stdlib_pp_proc(cust_width).call(o) }
-      assert_equal exp_obj_pps, act_obj_pps
+      assert_that(act_obj_pps).equals(exp_obj_pps)
     end
   end
 
@@ -119,7 +119,7 @@ module Assert::Utils
         out.sub!(/^\+\+\+ .+/, "+++ actual")
       end
 
-      assert_equal exp_diff_out, subject.syscmd_diff_proc.call(diff_a1, diff_b1)
+      assert_that(subject.syscmd_diff_proc.call(diff_a1, diff_b1)).equals(exp_diff_out)
     end
 
     should "allow you to specify a custom syscmd" do
@@ -129,7 +129,7 @@ module Assert::Utils
         out.sub!(/^\+\+\+ .+/, "+++ actual")
       end
 
-      assert_equal exp_diff_out, subject.syscmd_diff_proc(cust_syscmd).call(diff_a1, diff_b1)
+      assert_that(subject.syscmd_diff_proc(cust_syscmd).call(diff_a1, diff_b1)).equals(exp_diff_out)
     end
   end
 end

--- a/test/unit/view_helpers_tests.rb
+++ b/test/unit/view_helpers_tests.rb
@@ -31,20 +31,20 @@ module Assert::ViewHelpers
     should have_imeths :option
 
     should "include the config helpers" do
-      assert_includes Assert::ConfigHelpers, subject
+      assert_that(subject).includes(Assert::ConfigHelpers)
     end
 
     should "write option values" do
       helpers = helpers_class1.new
-      assert_equal test_opt_val1, helpers.test_opt
+      assert_that(helpers.test_opt).equals(test_opt_val1)
 
       new_val = Factory.integer
       helpers.test_opt new_val
-      assert_equal new_val, helpers.test_opt
+      assert_that(helpers.test_opt).equals(new_val)
 
       other_val = Factory.integer
       helpers.test_opt new_val, other_val
-      assert_equal [new_val, other_val], helpers.test_opt
+      assert_that(helpers.test_opt).equals([new_val, other_val])
     end
   end
 
@@ -62,74 +62,77 @@ module Assert::ViewHelpers
 
     should "know how to build captured output" do
       output = Factory.string
-      exp = "--- stdout ---\n"\
-            "#{output}"\
-            "--------------"
-      assert_equal exp, subject.captured_output(output)
+      exp =
+        "--- stdout ---\n"\
+        "#{output}"\
+        "--------------"
+      assert_that(subject.captured_output(output)).equals(exp)
     end
 
     should "know how to build the re-run test cmd" do
       test_id = "#{Dir.pwd}/#{Factory.string}_tests.rb:#{Factory.integer}"
       exp = "assert -t #{test_id.gsub(Dir.pwd, ".")}"
-      assert_equal exp, subject.re_run_test_cmd(test_id)
+      assert_that(subject.re_run_test_cmd(test_id)).equals(exp)
     end
 
     should "know its tests-to-run count and result count statements" do
       exp = "#{subject.tests_to_run_count} test#{"s" if subject.tests_to_run_count != 1}"
-      assert_equal exp, subject.tests_to_run_count_statement
+      assert_that(subject.tests_to_run_count_statement).equals(exp)
 
       exp = "#{subject.result_count} result#{"s" if subject.result_count != 1}"
-      assert_equal exp, subject.result_count_statement
+      assert_that(subject.result_count_statement).equals(exp)
     end
 
     should "know how to build a sentence from a list of items" do
       items = 1.times.map{ Factory.string }
-      assert_equal items.first, subject.to_sentence(items)
+      assert_that(subject.to_sentence(items)).equals(items.first)
 
       items = 2.times.map{ Factory.string }
-      assert_equal items.join(" and "), subject.to_sentence(items)
+      assert_that(subject.to_sentence(items)).equals(items.join(" and "))
 
       items = (Factory.integer(3)+2).times.map{ Factory.string }
       exp = [items[0..-2].join(", "), items.last].join(", and ")
-      assert_equal exp, subject.to_sentence(items)
+      assert_that(subject.to_sentence(items)).equals(exp)
     end
 
     should "know its all pass result summary message" do
       Assert.stub(subject, :result_count){ 0 }
-      assert_equal "uhh...", subject.all_pass_result_summary_msg
+      assert_that(subject.all_pass_result_summary_msg).equals("uhh...")
 
       Assert.stub(subject, :result_count){ 1 }
-      assert_equal "pass", subject.all_pass_result_summary_msg
+      assert_that(subject.all_pass_result_summary_msg).equals("pass")
 
       Assert.stub(subject, :result_count){ Factory.integer(10)+1 }
-      assert_equal "all pass", subject.all_pass_result_summary_msg
+      assert_that(subject.all_pass_result_summary_msg).equals("all pass")
     end
 
     should "know its result summary msg" do
       res_type = :pass
       Assert.stub(subject, :all_pass?){ true }
       exp = subject.all_pass_result_summary_msg
-      assert_equal exp, subject.result_summary_msg(res_type)
+      assert_that(subject.result_summary_msg(res_type)).equals(exp)
 
       Assert.stub(subject, :all_pass?){ false }
       res_type = [:pass, :ignore, :fail, :skip, :error].sample
       exp = "#{subject.send("#{res_type}_result_count")} #{res_type.to_s}"
-      assert_equal exp, subject.result_summary_msg(res_type)
+      assert_that(subject.result_summary_msg(res_type)).equals(exp)
     end
 
     should "know its results summary sentence" do
-      items = subject.ocurring_result_types.map do |result_sym|
-        subject.result_summary_msg(result_sym)
-      end
+      items =
+        subject.ocurring_result_types.map do |result_sym|
+          subject.result_summary_msg(result_sym)
+        end
       exp = subject.to_sentence(items)
-      assert_equal exp, subject.results_summary_sentence
+      assert_that(subject.results_summary_sentence).equals(exp)
 
       block = proc{ |summary, result| "#{summary}--#{result}" }
-      items = subject.ocurring_result_types.map do |result_sym|
-        block.call(subject.result_summary_msg(result_sym), result_sym)
-      end
+      items =
+        subject.ocurring_result_types.map do |result_sym|
+          block.call(subject.result_summary_msg(result_sym), result_sym)
+        end
       exp = subject.to_sentence(items)
-      assert_equal exp, subject.results_summary_sentence(&block)
+      assert_that(subject.results_summary_sentence(&block)).equals(exp)
     end
   end
 
@@ -140,19 +143,19 @@ module Assert::ViewHelpers
     should have_imeths :code_for
 
     should "know its codes" do
-      assert_not_empty subject::CODES
+      assert_that(subject::CODES).is_not_empty
     end
 
     should "map its code style names to ansi code strings" do
       styles = Factory.integer(3).times.map{ subject::CODES.keys.sample }
       exp = styles.map{ |n| "\e[#{subject::CODES[n]}m" }.join("")
-      assert_equal exp, subject.code_for(*styles)
+      assert_that(subject.code_for(*styles)).equals(exp)
 
       styles = Factory.integer(3).times.map{ Factory.string }
-      assert_equal "", subject.code_for(*styles)
+      assert_that(subject.code_for(*styles)).equals("")
 
       styles = []
-      assert_equal "", subject.code_for(*styles)
+      assert_that(subject.code_for(*styles)).equals("")
     end
   end
 
@@ -171,26 +174,26 @@ module Assert::ViewHelpers
 
       Assert.stub(subject, :is_tty?){ false }
       Assert.stub(subject, :styled){ false }
-      assert_equal msg, subject.ansi_styled_msg(msg, result_type)
+      assert_that(subject.ansi_styled_msg(msg, result_type)).equals(msg)
 
       Assert.stub(subject, :is_tty?){ false }
       Assert.stub(subject, :styled){ true }
-      assert_equal msg, subject.ansi_styled_msg(msg, result_type)
+      assert_that(subject.ansi_styled_msg(msg, result_type)).equals(msg)
 
       Assert.stub(subject, :is_tty?){ true }
       Assert.stub(subject, :styled){ false }
-      assert_equal msg, subject.ansi_styled_msg(msg, result_type)
+      assert_that(subject.ansi_styled_msg(msg, result_type)).equals(msg)
 
       Assert.stub(subject, :is_tty?){ true }
       Assert.stub(subject, :styled){ true }
       Assert.stub(subject, "#{result_type}_styles"){ [] }
-      assert_equal msg, subject.ansi_styled_msg(msg, result_type)
+      assert_that(subject.ansi_styled_msg(msg, result_type)).equals(msg)
 
       styles = Factory.integer(3).times.map{ Assert::ViewHelpers::Ansi::CODES.keys.sample }
       Assert.stub(subject, "#{result_type}_styles"){ styles }
       exp_code = Assert::ViewHelpers::Ansi.code_for(*styles)
       exp = exp_code + msg + Assert::ViewHelpers::Ansi.code_for(:reset)
-      assert_equal exp, subject.ansi_styled_msg(msg, result_type)
+      assert_that(subject.ansi_styled_msg(msg, result_type)).equals(exp)
     end
   end
 end

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -14,11 +14,11 @@ class Assert::View
     should have_instance_method :require_user_view
 
     should "include the config helpers" do
-      assert_includes Assert::ConfigHelpers, subject
+      assert_that(subject).includes(Assert::ConfigHelpers)
     end
 
     should "include the view helpers" do
-      assert_includes Assert::ViewHelpers, subject
+      assert_that(subject).includes(Assert::ViewHelpers)
     end
   end
 
@@ -37,33 +37,33 @@ class Assert::View
     should have_imeths :before_test, :after_test, :on_result
 
     should "default its style options" do
-      assert_false subject.styled
+      assert_that(subject.styled).is_false
 
-      assert_nil subject.pass_styles
-      assert_nil subject.fail_styles
-      assert_nil subject.error_styles
-      assert_nil subject.skip_styles
-      assert_nil subject.ignore_styles
+      assert_that(subject.pass_styles).is_nil
+      assert_that(subject.fail_styles).is_nil
+      assert_that(subject.error_styles).is_nil
+      assert_that(subject.skip_styles).is_nil
+      assert_that(subject.ignore_styles).is_nil
     end
 
     should "default its result abbreviations" do
-      assert_equal ".", subject.pass_abbrev
-      assert_equal "F", subject.fail_abbrev
-      assert_equal "I", subject.ignore_abbrev
-      assert_equal "S", subject.skip_abbrev
-      assert_equal "E", subject.error_abbrev
+      assert_that(subject.pass_abbrev).equals(".")
+      assert_that(subject.fail_abbrev).equals("F")
+      assert_that(subject.ignore_abbrev).equals("I")
+      assert_that(subject.skip_abbrev).equals("S")
+      assert_that(subject.error_abbrev).equals("E")
     end
 
     should "know its config" do
-      assert_equal config1, subject.config
+      assert_that(subject.config).equals(config1)
     end
 
     should "override the config helper's view value with itself" do
-      assert_equal subject, subject.view
+      assert_that(subject.view).equals(subject)
     end
 
     should "know if it is a tty" do
-      assert_equal !!io1.isatty, subject.is_tty?
+      assert_that(subject.is_tty?).equals(!!io1.isatty)
     end
   end
 end


### PR DESCRIPTION
This enables defining assertions in the form:

```ruby
assert_that(1).equals(1)
```

This form removes the ambiguity of the argument order in the
original assertion helpers and reads more like a formal assertion.
This is just another way to write tests and keeps Assert flexible
and un-imposing on the style that tests are written in.

# Other Changes

### rewrite Assert's test suite to use `assert_that` assertions

This rewrites all of the tests in Assert to use the `assert_that`
assertion style where possible. This not only provides a rich
system test for `assert_that`, there is no loss of coverage b/c
`assert_that` calls the original assertion helpers.

The main win in switching to this style is that it removes the
argument order ambiguity of expected vs actual values when they
are passed to the assertion helpers.