### PR TITLE
upgrade to the latest MuchStub

### DIFF
--- a/assert.gemspec
+++ b/assert.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = "~> 2.5"
 
   gem.add_dependency("much-factory", ["~> 0.1.0"])
-  gem.add_dependency("much-stub",    ["~> 0.1.3"])
+  gem.add_dependency("much-stub",    ["~> 0.1.4"])
 end

--- a/lib/assert/stub.rb
+++ b/lib/assert/stub.rb
@@ -9,6 +9,10 @@ module Assert
     MuchStub.stub(*args, &block)
   end
 
+  def self.stub_on_call(*args, &block)
+    MuchStub.stub_on_call(*args, &block)
+  end
+
   def self.unstub(*args)
     MuchStub.unstub(*args)
   end

--- a/test/unit/actual_value_tests.rb
+++ b/test/unit/actual_value_tests.rb
@@ -323,7 +323,7 @@ class Assert::ActualValue
 
     def assert_calls(context_method, when_calling:, on_value:)
       @last_call = nil
-      Assert.stub(context1, context_method).on_call(&capture_last_call_block)
+      Assert.stub_on_call(context1, context_method, &capture_last_call_block)
 
       unit_class.new(on_value, context: context1).public_send(*[*when_calling, *args1])
       yield(on_value, @last_call)

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -54,6 +54,18 @@ module Assert
       assert_that(stub1).is_kind_of(MuchStub::Stub)
     end
 
+    should "build a stub with an on_call block" do
+      my_meth_called_with = nil
+      stub1 =
+        Assert.stub_on_call(object1, :mymeth) { |call|
+          my_meth_called_with = call
+        }
+
+      object1.mymeth
+      assert_kind_of MuchStub::Stub, stub1
+      assert_equal [], my_meth_called_with.args
+    end
+
     should "lookup stubs that have been called before" do
       stub1 = Assert.stub(object1, :mymeth)
       stub2 = Assert.stub(object1, :mymeth)


### PR DESCRIPTION
This bring in the latest version which, in addition to keeping up
with the latest stuff, adds a `MuchStub.stub_on_call` that now
can be proxied/used.

This version also switches MuchStub::CallSpy to be a BasicObject
but that has no effect on Assert.