### PR TITLE
memoize `subject`s; update tests to use memoized subjects

### DIFF
--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -165,9 +165,12 @@ module Assert
     end
 
     def subject
-      if subj = self.class.subject
-        instance_eval(&subj)
+      unless instance_variable_defined?("@__assert_subject__")
+        @__assert_subject__ =
+          instance_eval(&self.class.subject) if self.class.subject
       end
+
+      @__assert_subject__
     end
 
     def inspect

--- a/lib/assert/context/let_dsl.rb
+++ b/lib/assert/context/let_dsl.rb
@@ -3,11 +3,11 @@ class Assert::Context; end
 module Assert::Context::LetDSL
   def let(name, &block)
     self.send(:define_method, name, &-> {
-      if instance_variable_get("@#{name}").nil?
-        instance_variable_set("@#{name}", instance_eval(&block))
+      unless instance_variable_defined?("@__assert_let_#{name}__")
+        instance_variable_set("@__assert_let_#{name}__", instance_eval(&block))
       end
 
-      instance_variable_get("@#{name}")
+      instance_variable_get("@__assert_let_#{name}__")
     })
   end
 end

--- a/lib/assert/context/subject_dsl.rb
+++ b/lib/assert/context/subject_dsl.rb
@@ -1,33 +1,32 @@
 module Assert; end
-class Assert::Context
-  module SubjectDSL
-    # Add a piece of description text or return the full description for the context
-    def description(text = nil)
-      if text
-        self.descriptions << text.to_s
-      else
-        parent = self.superclass.desc if self.superclass.respond_to?(:desc)
-        own = self.descriptions
-        [parent, *own].compact.reject(&:empty?).join(" ")
+class Assert::Context; end
+module Assert::Context::SubjectDSL
+  # Add a piece of description text or return the full description for the context
+  def description(text = nil)
+    if text
+      self.descriptions << text.to_s
+    else
+      parent = self.superclass.desc if self.superclass.respond_to?(:desc)
+      own = self.descriptions
+      [parent, *own].compact.reject(&:empty?).join(" ")
+    end
+  end
+  alias_method :desc, :description
+  alias_method :describe, :description
+
+  def subject(&block)
+    if block_given?
+      @subject = block
+    else
+      @subject || if superclass.respond_to?(:subject)
+        superclass.subject
       end
     end
-    alias_method :desc, :description
-    alias_method :describe, :description
+  end
 
-    def subject(&block)
-      if block_given?
-        @subject = block
-      else
-        @subject || if superclass.respond_to?(:subject)
-          superclass.subject
-        end
-      end
-    end
+  protected
 
-    protected
-
-    def descriptions
-      @descriptions ||= []
-    end
+  def descriptions
+    @descriptions ||= []
   end
 end

--- a/test/system/stub_tests.rb
+++ b/test/system/stub_tests.rb
@@ -8,26 +8,24 @@ class Assert::Stub
 
   class InstanceTests < SystemTests
     desc "for instance methods"
-    subject { instance1 }
+    subject { TestClass.new }
 
     setup do
-      Assert.stub(instance1, :noargs){ "default" }
-      Assert.stub(instance1, :noargs).with{ "none" }
+      Assert.stub(subject, :noargs){ "default" }
+      Assert.stub(subject, :noargs).with{ "none" }
 
-      Assert.stub(instance1, :withargs){ "default" }
-      Assert.stub(instance1, :withargs).with(1){ "one" }
+      Assert.stub(subject, :withargs){ "default" }
+      Assert.stub(subject, :withargs).with(1){ "one" }
 
-      Assert.stub(instance1, :anyargs){ "default" }
-      Assert.stub(instance1, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :anyargs){ "default" }
+      Assert.stub(subject, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(instance1, :minargs){ "default" }
-      Assert.stub(instance1, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(instance1, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(subject, :minargs){ "default" }
+      Assert.stub(subject, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(instance1, :withblock){ "default" }
+      Assert.stub(subject, :withblock){ "default" }
     end
-
-    let(:instance1) { TestClass.new }
 
     should "allow stubbing a method that doesn't take args" do
       assert_that(subject.noargs).equals("none")
@@ -82,26 +80,24 @@ class Assert::Stub
 
   class ClassTests < SystemTests
     desc "for singleton methods on a class"
-    subject { class1 }
+    subject { TestClass }
 
     setup do
-      Assert.stub(class1, :noargs){ "default" }
-      Assert.stub(class1, :noargs).with{ "none" }
+      Assert.stub(subject, :noargs){ "default" }
+      Assert.stub(subject, :noargs).with{ "none" }
 
-      Assert.stub(class1, :withargs){ "default" }
-      Assert.stub(class1, :withargs).with(1){ "one" }
+      Assert.stub(subject, :withargs){ "default" }
+      Assert.stub(subject, :withargs).with(1){ "one" }
 
-      Assert.stub(class1, :anyargs){ "default" }
-      Assert.stub(class1, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :anyargs){ "default" }
+      Assert.stub(subject, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(class1, :minargs){ "default" }
-      Assert.stub(class1, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(class1, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(subject, :minargs){ "default" }
+      Assert.stub(subject, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(class1, :withblock){ "default" }
+      Assert.stub(subject, :withblock){ "default" }
     end
-
-    let(:class1) { TestClass }
 
     should "allow stubbing a method that doesn't take args" do
       assert_that(subject.noargs).equals("none")
@@ -157,26 +153,24 @@ class Assert::Stub
 
   class ModuleTests < SystemTests
     desc "for singleton methods on a module"
-    subject { module1 }
+    subject { TestModule }
 
     setup do
-      Assert.stub(module1, :noargs){ "default" }
-      Assert.stub(module1, :noargs).with{ "none" }
+      Assert.stub(subject, :noargs){ "default" }
+      Assert.stub(subject, :noargs).with{ "none" }
 
-      Assert.stub(module1, :withargs){ "default" }
-      Assert.stub(module1, :withargs).with(1){ "one" }
+      Assert.stub(subject, :withargs){ "default" }
+      Assert.stub(subject, :withargs).with(1){ "one" }
 
-      Assert.stub(module1, :anyargs){ "default" }
-      Assert.stub(module1, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :anyargs){ "default" }
+      Assert.stub(subject, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(module1, :minargs){ "default" }
-      Assert.stub(module1, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(module1, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(subject, :minargs){ "default" }
+      Assert.stub(subject, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(module1, :withblock){ "default" }
+      Assert.stub(subject, :withblock){ "default" }
     end
-
-    let(:module1) { TestModule }
 
     should "allow stubbing a method that doesn't take args" do
       assert_that(subject.noargs).equals("none")
@@ -232,26 +226,24 @@ class Assert::Stub
 
   class ExtendedTests < SystemTests
     desc "for extended methods"
-    subject { class1 }
+    subject { Class.new{ extend TestMixin } }
 
     setup do
-      Assert.stub(class1, :noargs){ "default" }
-      Assert.stub(class1, :noargs).with{ "none" }
+      Assert.stub(subject, :noargs){ "default" }
+      Assert.stub(subject, :noargs).with{ "none" }
 
-      Assert.stub(class1, :withargs){ "default" }
-      Assert.stub(class1, :withargs).with(1){ "one" }
+      Assert.stub(subject, :withargs){ "default" }
+      Assert.stub(subject, :withargs).with(1){ "one" }
 
-      Assert.stub(class1, :anyargs){ "default" }
-      Assert.stub(class1, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :anyargs){ "default" }
+      Assert.stub(subject, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(class1, :minargs){ "default" }
-      Assert.stub(class1, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(class1, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(subject, :minargs){ "default" }
+      Assert.stub(subject, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(class1, :withblock){ "default" }
+      Assert.stub(subject, :withblock){ "default" }
     end
-
-    let(:class1) { Class.new{ extend TestMixin } }
 
     should "allow stubbing a method that doesn't take args" do
       assert_that(subject.noargs).equals("none")
@@ -307,26 +299,26 @@ class Assert::Stub
 
   class IncludedTests < SystemTests
     desc "for an included method"
-    subject { instance1 }
+    subject {
+      Class.new { include TestMixin }.new
+    }
 
     setup do
-      Assert.stub(instance1, :noargs){ "default" }
-      Assert.stub(instance1, :noargs).with{ "none" }
+      Assert.stub(subject, :noargs){ "default" }
+      Assert.stub(subject, :noargs).with{ "none" }
 
-      Assert.stub(instance1, :withargs){ "default" }
-      Assert.stub(instance1, :withargs).with(1){ "one" }
+      Assert.stub(subject, :withargs){ "default" }
+      Assert.stub(subject, :withargs).with(1){ "one" }
 
-      Assert.stub(instance1, :anyargs){ "default" }
-      Assert.stub(instance1, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :anyargs){ "default" }
+      Assert.stub(subject, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(instance1, :minargs){ "default" }
-      Assert.stub(instance1, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(instance1, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(subject, :minargs){ "default" }
+      Assert.stub(subject, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(instance1, :withblock){ "default" }
+      Assert.stub(subject, :withblock){ "default" }
     end
-
-    let(:instance1) { Class.new { include TestMixin }.new }
 
     should "allow stubbing a method that doesn't take args" do
       assert_that(subject.noargs).equals("none")
@@ -382,26 +374,24 @@ class Assert::Stub
 
   class InheritedClassTests < SystemTests
     desc "for an inherited class method"
-    subject { class1 }
+    subject { Class.new(TestClass) }
 
     setup do
-      Assert.stub(class1, :noargs){ "default" }
-      Assert.stub(class1, :noargs).with{ "none" }
+      Assert.stub(subject, :noargs){ "default" }
+      Assert.stub(subject, :noargs).with{ "none" }
 
-      Assert.stub(class1, :withargs){ "default" }
-      Assert.stub(class1, :withargs).with(1){ "one" }
+      Assert.stub(subject, :withargs){ "default" }
+      Assert.stub(subject, :withargs).with(1){ "one" }
 
-      Assert.stub(class1, :anyargs){ "default" }
-      Assert.stub(class1, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :anyargs){ "default" }
+      Assert.stub(subject, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(class1, :minargs){ "default" }
-      Assert.stub(class1, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(class1, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(subject, :minargs){ "default" }
+      Assert.stub(subject, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(class1, :withblock){ "default" }
+      Assert.stub(subject, :withblock){ "default" }
     end
-
-    let(:class1) { Class.new(TestClass) }
 
     should "allow stubbing a method that doesn't take args" do
       assert_that(subject.noargs).equals("none")
@@ -457,26 +447,24 @@ class Assert::Stub
 
   class InheritedInstanceTests < SystemTests
     desc "for an inherited instance method"
-    subject { instance1 }
+    subject { Class.new(TestClass).new }
 
     setup do
-      Assert.stub(instance1, :noargs){ "default" }
-      Assert.stub(instance1, :noargs).with{ "none" }
+      Assert.stub(subject, :noargs){ "default" }
+      Assert.stub(subject, :noargs).with{ "none" }
 
-      Assert.stub(instance1, :withargs){ "default" }
-      Assert.stub(instance1, :withargs).with(1){ "one" }
+      Assert.stub(subject, :withargs){ "default" }
+      Assert.stub(subject, :withargs).with(1){ "one" }
 
-      Assert.stub(instance1, :anyargs){ "default" }
-      Assert.stub(instance1, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :anyargs){ "default" }
+      Assert.stub(subject, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(instance1, :minargs){ "default" }
-      Assert.stub(instance1, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(instance1, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(subject, :minargs){ "default" }
+      Assert.stub(subject, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(instance1, :withblock){ "default" }
+      Assert.stub(subject, :withblock){ "default" }
     end
-
-    let(:instance1) { Class.new(TestClass).new }
 
     should "allow stubbing a method that doesn't take args" do
       assert_that(subject.noargs).equals("none")
@@ -532,26 +520,24 @@ class Assert::Stub
 
   class DelegateClassTests < SystemTests
     desc "a class that delegates another object"
-    subject { class1 }
+    subject { DelegateClass }
 
     setup do
-      Assert.stub(class1, :noargs){ "default" }
-      Assert.stub(class1, :noargs).with{ "none" }
+      Assert.stub(subject, :noargs){ "default" }
+      Assert.stub(subject, :noargs).with{ "none" }
 
-      Assert.stub(class1, :withargs){ "default" }
-      Assert.stub(class1, :withargs).with(1){ "one" }
+      Assert.stub(subject, :withargs){ "default" }
+      Assert.stub(subject, :withargs).with(1){ "one" }
 
-      Assert.stub(class1, :anyargs){ "default" }
-      Assert.stub(class1, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :anyargs){ "default" }
+      Assert.stub(subject, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(class1, :minargs){ "default" }
-      Assert.stub(class1, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(class1, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(subject, :minargs){ "default" }
+      Assert.stub(subject, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(class1, :withblock){ "default" }
+      Assert.stub(subject, :withblock){ "default" }
     end
-
-    let(:class1) { DelegateClass }
 
     should "allow stubbing a method that doesn't take args" do
       assert_that(subject.noargs).equals("none")
@@ -607,26 +593,24 @@ class Assert::Stub
 
   class DelegateInstanceTests < SystemTests
     desc "an instance that delegates another object"
-    subject { instance1 }
+    subject { DelegateClass.new }
 
     setup do
-      Assert.stub(instance1, :noargs){ "default" }
-      Assert.stub(instance1, :noargs).with{ "none" }
+      Assert.stub(subject, :noargs){ "default" }
+      Assert.stub(subject, :noargs).with{ "none" }
 
-      Assert.stub(instance1, :withargs){ "default" }
-      Assert.stub(instance1, :withargs).with(1){ "one" }
+      Assert.stub(subject, :withargs){ "default" }
+      Assert.stub(subject, :withargs).with(1){ "one" }
 
-      Assert.stub(instance1, :anyargs){ "default" }
-      Assert.stub(instance1, :anyargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :anyargs){ "default" }
+      Assert.stub(subject, :anyargs).with(1, 2){ "one-two" }
 
-      Assert.stub(instance1, :minargs){ "default" }
-      Assert.stub(instance1, :minargs).with(1, 2){ "one-two" }
-      Assert.stub(instance1, :minargs).with(1, 2, 3){ "one-two-three" }
+      Assert.stub(subject, :minargs){ "default" }
+      Assert.stub(subject, :minargs).with(1, 2){ "one-two" }
+      Assert.stub(subject, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      Assert.stub(instance1, :withblock){ "default" }
+      Assert.stub(subject, :withblock){ "default" }
     end
-
-    let(:instance1) { DelegateClass.new }
 
     should "allow stubbing a method that doesn't take args" do
       assert_that(subject.noargs).equals("none")

--- a/test/system/test_tests.rb
+++ b/test/system/test_tests.rb
@@ -6,17 +6,15 @@ class Assert::Test
     include Assert::Test::TestHelpers
 
     desc "Assert::Test"
-    subject { test1 }
 
     setup do
-      test1.run(&test_run_callback)
+      subject.run(&test_run_callback)
     end
   end
 
   class NoResultsTests < SystemTests
     desc "when producing no results"
-
-    let(:test1) { Factory.test }
+    subject { Factory.test }
 
     should "generate 0 results" do
       assert_that(test_run_result_count).equals(0)
@@ -25,8 +23,7 @@ class Assert::Test
 
   class PassTests < SystemTests
     desc "when passing a single assertion"
-
-    let(:test1) { Factory.test{ assert(1 == 1) } }
+    subject { Factory.test{ assert(1 == 1) } }
 
     should "generate 1 result" do
       assert_that(test_run_result_count).equals(1)
@@ -39,8 +36,7 @@ class Assert::Test
 
   class FailTests < SystemTests
     desc "when failing a single assertion"
-
-    let(:test1) { Factory.test{ assert(1 == 0) } }
+    subject { Factory.test{ assert(1 == 0) } }
 
     should "generate 1 result" do
       assert_that(test_run_result_count).equals(1)
@@ -53,8 +49,7 @@ class Assert::Test
 
   class SkipTests < SystemTests
     desc "when skipping once"
-
-    let(:test1) { Factory.test{ skip } }
+    subject { Factory.test{ skip } }
 
     should "generate 1 result" do
       assert_that(test_run_result_count).equals(1)
@@ -67,8 +62,7 @@ class Assert::Test
 
   class ErrorTests < SystemTests
     desc "when erroring once"
-
-    let(:test1) { Factory.test{ raise("WHAT") } }
+    subject { Factory.test{ raise("WHAT") } }
 
     should "generate 1 result" do
       assert_that(test_run_result_count).equals(1)
@@ -81,8 +75,7 @@ class Assert::Test
 
   class MixedTests < SystemTests
     desc "when passing 1 assertion and failing 1 assertion"
-
-    let(:test1) {
+    subject {
       Factory.test do
         assert(1 == 1)
         assert(1 == 0)
@@ -104,8 +97,7 @@ class Assert::Test
 
   class MixedSkipTests < SystemTests
     desc "when passing 1 assertion and failing 1 assertion with a skip call in between"
-
-    let(:test1) {
+    subject {
       Factory.test do
         assert(1 == 1)
         skip
@@ -136,8 +128,7 @@ class Assert::Test
 
   class MixedErrorTests < SystemTests
     desc "when passing 1 assertion and failing 1 assertion with an exception raised in between"
-
-    let(:test1) {
+    subject {
       Factory.test do
         assert(1 == 1)
         raise Exception, "something errored"
@@ -168,8 +159,7 @@ class Assert::Test
 
   class MixedPassTests < SystemTests
     desc "when passing 1 assertion and failing 1 assertion with a pass call in between"
-
-    let(:test1) {
+    subject {
       Factory.test do
         assert(1 == 1)
         pass
@@ -196,8 +186,7 @@ class Assert::Test
 
   class MixedFailTests < SystemTests
     desc "when failing 1 assertion and passing 1 assertion with a fail call in between"
-
-    let(:test1) {
+    subject {
       Factory.test do
         assert(1 == 0)
         fail
@@ -224,8 +213,7 @@ class Assert::Test
 
   class MixedFlunkTests < SystemTests
     desc "has failing 1 assertion and passing 1 assertion with a flunk call in between"
-
-    let(:test1) {
+    subject {
       Factory.test do
         assert(1 == 0)
         flunk
@@ -252,6 +240,9 @@ class Assert::Test
 
   class WithSetupsTests < SystemTests
     desc "that has setup logic"
+    subject {
+      Factory.test("t", Factory.context_info(context_class1)) { pass "TEST" }
+    }
 
     let(:context_class1) {
       Factory.context_class do
@@ -260,9 +251,6 @@ class Assert::Test
         # test/unit style
         def setup; pass "test/unit style setup"; end
       end
-    }
-    let(:test1) {
-      Factory.test("t", Factory.context_info(context_class1)) { pass "TEST" }
     }
 
     should "execute all setup logic when run" do
@@ -275,6 +263,9 @@ class Assert::Test
 
   class WithTeardownsTests < SystemTests
     desc "that has teardown logic"
+    subject {
+      Factory.test("t", Factory.context_info(context_class1)) { pass "TEST" }
+    }
 
     let(:context_class1) {
       Factory.context_class do
@@ -283,9 +274,6 @@ class Assert::Test
         # test/unit style
         def teardown; pass "test/unit style teardown"; end
       end
-    }
-    let(:test1) {
-      Factory.test("t", Factory.context_info(context_class1)) { pass "TEST" }
     }
 
     should "execute all teardown logic when run" do
@@ -298,6 +286,9 @@ class Assert::Test
 
   class WithAroundsTests < SystemTests
     desc "that has around logic (in addition to setups/teardowns)"
+    subject {
+      Factory.test("t", Factory.context_info(context_class1)) { pass "TEST" }
+    }
 
     let(:parent_context_class1) {
       Factory.modes_off_context_class do
@@ -327,9 +318,6 @@ class Assert::Test
         end
         teardown { pass "child teardown2" }
       end
-    }
-    let(:test1) {
-      Factory.test("t", Factory.context_info(context_class1)) { pass "TEST" }
     }
 
     should "run the arounds outside of the setups/teardowns/test" do

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -7,7 +7,9 @@ require "much-stub"
 module Assert
   class UnitTests < Assert::Context
     desc "Assert"
-    subject { Assert }
+    subject { unit_class }
+
+    let(:unit_class) { Assert }
 
     should have_imeths :config, :configure, :view, :suite, :runner
     should have_imeths :stubs, :stub, :unstub, :unstub!, :stub_send

--- a/test/unit/assertions/assert_block_tests.rb
+++ b/test/unit/assertions/assert_block_tests.rb
@@ -6,16 +6,15 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_block`"
-    subject { test1 }
-
-    let(:desc1) { "assert block fail desc" }
-    let(:test1) {
+    subject {
       desc = desc1
       Factory.test do
         assert_block { true }        # pass
         assert_block(desc) { false } # fail
       end
     }
+
+    let(:desc1) { "assert block fail desc" }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -33,16 +32,15 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_block`"
-    subject { test1 }
-
-    let(:desc1) { "assert not block fail desc" }
-    let(:test1) {
+    subject {
       desc = desc1
       Factory.test do
         assert_not_block(desc) { true } # fail
         assert_not_block { false }      # pass
       end
     }
+
+    let(:desc1) { "assert not block fail desc" }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)

--- a/test/unit/assertions/assert_empty_tests.rb
+++ b/test/unit/assertions/assert_empty_tests.rb
@@ -8,18 +8,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_empty`"
-    subject { test1 }
-
-    let(:desc1) { "assert empty fail desc" }
-    let(:args1) { [[1], desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_empty([])    # pass
         assert_empty(*args) # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert empty fail desc" }
+    let(:args1) { [[1], desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -38,18 +37,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_empty`"
-    subject { test1 }
-
-    let(:desc1) { "assert not empty fail desc" }
-    let(:args1) { [[], desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_not_empty([1])   # pass
         assert_not_empty(*args) # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert not empty fail desc" }
+    let(:args1) { [[], desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)

--- a/test/unit/assertions/assert_equal_tests.rb
+++ b/test/unit/assertions/assert_equal_tests.rb
@@ -8,18 +8,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_equal`"
-    subject { test1 }
-
-    let(:desc1) { "assert equal fail desc" }
-    let(:args1) { ["1", "2", desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_equal(1, 1)  # pass
         assert_equal(*args) # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert equal fail desc" }
+    let(:args1) { ["1", "2", desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -39,18 +38,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_equal`"
-    subject { test1 }
-
-    let(:desc1) { "assert not equal fail desc" }
-    let(:args1) { ["1", "1", desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_not_equal(*args) # fail
         assert_not_equal(1, 2)  # pass
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert not equal fail desc" }
+    let(:args1) { ["1", "1", desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -103,9 +101,7 @@ module Assert::Assertions
 
   class AssertEqualDiffTests < DiffTests
     desc "`assert_equal`"
-    subject { test1 }
-
-    let(:test1) {
+    subject {
       exp_obj, act_obj = exp_obj1, act_obj1
       Factory.test(config1) do
         assert_equal(exp_obj, act_obj)
@@ -124,9 +120,7 @@ module Assert::Assertions
 
   class AssertNotEqualDiffTests < DiffTests
     desc "`assert_not_equal`"
-    subject { test1 }
-
-    let(:test1) {
+    subject {
       exp_obj = exp_obj1
       Factory.test(config1) do
         assert_not_equal(exp_obj, exp_obj)

--- a/test/unit/assertions/assert_file_exists_tests.rb
+++ b/test/unit/assertions/assert_file_exists_tests.rb
@@ -9,18 +9,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_file_exists`"
-    subject { test1 }
-
-    let(:desc1) { "assert file exists fail desc" }
-    let(:args1) { ["/a/path/to/some/file/that/no/exists", desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_file_exists(__FILE__) # pass
         assert_file_exists(*args)    # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert file exists fail desc" }
+    let(:args1) { ["/a/path/to/some/file/that/no/exists", desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -38,18 +37,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_file_exists`"
-    subject { test1 }
-
-    let(:desc1) { "assert not file exists fail desc" }
-    let(:args1) { [__FILE__, desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_not_file_exists("/file/path") # pass
         assert_not_file_exists(*args)        # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert not file exists fail desc" }
+    let(:args1) { [__FILE__, desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)

--- a/test/unit/assertions/assert_includes_tests.rb
+++ b/test/unit/assertions/assert_includes_tests.rb
@@ -8,18 +8,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_includes`"
-    subject { test1 }
-
-    let(:desc1) { "assert includes fail desc" }
-    let(:args1) { [2, [1], desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_includes(1, [1]) # pass
         assert_includes(*args)  # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert includes fail desc" }
+    let(:args1) { [2, [1], desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -40,18 +39,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_included`"
-    subject { test1 }
-
-    let(:desc1) { "assert not included fail desc" }
-    let(:args1) { [1, [1], desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_not_included(2, [1]) # pass
         assert_not_included(*args)  # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert not included fail desc" }
+    let(:args1) { [1, [1], desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)

--- a/test/unit/assertions/assert_instance_of_tests.rb
+++ b/test/unit/assertions/assert_instance_of_tests.rb
@@ -8,18 +8,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_instance_of`"
-    subject { test1 }
-
-    let(:desc1) { "assert instance of fail desc" }
-    let(:args1) { [Array, "object", desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_instance_of(String, "object") # pass
         assert_instance_of(*args)            # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert instance of fail desc" }
+    let(:args1) { [Array, "object", desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -39,18 +38,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_instance_of`"
-    subject { test1 }
-
-    let(:desc1) { "assert not instance of fail desc" }
-    let(:args1) { [String, "object", desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_not_instance_of(*args)           # fail
         assert_not_instance_of(Array, "object") # pass
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert not instance of fail desc" }
+    let(:args1) { [String, "object", desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)

--- a/test/unit/assertions/assert_kind_of_tests.rb
+++ b/test/unit/assertions/assert_kind_of_tests.rb
@@ -8,18 +8,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_kind_of`"
-    subject { test1 }
-
-    let(:desc1) { "assert kind of fail desc" }
-    let(:args1) { [Array, "object", desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_kind_of(String, "object") # pass
         assert_kind_of(*args)            # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert kind of fail desc" }
+    let(:args1) { [Array, "object", desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -39,18 +38,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_kind_of`"
-    subject { test1 }
-
-    let(:desc1) { "assert not kind of fail desc" }
-    let(:args1) { [String, "object", desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_not_kind_of(*args)           # fail
         assert_not_kind_of(Array, "object") # pass
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert not kind of fail desc" }
+    let(:args1) { [String, "object", desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)

--- a/test/unit/assertions/assert_match_tests.rb
+++ b/test/unit/assertions/assert_match_tests.rb
@@ -8,18 +8,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_match`"
-    subject { test1 }
-
-    let(:desc1) { "assert match fail desc" }
-    let(:args1) { ["not", "a string", desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_match(/a/, "a string") # pass
         assert_match(*args)           # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert match fail desc" }
+    let(:args1) { ["not", "a string", desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -39,18 +38,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_match`"
-    subject { test1 }
-
-    let(:desc1) { "assert not match fail desc" }
-    let(:args1) { [/a/, "a string", desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_not_match(*args)             # fail
         assert_not_match("not", "a string") # pass
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert not match fail desc" }
+    let(:args1) { [/a/, "a string", desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)

--- a/test/unit/assertions/assert_nil_tests.rb
+++ b/test/unit/assertions/assert_nil_tests.rb
@@ -8,18 +8,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_nil`"
-    subject { test1 }
-
-    let(:desc1) { "assert nil empty fail desc" }
-    let(:args1) { [1, desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_nil(nil)   # pass
         assert_nil(*args) # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert nil empty fail desc" }
+    let(:args1) { [1, desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -37,18 +36,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_nil`"
-    subject { test1 }
-
-    let(:desc1) { "assert not nil empty fail desc" }
-    let(:args1) { [nil, desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_not_nil(1)     # pass
         assert_not_nil(*args) # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert not nil empty fail desc" }
+    let(:args1) { [nil, desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)

--- a/test/unit/assertions/assert_raises_tests.rb
+++ b/test/unit/assertions/assert_raises_tests.rb
@@ -6,10 +6,7 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_raises`"
-    subject { test1 }
-
-    let(:desc1) { "assert raises fail desc" }
-    let(:test1) {
+    subject {
       desc = desc1
       Factory.test do
         assert_raises(StandardError, RuntimeError) { raise(StandardError) }    # pass
@@ -19,6 +16,8 @@ module Assert::Assertions
         assert_raises(desc) { true }                                           # fail
       end
     }
+
+    let(:desc1) { "assert raises fail desc" }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -62,10 +61,7 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_nothing_raised`"
-    subject { test1 }
-
-    let(:desc1) { "assert nothing raised fail desc" }
-    let(:test1) {
+    subject {
       desc = desc1
       Factory.test do
         assert_nothing_raised(StandardError, RuntimeError, desc) { raise(StandardError) } # fail
@@ -74,6 +70,8 @@ module Assert::Assertions
         assert_nothing_raised { true }                                                    # pass
       end
     }
+
+    let(:desc1) { "assert nothing raised fail desc" }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)

--- a/test/unit/assertions/assert_respond_to_tests.rb
+++ b/test/unit/assertions/assert_respond_to_tests.rb
@@ -8,18 +8,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_respond_to`"
-    subject { test1 }
-
-    let(:desc1) { "assert respond to fail desc" }
-    let(:args1) { [:abs, "1", desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_respond_to(:abs, 1) # pass
         assert_respond_to(*args)   # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert respond to fail desc" }
+    let(:args1) { [:abs, "1", desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -40,18 +39,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_respond_to`"
-    subject { test1 }
-
-    let(:desc1) { "assert not respond to fail desc" }
-    let(:args1) { [:abs, 1, desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_not_respond_to(*args)     # fail
         assert_not_respond_to(:abs, "1") # pass
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert not respond to fail desc" }
+    let(:args1) { [:abs, 1, desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)

--- a/test/unit/assertions/assert_same_tests.rb
+++ b/test/unit/assertions/assert_same_tests.rb
@@ -8,13 +8,7 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_same`"
-    subject { test1 }
-
-    let(:class1) { Class.new }
-    let(:object1) { class1.new }
-    let(:desc1) { "assert same fail desc" }
-    let(:args1) { [object1, class1.new, desc1] }
-    let(:test1) {
+    subject {
       args   = args1
       object = object1
       Factory.test do
@@ -22,7 +16,12 @@ module Assert::Assertions
         assert_same(*args)          # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:class1) { Class.new }
+    let(:object1) { class1.new }
+    let(:desc1) { "assert same fail desc" }
+    let(:args1) { [object1, class1.new, desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -45,13 +44,7 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_same`"
-    subject { test1 }
-
-    let(:class1) { Class.new }
-    let(:object1) { class1.new }
-    let(:desc1) { "assert not same fail desc" }
-    let(:args1) { [object1, object1, desc1] }
-    let(:test1) {
+    subject {
       args   = args1
       object = object1
       klass  = class1
@@ -60,7 +53,12 @@ module Assert::Assertions
         assert_not_same(object, klass.new) # pass
       end
     }
-    let(:config1) { test1.config }
+
+    let(:class1) { Class.new }
+    let(:object1) { class1.new }
+    let(:desc1) { "assert not same fail desc" }
+    let(:args1) { [object1, object1, desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -98,9 +96,7 @@ module Assert::Assertions
 
   class AssertSameDiffTests < DiffTests
     desc "`assert_same`"
-    subject { test1 }
-
-    let(:test1) {
+    subject {
       exp_obj, act_obj = exp_obj1, act_obj1
       Factory.test(config1) do
         assert_same(exp_obj, act_obj)
@@ -122,9 +118,7 @@ module Assert::Assertions
 
   class AssertNotSameDiffTests < DiffTests
     desc "`assert_not_same`"
-    subject { test1 }
-
-    let(:test1) {
+    subject {
       act_obj = act_obj1
       Factory.test(config1) do
         assert_not_same(act_obj, act_obj)

--- a/test/unit/assertions/assert_true_false_tests.rb
+++ b/test/unit/assertions/assert_true_false_tests.rb
@@ -8,18 +8,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_true`"
-    subject { test1 }
-
-    let(:desc1) { "assert true fail desc" }
-    let(:args1) { ["whatever", desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_true(true)  # pass
         assert_true(*args) # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert true fail desc" }
+    let(:args1) { ["whatever", desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -37,18 +36,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_true`"
-    subject { test1 }
-
-    let(:desc1) { "assert not true fail desc" }
-    let(:args1) { [true, desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_not_true(false) # pass
         assert_not_true(*args) # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert not true fail desc" }
+    let(:args1) { [true, desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -66,18 +64,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_false`"
-    subject { test1 }
-
-    let(:desc1) { "assert false fail desc" }
-    let(:args1) { ["whatever", desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_false(false) # pass
         assert_false(*args) # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert false fail desc" }
+    let(:args1) { ["whatever", desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)
@@ -95,18 +92,17 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "`assert_not_false`"
-    subject { test1 }
-
-    let(:desc1) { "assert not false fail desc" }
-    let(:args1) { [false, desc1] }
-    let(:test1) {
+    subject {
       args = args1
       Factory.test do
         assert_not_false(true)  # pass
         assert_not_false(*args) # fail
       end
     }
-    let(:config1) { test1.config }
+
+    let(:desc1) { "assert not false fail desc" }
+    let(:args1) { [false, desc1] }
+    let(:config1) { subject.config }
 
     should "produce results as expected" do
       subject.run(&test_run_callback)

--- a/test/unit/assertions_tests.rb
+++ b/test/unit/assertions_tests.rb
@@ -6,11 +6,10 @@ module Assert::Assertions
     include Assert::Test::TestHelpers
 
     desc "Assert::Context"
-    subject { context1 }
+    subject { context_class1.new(test1, test1.config, proc { |r| }) }
 
     let(:context_class1) { Factory.modes_off_context_class }
     let(:test1) { Factory.test }
-    let(:context1) { context_class1.new(test1, test1.config, proc { |r| }) }
 
     should have_imeths :assert_block, :assert_not_block, :refute_block
     should have_imeths :assert_raises, :assert_not_raises

--- a/test/unit/config_helpers_tests.rb
+++ b/test/unit/config_helpers_tests.rb
@@ -6,20 +6,24 @@ require "assert/config"
 module Assert::ConfigHelpers
   class UnitTests < Assert::Context
     desc "Assert::ConfigHelpers"
-    subject { helpers1 }
+    subject { unit_class }
 
-    let(:helpers_class1) {
+    let(:unit_class) {
       Class.new do
         include Assert::ConfigHelpers
 
         def config
           # use the assert config since it has tests, contexts, etc
-          # also maybe use a fresh config that is empty
+          # also use a fresh config that is empty
           @config ||= [Assert.config, Assert::Config.new].sample
         end
       end
     }
-    let(:helpers1) { helpers_class1.new }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new }
 
     should have_imeths :runner, :suite, :view
     should have_imeths :runner_seed, :single_test?, :single_test_file_line

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -10,9 +10,14 @@ require "assert/runner"
 class Assert::Config
   class UnitTests < Assert::Context
     desc "Assert::Config"
-    subject { config1 }
+    subject { unit_class }
 
-    let(:config1) { Assert::Config.new }
+    let(:unit_class) { Assert::Config }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new }
 
     should have_imeths :view, :suite, :runner
     should have_imeths :test_dir, :test_helper, :test_file_suffixes

--- a/test/unit/context/setup_dsl_tests.rb
+++ b/test/unit/context/setup_dsl_tests.rb
@@ -4,10 +4,9 @@ require "assert/context/setup_dsl"
 module Assert::Context::SetupDSL
   class UnitTests < Assert::Context
     desc "Assert::Context::SetupDSL"
-    subject { context_class1 }
+    subject { Factory.modes_off_context_class }
 
     let(:block1) { ::Proc.new {} }
-    let(:context_class1) { Factory.modes_off_context_class }
   end
 
   class SetupTeardownOnceMethodsTests < UnitTests
@@ -49,8 +48,9 @@ module Assert::Context::SetupDSL
   end
 
   class ParentContextClassTests < UnitTests
+    subject { Factory.modes_off_context_class(parent_class1) }
+
     let(:parent_class1)  { Factory.modes_off_context_class }
-    let(:context_class1) { Factory.modes_off_context_class(parent_class1) }
   end
 
   class SetupTeardownMultipleTests < ParentContextClassTests

--- a/test/unit/context/subject_dsl_tests.rb
+++ b/test/unit/context/subject_dsl_tests.rb
@@ -4,10 +4,9 @@ require "assert/context/subject_dsl"
 module Assert::Context::SubjectDSL
   class UnitTests < Assert::Context
     desc "Assert::Context::SubjectDSL"
-    subject { context_class1 }
+    subject { Factory.modes_off_context_class(parent_class1) }
 
     let(:parent_class1)  { Factory.modes_off_context_class }
-    let(:context_class1) { Factory.modes_off_context_class(parent_class1) }
     let(:subject_block1) { Proc.new {} }
   end
 

--- a/test/unit/context/suite_dsl_tests.rb
+++ b/test/unit/context/suite_dsl_tests.rb
@@ -6,10 +6,9 @@ require "assert/suite"
 module Assert::Context::SuiteDSL
   class UnitTests < Assert::Context
     desc "Assert::Context::SuiteDSL"
-    subject { context_class1 }
+    subject { Factory.context_class(parent_class1) }
 
     let(:parent_class1)  { Factory.context_class }
-    let(:context_class1) { Factory.context_class(parent_class1) }
     let(:custom_suite1)  { Factory.modes_off_suite }
 
     should "use `Assert.suite` by default" do

--- a/test/unit/context_info_tests.rb
+++ b/test/unit/context_info_tests.rb
@@ -6,13 +6,20 @@ require "assert/context"
 class Assert::ContextInfo
   class UnitTests < Assert::Context
     desc "Assert::ContextInfo"
+    subject { unit_class }
+
+    let(:unit_class) { Assert::ContextInfo }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new(context1, nil, @caller.first) }
+
     setup do
       @caller = caller
     end
-    subject { info1 }
 
     let(:context1) { Assert::Context }
-    let(:info1)    { Assert::ContextInfo.new(context1, nil, @caller.first) }
 
     should have_readers :called_from, :klass, :file
     should have_imeths :test_name

--- a/test/unit/default_suite_tests.rb
+++ b/test/unit/default_suite_tests.rb
@@ -6,12 +6,18 @@ require "assert/suite"
 class Assert::DefaultSuite
   class UnitTests < Assert::Context
     desc "Assert::DefaultSuite"
-    subject { suite1 }
+    subject { unit_class }
+
+    let(:unit_class) { Assert::DefaultSuite }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new(config1) }
 
     let(:ci1)     { Factory.context_info(Factory.modes_off_context_class) }
     let(:test1)   { Factory.test(Factory.string, ci1) { } }
     let(:config1) { Factory.modes_off_config }
-    let(:suite1)  { Assert::DefaultSuite.new(config1) }
 
     should "be a Suite" do
       assert_that(subject).is_kind_of(Assert::Suite)

--- a/test/unit/factory_tests.rb
+++ b/test/unit/factory_tests.rb
@@ -6,7 +6,9 @@ require "much-factory"
 module Assert::Factory
   class UnitTests < Assert::Context
     desc "Assert::Factory"
-    subject { Assert::Factory }
+    subject { unit_class }
+
+    let(:unit_class) { Assert::Factory }
 
     should "include and extend MuchFactory" do
       assert_that(subject).includes(MuchFactory)

--- a/test/unit/file_line_tests.rb
+++ b/test/unit/file_line_tests.rb
@@ -4,7 +4,9 @@ require "assert/file_line"
 class Assert::FileLine
   class UnitTests < Assert::Context
     desc "Assert::FileLine"
-    subject { Assert::FileLine }
+    subject { unit_class }
+
+    let(:unit_class) { Assert::FileLine }
 
     let(:file1) { "#{Factory.path}_tests.rb" }
     let(:line1) { Factory.integer.to_s }
@@ -43,9 +45,7 @@ class Assert::FileLine
 
   class InitTests < UnitTests
     desc "when init"
-    subject { file_line1 }
-
-    let(:file_line1) { Assert::FileLine.new(file1, line1) }
+    subject { unit_class.new(file1, line1) }
 
     should have_readers :file, :line
 
@@ -53,11 +53,11 @@ class Assert::FileLine
       assert_that(subject.file).equals(file1)
       assert_that(subject.line).equals(line1)
 
-      file_line = Assert::FileLine.new(file1)
+      file_line = unit_class.new(file1)
       assert_that(file_line.file).equals(file1)
       assert_that(file_line.line).equals("")
 
-      file_line = Assert::FileLine.new
+      file_line = unit_class.new
       assert_that(file_line.file).equals("")
       assert_that(file_line.line).equals("")
     end
@@ -67,8 +67,8 @@ class Assert::FileLine
     end
 
     should "know if it is equal to another file line" do
-      yes = Assert::FileLine.new(file1, line1)
-      no = Assert::FileLine.new("#{Factory.path}_tests.rb", Factory.integer.to_s)
+      yes = unit_class.new(file1, line1)
+      no = unit_class.new("#{Factory.path}_tests.rb", Factory.integer.to_s)
 
       assert_that(subject).equals(yes)
       assert_not_equal no,  subject

--- a/test/unit/macro_tests.rb
+++ b/test/unit/macro_tests.rb
@@ -4,9 +4,14 @@ require "assert/macro"
 class Assert::Macro
   class UnitTests < Assert::Context
     desc "Assert::Macro"
-    subject { macro1 }
+    subject { unit_class }
 
-    let(:macro1) { Assert::Macro.new {} }
+    let(:unit_class) { Assert::Macro }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new {} }
 
     should "have an accessor for its (optional) name" do
       assert_that(subject).responds_to(:name)
@@ -14,11 +19,11 @@ class Assert::Macro
     end
 
     should "default its name if no given" do
-      assert_that((Assert::Macro.new {}).name).equals("run this macro")
+      assert_that((unit_class.new {}).name).equals("run this macro")
     end
 
     should "initialize with a given name" do
-      assert_that((Assert::Macro.new("test") {}).name).equals("test")
+      assert_that((unit_class.new("test") {}).name).equals("test")
     end
 
     should "be a Proc" do
@@ -26,7 +31,7 @@ class Assert::Macro
     end
 
     should "complain if you create a macro without a block" do
-      assert_that(-> { Assert::Macro.new }).raises(ArgumentError)
+      assert_that(-> { unit_class.new }).raises(ArgumentError)
     end
   end
 

--- a/test/unit/result_tests.rb
+++ b/test/unit/result_tests.rb
@@ -6,7 +6,9 @@ require "assert/file_line"
 module Assert::Result
   class UnitTests < Assert::Context
     desc "Assert::Result"
-    subject { Assert::Result }
+    subject { unit_class }
+
+    let(:unit_class) { Assert::Result }
 
     let(:test1) { Factory.test("a test name") }
 
@@ -32,9 +34,9 @@ module Assert::Result
     end
   end
 
-  class BaseTests < UnitTests
-    desc "Base"
-    subject { result1 }
+  class InitBaseTests < UnitTests
+    desc "Base when init"
+    subject { Base.new(given_data1) }
 
     let(:given_data1) {
       {
@@ -47,7 +49,6 @@ module Assert::Result
         :backtrace      => Backtrace.new(Factory.backtrace)
       }
     }
-    let(:result1) { Base.new(given_data1) }
 
     should have_cmeths :type, :name, :for_test
     should have_imeths :type, :name, :test_name, :test_file_line
@@ -226,11 +227,9 @@ module Assert::Result
     end
   end
 
-  class PassTests < UnitTests
-    desc "Pass"
-    subject { result1 }
-
-    let(:result1) { Pass.new({}) }
+  class InitPassTests < UnitTests
+    desc "Pass when init"
+    subject { Pass.new({}) }
 
     should "know its type/name" do
       assert_that(subject.type).equals(:pass)
@@ -239,11 +238,9 @@ module Assert::Result
     end
   end
 
-  class IgnoreTests < UnitTests
-    desc "Ignore"
-    subject { result1 }
-
-    let(:result1) { Ignore.new({}) }
+  class InitIgnoreTests < UnitTests
+    desc "Ignore when init"
+    subject { Ignore.new({}) }
 
     should "know its type/name" do
       assert_that(subject.type).equals(:ignore)
@@ -252,8 +249,8 @@ module Assert::Result
     end
   end
 
-  class HaltingTestResultErrorTests < UnitTests
-    desc "HaltingTestResultError"
+  class InitHaltingTestResultErrorTests < UnitTests
+    desc "HaltingTestResultError when init"
     subject { HaltingTestResultError.new }
 
     should have_accessors :assert_with_bt
@@ -263,20 +260,18 @@ module Assert::Result
     end
   end
 
-  class TestFailureTests < UnitTests
-    desc "TestFailure"
-    subject { TestFailure }
+  class InitTestFailureTests < UnitTests
+    desc "TestFailure when init"
+    subject { TestFailure.new }
 
     should "be a halting test result error" do
-      assert_that(subject.new).is_kind_of(HaltingTestResultError)
+      assert_that(subject).is_kind_of(HaltingTestResultError)
     end
   end
 
-  class FailTests < UnitTests
-    desc "Fail"
-    subject { result1 }
-
-    let(:result1) { Fail.new({}) }
+  class InitFailTests < UnitTests
+    desc "Fail when init"
+    subject { Fail.new({}) }
 
     should "know its type/name" do
       assert_that(subject.type).equals(:fail)
@@ -311,20 +306,18 @@ module Assert::Result
     end
   end
 
-  class TestSkippedTests < UnitTests
-    desc "TestSkipped"
-    subject { TestSkipped }
+  class InitTestSkippedTests < UnitTests
+    desc "TestSkipped when init"
+    subject { TestSkipped.new }
 
     should "be a halting test result error" do
-      assert_that(subject.new).is_kind_of(HaltingTestResultError)
+      assert_that(subject).is_kind_of(HaltingTestResultError)
     end
   end
 
-  class SkipTests < UnitTests
-    desc "Skip"
-    subject { result1 }
-
-    let(:result1) { Skip.new({}) }
+  class InitSkipTests < UnitTests
+    desc "Skip when init"
+    subject { Skip.new({}) }
 
     should "know its type/name" do
       assert_that(subject.type).equals(:skip)
@@ -359,11 +352,9 @@ module Assert::Result
     end
   end
 
-  class ErrorTests < UnitTests
-    desc "Error"
-    subject { result1 }
-
-    let(:result1) { Error.new({}) }
+  class InitErrorTests < UnitTests
+    desc "Error when init"
+    subject { Error.new({}) }
 
     should "know its class-level type/name" do
       assert_that(subject.class.type).equals(:error)
@@ -388,11 +379,9 @@ module Assert::Result
     end
   end
 
-  class BacktraceTests < UnitTests
-    desc "Backtrace"
-    subject { backtrace1 }
-
-    let(:backtrace1) { Backtrace.new(Factory.backtrace) }
+  class InitBacktraceTests < UnitTests
+    desc "Backtrace when init"
+    subject { Backtrace.new(Factory.backtrace) }
 
     should have_cmeths :parse, :to_s
     should have_imeths :filtered

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -6,10 +6,11 @@ require "assert/test"
 require "test/support/inherited_stuff"
 
 class Assert::Suite
-
   class UnitTests < Assert::Context
     desc "Assert::Suite"
-    subject { Assert::Suite }
+    subject { unit_class }
+
+    let(:unit_class) { Assert::Suite }
 
     should "include the config helpers" do
       assert_that(subject).includes(Assert::ConfigHelpers)
@@ -23,10 +24,9 @@ class Assert::Suite
 
   class InitTests < UnitTests
     desc "when init"
-    subject { suite1 }
+    subject { unit_class.new(config1) }
 
     let(:config1) { Factory.modes_off_config }
-    let(:suite1)  { Assert::Suite.new(config1) }
 
     should have_readers :config, :test_methods, :setups, :teardowns
     should have_accessors :start_time, :end_time
@@ -84,8 +84,8 @@ class Assert::Suite
 
     should "add setup procs" do
       status = nil
-      suite1.setup{ status = "setups" }
-      suite1.startup{ status += " have been run" }
+      subject.setup{ status = "setups" }
+      subject.startup{ status += " have been run" }
 
       assert_that(subject.setups.count).equals(2)
       subject.setups.each(&:call)
@@ -94,8 +94,8 @@ class Assert::Suite
 
     should "add teardown procs" do
       status = nil
-      suite1.teardown{ status = "teardowns" }
-      suite1.shutdown{ status += " have been run" }
+      subject.teardown{ status = "teardowns" }
+      subject.shutdown{ status += " have been run" }
 
       assert_that(subject.teardowns.count).equals(2)
       subject.teardowns.each(&:call)
@@ -107,7 +107,7 @@ class Assert::Suite
     desc "with tests loaded"
 
     setup do
-      tests1.each{ |test| suite1.on_test(test) }
+      tests1.each{ |test| subject.on_test(test) }
     end
 
     let(:ci1) { proc{ Factory.context_info(Factory.modes_off_context_class) } }

--- a/test/unit/utils_tests.rb
+++ b/test/unit/utils_tests.rb
@@ -7,7 +7,9 @@ require "assert/config"
 module Assert::Utils
   class UnitTests < Assert::Context
     desc "Assert::Utils"
-    subject { Assert::Utils }
+    subject { unit_class }
+
+    let(:unit_class) { Assert::Utils }
 
     let(:objs1) { [1, "hi there", Hash.new, [:a, :b]] }
 

--- a/test/unit/view_helpers_tests.rb
+++ b/test/unit/view_helpers_tests.rb
@@ -10,10 +10,9 @@ require "assert/view"
 module Assert::ViewHelpers
   class UnitTests < Assert::Context
     desc "Assert::ViewHelpers"
-    subject { helpers_class1 }
+    subject { unit_class }
 
-    let(:test_opt_val1) { Factory.string }
-    let(:helpers_class1) {
+    let(:unit_class) {
       test_opt_val = test_opt_val1
       Class.new do
         include Assert::ViewHelpers
@@ -28,6 +27,8 @@ module Assert::ViewHelpers
       end
     }
 
+    let(:test_opt_val1) { Factory.string }
+
     should have_imeths :option
 
     should "include the config helpers" do
@@ -35,7 +36,7 @@ module Assert::ViewHelpers
     end
 
     should "write option values" do
-      helpers = helpers_class1.new
+      helpers = unit_class.new
       assert_that(helpers.test_opt).equals(test_opt_val1)
 
       new_val = Factory.integer
@@ -50,9 +51,7 @@ module Assert::ViewHelpers
 
   class InitTests < UnitTests
     desc "when init"
-    subject { helpers1 }
-
-    let(:helpers1) { helpers_class1.new }
+    subject { unit_class.new }
 
     should have_imeths :captured_output, :re_run_test_cmd
     should have_imeths :tests_to_run_count_statement, :result_count_statement

--- a/test/unit/view_tests.rb
+++ b/test/unit/view_tests.rb
@@ -9,7 +9,9 @@ require "assert/view_helpers"
 class Assert::View
   class UnitTests < Assert::Context
     desc "Assert::View"
-    subject { Assert::View }
+    subject { unit_class }
+
+    let(:unit_class) { Assert::View }
 
     should have_instance_method :require_user_view
 
@@ -24,11 +26,10 @@ class Assert::View
 
   class InitTests < UnitTests
     desc "when init"
-    subject { view1 }
+    subject { Assert::View.new(config1, io1) }
 
     let(:io1)     { StringIO.new("", "w+") }
     let(:config1) { Factory.modes_off_config }
-    let(:view1)   { Assert::View.new(config1, io1) }
 
     should have_readers :config
     should have_imeths :view, :is_tty?


### PR DESCRIPTION
This updates the `Assert::Context#subject` to memoize its return
values. I can't remember why we never memoized the subject before
but now that we have memoized `let`s, it feels awkward/unexpected
to not have memoized `subject`s.

This also updates the test suite to make use of the memoized
subjects. We had many let's that were only there to be memoized
subject values. They are unnecessary if subjects are implicitly
memoized.

Note: this also updates the instance variable name used to memoize
`let`s to use the `@__assert_{whatever}__` naming convention. This
keeps `let`s from polluting the instance variable namespace and
conflicting with instance variables created in `setup` blocks.

Note: I chose to switch-to/use `instance_variable_defined?` b/c
both `subject`s and `let`s can be `nil` so this isn't a good
memoization signal. A better signal is whether an instance method
is defined or not. This allows `nil` values to get memoized and
not re-processed.