### PR TITLE
remove Test::Unit; add new assertion helpers; allow passing block actual values via block slot

### DIFF
--- a/lib/assert/actual_value.rb
+++ b/lib/assert/actual_value.rb
@@ -2,8 +2,45 @@ require "much-stub"
 
 module Assert; end
 class Assert::ActualValue
-  def initialize(value, context:)
-    @value = value
+  def self.not_given
+    @not_given ||=
+      Class.new {
+        def to_s
+          "Assert::ActualValue.not_given"
+        end
+
+        def blank?
+          true
+        end
+
+        def present?
+          false
+        end
+
+        def ==(other)
+          if other.is_a?(self.class)
+            true
+          else
+            super
+          end
+        end
+
+        def inspect
+          to_s
+        end
+      }.new
+  end
+
+  def self.not_given?(value)
+    value == not_given
+  end
+
+  def self.given?(value)
+    value != not_given
+  end
+
+  def initialize(value = self.class.not_given, context:, &value_block)
+    @value = self.class.given?(value) ? value : value_block
     @context = context
   end
 

--- a/lib/assert/actual_value.rb
+++ b/lib/assert/actual_value.rb
@@ -60,6 +60,14 @@ class Assert::ActualValue
     @context.assert_nothing_raised(*expected_exceptions, &@value)
   end
 
+  def changes(*args)
+    @context.assert_changes(*args, &@value)
+  end
+
+  def does_not_change(*args)
+    @context.assert_not_changes(*args, &@value)
+  end
+
   def is_a_kind_of(expected_class, *args)
     @context.assert_kind_of(expected_class, @value, *args)
   end

--- a/lib/assert/actual_value.rb
+++ b/lib/assert/actual_value.rb
@@ -54,10 +54,12 @@ class Assert::ActualValue
   def is_the_same_as(expected_object, *args)
     @context.assert_same(expected_object, @value, *args)
   end
+  alias_method :is, :is_the_same_as
 
   def is_not_the_same_as(expected_object, *args)
     @context.assert_not_same(expected_object, @value, *args)
   end
+  alias_method :is_not, :is_not_the_same_as
 
   def equals(expected_value, *args)
     @context.assert_equal(expected_value, @value, *args)

--- a/lib/assert/assertions.rb
+++ b/lib/assert/assertions.rb
@@ -198,6 +198,75 @@ module Assert
     alias_method :assert_not_raises, :assert_nothing_raised
     alias_method :assert_not_raise, :assert_nothing_raised
 
+    def assert_changes(
+          ruby_string_to_eval,
+          desc: nil,
+          from: Assert::ActualValue.not_given,
+          to: Assert::ActualValue.not_given,
+          &block
+        )
+      desc_msg = desc ? "#{desc}\n" : ""
+      from_eval = instance_eval(ruby_string_to_eval)
+      if Assert::ActualValue.given?(from)
+        assert_equal(
+          from,
+          from_eval,
+          "#{desc_msg}Expected `#{ruby_string_to_eval}` to change from `#{from.inspect}`."
+        )
+      end
+
+      block.call
+
+      to_eval = instance_eval(ruby_string_to_eval)
+      if Assert::ActualValue.given?(to)
+        assert_equal(
+          to,
+          to_eval,
+          "#{desc_msg}Expected `#{ruby_string_to_eval}` to change to `#{to.inspect}`."
+        )
+      end
+
+      if (
+        Assert::ActualValue.not_given?(from) &&
+        Assert::ActualValue.not_given?(to)
+      )
+        assert_not_equal(
+          from_eval,
+          to_eval,
+          "#{desc_msg}Expected `#{ruby_string_to_eval}` to change; "\
+          "it was `#{from_eval.inspect}` and didn't change."
+        )
+      end
+    end
+
+    def assert_not_changes(
+          ruby_string_to_eval,
+          desc: nil,
+          from: Assert::ActualValue.not_given,
+          &block
+        )
+      desc_msg = desc ? "#{desc}\n" : ""
+      from_eval = instance_eval(ruby_string_to_eval)
+      if Assert::ActualValue.given?(from)
+        assert_equal(
+          from,
+          from_eval,
+          "#{desc_msg}Expected `#{ruby_string_to_eval}` to not change from `#{from.inspect}`."
+        )
+      end
+
+      block.call
+
+      to_eval = instance_eval(ruby_string_to_eval)
+      assert_equal(
+        from_eval,
+        to_eval,
+        "#{desc_msg}Expected `#{ruby_string_to_eval}` to not change; "\
+        "it was `#{from_eval.inspect}` and changed to `#{to_eval.inspect}`."
+      )
+    end
+    alias_method :refute_changes, :assert_not_changes
+
     def assert_respond_to(method, object, desc = nil)
       assert(object.respond_to?(method), desc) do
         "Expected #{Assert::U.show(object, __assert_config__)} (#{object.class})"\

--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -70,8 +70,11 @@ module Assert
     end
     alias_method :refute, :assert_not
 
-    def assert_that(actual_value)
-      Assert::ActualValue.new(actual_value, context: self)
+    def assert_that(
+          actual_value = Assert::ActualValue.not_given,
+          &actual_value_block
+        )
+      Assert::ActualValue.new(actual_value, context: self, &actual_value_block)
     end
 
     # adds a Pass result to the end of the test's results
@@ -80,8 +83,10 @@ module Assert
       if @__assert_pending__ == 0
         capture_result(Assert::Result::Pass, pass_msg)
       else
-        capture_result(Assert::Result::Fail, "Pending pass (make it "\
-                                             "not pending)")
+        capture_result(
+          Assert::Result::Fail,
+          "Pending pass (make it not pending)"
+        )
       end
     end
 

--- a/lib/assert/context.rb
+++ b/lib/assert/context.rb
@@ -13,8 +13,13 @@ require "assert/suite"
 require "assert/utils"
 
 module Assert
+  # A Context is a scope for tests to run in. Contexts have setup and teardown
+  # blocks, subjects, and descriptions. Tests are run in the scope of a Context
+  # instance. Therefore, a Context should have minimal base
+  # logic/methods/instance_vars. The instance should remain pure to not pollute
+  # test scopes.
   class Context
-    # put all logic in DSL methods to keep context instances pure for running tests
+    # Put all logic in DSL methods to keep context instances pure.
     extend SetupDSL
     extend SubjectDSL
     extend SuiteDSL
@@ -23,33 +28,6 @@ module Assert
     include MethodMissing
     include Assert::Assertions
     include Assert::Macros::Methods
-
-    # a Context is a scope for tests to run in.  Contexts have setup and
-    # teardown blocks, subjects, and descriptions.  Tests are run in the
-    # scope of a Context instance.  Therefore, a Context should have
-    # minimal base logic/methods/instance_vars.  The instance should remain
-    # pure to not pollute test scopes.
-
-    # if a test method is added to a context manually (not using a context helper):
-    # capture any context info, build a test obj, and add it to the suite
-    def self.method_added(method_name)
-      if method_name.to_s =~ Suite::TEST_METHOD_REGEX
-        klass_method_name = "#{self}##{method_name}"
-
-        if self.suite.test_methods.include?(klass_method_name)
-          puts "WARNING: redefining "#{klass_method_name}""
-          puts "  from: #{caller_locations(1,1)}"
-        else
-          self.suite.test_methods << klass_method_name
-        end
-
-        self.suite.on_test(Test.for_method(
-          method_name.to_s,
-          ContextInfo.new(self, nil, caller_locations(1,1)),
-          self.suite.config
-        ))
-      end
-    end
 
     def initialize(running_test, config, result_callback)
       @__assert_running_test__ = running_test

--- a/lib/assert/result.rb
+++ b/lib/assert/result.rb
@@ -129,7 +129,11 @@ module Assert::Result
     end
 
     def ==(other_result)
-      self.type == other_result.type && self.message == other_result.message
+      if other_result.is_a?(self.class)
+        self.type == other_result.type && self.message == other_result.message
+      else
+        super
+      end
     end
 
     def inspect

--- a/lib/assert/suite.rb
+++ b/lib/assert/suite.rb
@@ -10,22 +10,19 @@ module Assert
   class Suite
     include Assert::ConfigHelpers
 
-    TEST_METHOD_REGEX = /^test./.freeze
-
     # A suite is a set of tests to run.  When a test class subclasses
     # the Context class, that test class is pushed to the suite.
 
-    attr_reader :config, :test_methods, :setups, :teardowns
+    attr_reader :config, :setups, :teardowns
     attr_accessor :start_time, :end_time
 
     def initialize(config)
-      @config       = config
-      @tests        = []
-      @test_methods = []
-      @setups       = []
-      @teardowns    = []
-      @start_time   = Time.now
-      @end_time     = @start_time
+      @config     = config
+      @tests      = []
+      @setups     = []
+      @teardowns  = []
+      @start_time = Time.now
+      @end_time   = @start_time
     end
 
     def suite; self; end

--- a/lib/assert/test.rb
+++ b/lib/assert/test.rb
@@ -20,14 +20,6 @@ module Assert
       }))
     end
 
-    def self.for_method(method_name, context_info, config)
-      self.new(self.name_file_line_context_data(context_info, method_name).merge({
-        :context_info => context_info,
-        :config       => config,
-        :code         => proc{ self.send(method_name) }
-      }))
-    end
-
     def initialize(build_data = nil)
       @build_data      = build_data || {}
       @result_callback = nil

--- a/test/system/stub_tests.rb
+++ b/test/system/stub_tests.rb
@@ -54,27 +54,27 @@ class Assert::Stub
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :noargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
+      assert_that { Assert.stub(subject, :withargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :withargs).with(1, 2){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :minargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :minargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :withblock).with(1){ } }.raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_that(-> { subject.noargs(1) }).raises
+      assert_that { subject.noargs(1) }.raises
 
-      assert_that(-> { subject.withargs }).raises
-      assert_that(-> { subject.withargs(1, 2) }).raises
+      assert_that { subject.withargs }.raises
+      assert_that { subject.withargs(1, 2) }.raises
 
-      assert_that(-> { subject.minargs }).raises
-      assert_that(-> { subject.minargs(1) }).raises
+      assert_that { subject.minargs }.raises
+      assert_that { subject.minargs(1) }.raises
 
-      assert_that(-> { subject.withblock(1) }).raises
+      assert_that { subject.withblock(1) }.raises
     end
   end
 
@@ -127,27 +127,27 @@ class Assert::Stub
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :noargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
+      assert_that { Assert.stub(subject, :withargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :withargs).with(1, 2){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :minargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :minargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :withblock).with(1){ } }.raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_that(-> { subject.noargs(1) }).raises
+      assert_that { subject.noargs(1) }.raises
 
-      assert_that(-> { subject.withargs }).raises
-      assert_that(-> { subject.withargs(1, 2) }).raises
+      assert_that { subject.withargs }.raises
+      assert_that { subject.withargs(1, 2) }.raises
 
-      assert_that(-> { subject.minargs }).raises
-      assert_that(-> { subject.minargs(1) }).raises
+      assert_that { subject.minargs }.raises
+      assert_that { subject.minargs(1) }.raises
 
-      assert_that(-> { subject.withblock(1) }).raises
+      assert_that { subject.withblock(1) }.raises
     end
   end
 
@@ -200,27 +200,27 @@ class Assert::Stub
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :noargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
+      assert_that { Assert.stub(subject, :withargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :withargs).with(1, 2){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :minargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :minargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :withblock).with(1){ } }.raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_that(-> { subject.noargs(1) }).raises
+      assert_that { subject.noargs(1) }.raises
 
-      assert_that(-> { subject.withargs }).raises
-      assert_that(-> { subject.withargs(1, 2) }).raises
+      assert_that { subject.withargs }.raises
+      assert_that { subject.withargs(1, 2) }.raises
 
-      assert_that(-> { subject.minargs }).raises
-      assert_that(-> { subject.minargs(1) }).raises
+      assert_that { subject.minargs }.raises
+      assert_that { subject.minargs(1) }.raises
 
-      assert_that(-> { subject.withblock(1) }).raises
+      assert_that { subject.withblock(1) }.raises
     end
   end
 
@@ -273,27 +273,27 @@ class Assert::Stub
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :noargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
+      assert_that { Assert.stub(subject, :withargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :withargs).with(1, 2){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :minargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :minargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :withblock).with(1){ } }.raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_that(-> { subject.noargs(1) }).raises
+      assert_that { subject.noargs(1) }.raises
 
-      assert_that(-> { subject.withargs }).raises
-      assert_that(-> { subject.withargs(1, 2) }).raises
+      assert_that { subject.withargs }.raises
+      assert_that { subject.withargs(1, 2) }.raises
 
-      assert_that(-> { subject.minargs }).raises
-      assert_that(-> { subject.minargs(1) }).raises
+      assert_that { subject.minargs }.raises
+      assert_that { subject.minargs(1) }.raises
 
-      assert_that(-> { subject.withblock(1) }).raises
+      assert_that { subject.withblock(1) }.raises
     end
   end
 
@@ -348,27 +348,27 @@ class Assert::Stub
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :noargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
+      assert_that { Assert.stub(subject, :withargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :withargs).with(1, 2){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :minargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :minargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :withblock).with(1){ } }.raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_that(-> { subject.noargs(1) }).raises
+      assert_that { subject.noargs(1) }.raises
 
-      assert_that(-> { subject.withargs }).raises
-      assert_that(-> { subject.withargs(1, 2) }).raises
+      assert_that { subject.withargs }.raises
+      assert_that { subject.withargs(1, 2) }.raises
 
-      assert_that(-> { subject.minargs }).raises
-      assert_that(-> { subject.minargs(1) }).raises
+      assert_that { subject.minargs }.raises
+      assert_that { subject.minargs(1) }.raises
 
-      assert_that(-> { subject.withblock(1) }).raises
+      assert_that { subject.withblock(1) }.raises
     end
   end
 
@@ -421,27 +421,27 @@ class Assert::Stub
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :noargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
+      assert_that { Assert.stub(subject, :withargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :withargs).with(1, 2){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :minargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :minargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :withblock).with(1){ } }.raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_that(-> { subject.noargs(1) }).raises
+      assert_that { subject.noargs(1) }.raises
 
-      assert_that(-> { subject.withargs }).raises
-      assert_that(-> { subject.withargs(1, 2) }).raises
+      assert_that { subject.withargs }.raises
+      assert_that { subject.withargs(1, 2) }.raises
 
-      assert_that(-> { subject.minargs }).raises
-      assert_that(-> { subject.minargs(1) }).raises
+      assert_that { subject.minargs }.raises
+      assert_that { subject.minargs(1) }.raises
 
-      assert_that(-> { subject.withblock(1) }).raises
+      assert_that { subject.withblock(1) }.raises
     end
   end
 
@@ -494,27 +494,27 @@ class Assert::Stub
     end
 
     should "not allow stubbing methods with invalid arity" do
-      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :noargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).raises
+      assert_that { Assert.stub(subject, :withargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :withargs).with(1, 2){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).raises
-      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :minargs).with{ } }.raises
+      assert_that { Assert.stub(subject, :minargs).with(1){ } }.raises
 
-      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).raises
+      assert_that { Assert.stub(subject, :withblock).with(1){ } }.raises
     end
 
     should "not allow calling methods with invalid arity" do
-      assert_that(-> { subject.noargs(1) }).raises
+      assert_that { subject.noargs(1) }.raises
 
-      assert_that(-> { subject.withargs }).raises
-      assert_that(-> { subject.withargs(1, 2) }).raises
+      assert_that { subject.withargs }.raises
+      assert_that { subject.withargs(1, 2) }.raises
 
-      assert_that(-> { subject.minargs }).raises
-      assert_that(-> { subject.minargs(1) }).raises
+      assert_that { subject.minargs }.raises
+      assert_that { subject.minargs(1) }.raises
 
-      assert_that(-> { subject.withblock(1) }).raises
+      assert_that { subject.withblock(1) }.raises
     end
   end
 
@@ -567,27 +567,27 @@ class Assert::Stub
     end
 
     should "allow stubbing methods with invalid arity" do
-      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).does_not_raise
+      assert_that { Assert.stub(subject, :noargs).with(1){ } }.does_not_raise
 
-      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).does_not_raise
-      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).does_not_raise
+      assert_that { Assert.stub(subject, :withargs).with{ } }.does_not_raise
+      assert_that { Assert.stub(subject, :withargs).with(1, 2){ } }.does_not_raise
 
-      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).does_not_raise
-      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).does_not_raise
+      assert_that { Assert.stub(subject, :minargs).with{ } }.does_not_raise
+      assert_that { Assert.stub(subject, :minargs).with(1){ } }.does_not_raise
 
-      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).does_not_raise
+      assert_that { Assert.stub(subject, :withblock).with(1){ } }.does_not_raise
     end
 
     should "allow calling methods with invalid arity" do
-      assert_that(-> { subject.noargs(1) }).does_not_raise
+      assert_that { subject.noargs(1) }.does_not_raise
 
-      assert_that(-> { subject.withargs }).does_not_raise
-      assert_that(-> { subject.withargs(1, 2) }).does_not_raise
+      assert_that { subject.withargs }.does_not_raise
+      assert_that { subject.withargs(1, 2) }.does_not_raise
 
-      assert_that(-> { subject.minargs }).does_not_raise
-      assert_that(-> { subject.minargs(1) }).does_not_raise
+      assert_that { subject.minargs }.does_not_raise
+      assert_that { subject.minargs(1) }.does_not_raise
 
-      assert_that(-> { subject.withblock(1) }).does_not_raise
+      assert_that { subject.withblock(1) }.does_not_raise
     end
   end
 
@@ -640,27 +640,27 @@ class Assert::Stub
     end
 
     should "allow stubbing methods with invalid arity" do
-      assert_that(-> { Assert.stub(subject, :noargs).with(1){ } }).does_not_raise
+      assert_that { Assert.stub(subject, :noargs).with(1){ } }.does_not_raise
 
-      assert_that(-> { Assert.stub(subject, :withargs).with{ } }).does_not_raise
-      assert_that(-> { Assert.stub(subject, :withargs).with(1, 2){ } }).does_not_raise
+      assert_that { Assert.stub(subject, :withargs).with{ } }.does_not_raise
+      assert_that { Assert.stub(subject, :withargs).with(1, 2){ } }.does_not_raise
 
-      assert_that(-> { Assert.stub(subject, :minargs).with{ } }).does_not_raise
-      assert_that(-> { Assert.stub(subject, :minargs).with(1){ } }).does_not_raise
+      assert_that { Assert.stub(subject, :minargs).with{ } }.does_not_raise
+      assert_that { Assert.stub(subject, :minargs).with(1){ } }.does_not_raise
 
-      assert_that(-> { Assert.stub(subject, :withblock).with(1){ } }).does_not_raise
+      assert_that { Assert.stub(subject, :withblock).with(1){ } }.does_not_raise
     end
 
     should "allow calling methods with invalid arity" do
-      assert_that(-> { subject.noargs(1) }).does_not_raise
+      assert_that { subject.noargs(1) }.does_not_raise
 
-      assert_that(-> { subject.withargs }).does_not_raise
-      assert_that(-> { subject.withargs(1, 2) }).does_not_raise
+      assert_that { subject.withargs }.does_not_raise
+      assert_that { subject.withargs(1, 2) }.does_not_raise
 
-      assert_that(-> { subject.minargs }).does_not_raise
-      assert_that(-> { subject.minargs(1) }).does_not_raise
+      assert_that { subject.minargs }.does_not_raise
+      assert_that { subject.minargs(1) }.does_not_raise
 
-      assert_that(-> { subject.withblock(1) }).does_not_raise
+      assert_that { subject.withblock(1) }.does_not_raise
     end
   end
 

--- a/test/unit/actual_value_tests.rb
+++ b/test/unit/actual_value_tests.rb
@@ -18,6 +18,7 @@ class Assert::ActualValue
 
     should have_imeths :returns_true, :does_not_return_true
     should have_imeths :raises, :does_not_raise
+    should have_imeths :changes, :does_not_change
     should have_imeths :is_a_kind_of, :is_not_a_kind_of
     should have_imeths :is_kind_of, :is_not_kind_of
     should have_imeths :is_an_instance_of, :is_not_an_instance_of
@@ -73,6 +74,24 @@ class Assert::ActualValue
       assert_calls(
         :assert_nothing_raised,
         when_calling: :does_not_raise,
+        on_value: -> {}
+      ) do |value, call|
+        assert_equal args1, call.args
+        assert_equal value, call.block
+      end
+
+      assert_calls(
+        :assert_changes,
+        when_calling: :changes,
+        on_value: -> {}
+      ) do |value, call|
+        assert_equal args1, call.args
+        assert_equal value, call.block
+      end
+
+      assert_calls(
+        :assert_not_changes,
+        when_calling: :does_not_change,
         on_value: -> {}
       ) do |value, call|
         assert_equal args1, call.args

--- a/test/unit/actual_value_tests.rb
+++ b/test/unit/actual_value_tests.rb
@@ -24,6 +24,7 @@ class Assert::ActualValue
     should have_imeths :is_instance_of, :is_not_instance_of
     should have_imeths :responds_to, :does_not_respond_to
     should have_imeths :is_the_same_as, :is_not_the_same_as
+    should have_imeths :is, :is_not
     should have_imeths :equals, :does_not_equal
     should have_imeths :is_equal_to, :is_not_equal_to
     should have_imeths :matches, :does_not_match
@@ -167,8 +168,24 @@ class Assert::ActualValue
       end
 
       assert_calls(
+        :assert_same,
+        when_calling: [:is, "something"],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal ["something", value, *args1], call.args
+      end
+
+      assert_calls(
         :assert_not_same,
         when_calling: [:is_not_the_same_as, "something"],
+        on_value: actual_value1
+      ) do |value, call|
+        assert_equal ["something", value, *args1], call.args
+      end
+
+      assert_calls(
+        :assert_not_same,
+        when_calling: [:is_not, "something"],
         on_value: actual_value1
       ) do |value, call|
         assert_equal ["something", value, *args1], call.args

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -19,9 +19,9 @@ module Assert
     end
 
     should "map its view, suite and runner to its config" do
-      assert_that(subject.view).is_the_same_as(subject.config.view)
-      assert_that(subject.suite).is_the_same_as(subject.config.suite)
-      assert_that(subject.runner).is_the_same_as(subject.config.runner)
+      assert_that(subject.view).is(subject.config.view)
+      assert_that(subject.suite).is(subject.config.suite)
+      assert_that(subject.runner).is(subject.config.runner)
     end
 
     # Note: don't really need to explicitly test the configure method as
@@ -29,18 +29,6 @@ module Assert
   end
 
   class StubTests < UnitTests
-    # setup do
-    #   orig_value1 = Factory.string
-    #   stub_value1 = Factory.string
-
-    #   @myclass =
-    #   Class.new do
-    #     def initialize(value); @value = value; end
-    #     def mymeth; @value; end
-    #   end
-    #   object1 = @myclass.new(orig_value1)
-    # end
-
     let(:class1) {
       Class.new do
         def initialize(value); @value = value; end
@@ -71,7 +59,7 @@ module Assert
     should "lookup stubs that have been called before" do
       stub1 = Assert.stub(object1, :mymeth)
       stub2 = Assert.stub(object1, :mymeth)
-      assert_that(stub2).is_the_same_as(stub1)
+      assert_that(stub2).is(stub1)
     end
 
     should "set the stub's do block if given a block" do

--- a/test/unit/assert_tests.rb
+++ b/test/unit/assert_tests.rb
@@ -64,7 +64,7 @@ module Assert
 
     should "set the stub's do block if given a block" do
       Assert.stub(object1, :mymeth)
-      assert_that(-> { object1.mymeth }).raises(MuchStub::NotStubbedError)
+      assert_that { object1.mymeth }.raises(MuchStub::NotStubbedError)
       Assert.stub(object1, :mymeth){ stub_value1 }
       assert_that(object1.mymeth).equals(stub_value1)
     end
@@ -109,8 +109,9 @@ module Assert
 
     should "be able to call a stub's original method" do
       err =
-        assert_that(-> { Assert.stub_send(object1, :mymeth) }).
-          raises(MuchStub::NotStubbedError)
+        assert_that {
+          Assert.stub_send(object1, :mymeth)
+        }.raises(MuchStub::NotStubbedError)
       assert_that(err.message).includes("not stubbed.")
       assert_that(err.backtrace.first).includes("test/unit/assert_tests.rb")
 

--- a/test/unit/assertions/assert_changes_tests.rb
+++ b/test/unit/assertions/assert_changes_tests.rb
@@ -1,0 +1,97 @@
+require "assert"
+require "assert/assertions"
+
+module Assert::Assertions
+  class AssertChangesTests < Assert::Context
+    include Assert::Test::TestHelpers
+
+    desc "`assert_changes`"
+    subject {
+      desc = desc1
+      Factory.test do
+        @my_var = 1
+        assert_changes("@my_var", from: 1, to: 2) { @my_var = 2 } # pass
+        @my_var = 1
+        assert_changes("@my_var", from: 1) { @my_var = 2 }        # pass
+        @my_var = 1
+        assert_changes("@my_var", to: 2) { @my_var = 2 }          # pass
+        @my_var = 1
+        assert_changes("@my_var", desc: desc) { @my_var = 2 }     # pass
+
+        @my_var = 1
+        assert_changes("@my_var", from: 2, to: 1) { @my_var = 2 } # fail
+        @my_var = 1
+        assert_changes("@my_var", from: 2) { @my_var = 2 }        # fail
+        @my_var = 1
+        assert_changes("@my_var", to: 1) { @my_var = 2 }          # fail
+        @my_var = 1
+        assert_changes("@my_var", desc: desc) { @my_var = 1 }     # fail
+      end
+    }
+
+    let(:desc1) { "assert changes fail desc" }
+
+    should "produce results as expected" do
+      subject.run(&test_run_callback)
+
+      assert_that(test_run_result_count).equals(10)
+      assert_that(test_run_result_count(:pass)).equals(5)
+      assert_that(test_run_result_count(:fail)).equals(5)
+
+      exp =
+        [
+          "Expected `@my_var` to change from `2`",
+          "Expected `@my_var` to change to `1`",
+          "Expected `@my_var` to change from `2`",
+          "Expected `@my_var` to change to `1`",
+          "#{desc1}\nExpected `@my_var` to change; "\
+          "it was `1` and didn't change",
+        ]
+      messages = test_run_results(:fail).map(&:message)
+      messages.each_with_index{ |msg, n| assert_that(msg).matches(/^#{exp[n]}/) }
+    end
+  end
+
+  class AssertNotChangesTests < Assert::Context
+    include Assert::Test::TestHelpers
+
+    desc "`assert_changes`"
+    subject {
+      desc = desc1
+      Factory.test do
+        @my_var = 1
+        assert_not_changes("@my_var", from: 1) { @my_var = 1 }    # pass
+        @my_var = 1
+        assert_not_changes("@my_var", desc: desc) { @my_var = 1 } # pass
+
+        @my_var = 1
+        assert_not_changes("@my_var", from: 2) { @my_var = 1 }    # fail
+        @my_var = 1
+        assert_not_changes("@my_var", from: 1) { @my_var = 2 }    # fail
+        @my_var = 1
+        assert_not_changes("@my_var", desc: desc) { @my_var = 2 } # fail
+      end
+    }
+
+    let(:desc1) { "assert not changes fail desc" }
+
+    should "produce results as expected" do
+      subject.run(&test_run_callback)
+
+      assert_that(test_run_result_count).equals(8)
+      assert_that(test_run_result_count(:pass)).equals(5)
+      assert_that(test_run_result_count(:fail)).equals(3)
+
+      exp =
+        [
+          "Expected `@my_var` to not change from `2`",
+          "Expected `@my_var` to not change; "\
+          "it was `1` and changed to `2`",
+          "#{desc1}\nExpected `@my_var` to not change; "\
+          "it was `1` and changed to `2`",
+        ]
+      messages = test_run_results(:fail).map(&:message)
+      messages.each_with_index{ |msg, n| assert_that(msg).matches(/^#{exp[n]}/) }
+    end
+  end
+end

--- a/test/unit/assertions/assert_equal_tests.rb
+++ b/test/unit/assertions/assert_equal_tests.rb
@@ -69,8 +69,28 @@ module Assert::Assertions
 
     desc "with objects that define custom equality operators"
 
-    let(:is_class)     { Class.new do; def ==(other); true;  end; end }
-    let(:is_not_class) { Class.new do; def ==(other); false; end; end }
+    let(:is_class)     {
+      Class.new do
+        def ==(other)
+          if other.is_a?(Assert::ActualValue.not_given.class)
+            super
+          else
+            true
+          end
+        end
+      end
+    }
+    let(:is_not_class) {
+      Class.new do
+        def ==(other)
+          if other.is_a?(Assert::ActualValue.not_given.class)
+            super
+          else
+            false
+          end
+        end
+      end
+    }
 
     let(:is1) { is_class.new }
     let(:is_not1) { is_not_class.new }

--- a/test/unit/assertions/assert_raises_tests.rb
+++ b/test/unit/assertions/assert_raises_tests.rb
@@ -27,10 +27,11 @@ module Assert::Assertions
       assert_that(test_run_result_count(:fail)).equals(4)
 
       exp =
-        [ "#{desc1}\nStandardError or RuntimeError exception expected, not:",
+        [
+          "#{desc1}\nStandardError or RuntimeError exception expected, not:",
           "#{desc1}\nRuntimeError exception expected, not:",
           "#{desc1}\nRuntimeError exception expected but nothing raised.",
-          "#{desc1}\nAn exception expected but nothing raised."
+          "#{desc1}\nAn exception expected but nothing raised.",
         ]
       messages = test_run_results(:fail).map(&:message)
       messages.each_with_index{ |msg, n| assert_that(msg).matches(/^#{exp[n]}/) }
@@ -81,8 +82,9 @@ module Assert::Assertions
       assert_that(test_run_result_count(:fail)).equals(2)
 
       exp =
-        [ "#{desc1}\nStandardError or RuntimeError exception not expected, but raised:",
-          "#{desc1}\nAn exception not expected, but raised:"
+        [
+          "#{desc1}\nStandardError or RuntimeError exception not expected, but raised:",
+          "#{desc1}\nAn exception not expected, but raised:",
         ]
       messages = test_run_results(:fail).map(&:message)
       messages.each_with_index{ |msg, n| assert_that(msg).matches(/^#{exp[n]}/) }

--- a/test/unit/assertions_tests.rb
+++ b/test/unit/assertions_tests.rb
@@ -12,24 +12,25 @@ module Assert::Assertions
     let(:test1) { Factory.test }
 
     should have_imeths :assert_block, :assert_not_block, :refute_block
+    should have_imeths :assert_empty, :assert_not_empty, :refute_empty
+    should have_imeths :assert_equal, :assert_not_equal, :refute_equal
+    should have_imeths :assert_file_exists, :assert_not_file_exists, :refute_file_exists
+    should have_imeths :assert_includes, :assert_not_includes
+    should have_imeths :assert_included, :assert_not_included
+    should have_imeths :refute_includes, :refute_included
+    should have_imeths :assert_instance_of, :assert_not_instance_of, :refute_instance_of
+    should have_imeths :assert_kind_of, :assert_not_kind_of, :refute_kind_of
+    should have_imeths :assert_match, :assert_not_match, :assert_no_match, :refute_match
+    should have_imeths :assert_nil, :assert_not_nil, :refute_nil
+    should have_imeths :assert_true, :assert_not_true, :refute_true
+    should have_imeths :assert_false, :assert_not_false, :refute_false
     should have_imeths :assert_raises, :assert_not_raises
     should have_imeths :assert_raise, :assert_not_raise, :assert_nothing_raised
-    should have_imeths :assert_kind_of, :assert_not_kind_of, :refute_kind_of
-    should have_imeths :assert_instance_of, :assert_not_instance_of, :refute_instance_of
+    should have_imeths :assert_changes, :assert_not_changes, :refute_changes
     should have_imeths :assert_respond_to, :assert_responds_to
     should have_imeths :assert_not_respond_to, :assert_not_responds_to
     should have_imeths :refute_respond_to, :refute_responds_to
     should have_imeths :assert_same, :assert_not_same, :refute_same
-    should have_imeths :assert_equal, :assert_not_equal, :refute_equal
-    should have_imeths :assert_match, :assert_not_match, :assert_no_match, :refute_match
-    should have_imeths :assert_empty, :assert_not_empty, :refute_empty
-    should have_imeths :assert_includes, :assert_not_includes
-    should have_imeths :assert_included, :assert_not_included
-    should have_imeths :refute_includes, :refute_included
-    should have_imeths :assert_nil, :assert_not_nil, :refute_nil
-    should have_imeths :assert_true, :assert_not_true, :refute_true
-    should have_imeths :assert_false, :assert_not_false, :refute_false
-    should have_imeths :assert_file_exists, :assert_not_file_exists, :refute_file_exists
   end
 
   class IgnoredTests < UnitTests

--- a/test/unit/config_helpers_tests.rb
+++ b/test/unit/config_helpers_tests.rb
@@ -49,10 +49,10 @@ module Assert::ConfigHelpers
     end
 
     should "know if it is in single test mode" do
-      Assert.stub(subject.config, :single_test?){ true }
+      Assert.stub(subject.config, :single_test?) { true }
       assert_that(subject.single_test?).is_true
 
-      Assert.stub(subject.config, :single_test?){ false }
+      Assert.stub(subject.config, :single_test?) { false }
       assert_that(subject.single_test?).is_false
     end
 

--- a/test/unit/context/test_dsl_tests.rb
+++ b/test/unit/context/test_dsl_tests.rb
@@ -124,8 +124,9 @@ module Assert::Context::TestDSL
       context, test = build_eval_context{ test_eventually(m) }
 
       assert_that(context.class.suite.tests_to_run_count).equals(1)
-      assert_that(-> { context.instance_eval(&test.code) }).
-        raises(Assert::Result::TestSkipped)
+      assert_that {
+        context.instance_eval(&test.code)
+      }.raises(Assert::Result::TestSkipped)
     end
 
     should "build a test that skips from a macro using `should_eventually`" do
@@ -134,8 +135,9 @@ module Assert::Context::TestDSL
       context, test = build_eval_context{ should_eventually(m) }
 
       assert_that(context.class.suite.tests_to_run_count).equals(1)
-      assert_that(-> { context.instance_eval(&test.code) }).
-        raises(Assert::Result::TestSkipped)
+      assert_that {
+        context.instance_eval(&test.code)
+      }.raises(Assert::Result::TestSkipped)
     end
 
     private

--- a/test/unit/macro_tests.rb
+++ b/test/unit/macro_tests.rb
@@ -31,7 +31,7 @@ class Assert::Macro
     end
 
     should "complain if you create a macro without a block" do
-      assert_that(-> { unit_class.new }).raises(ArgumentError)
+      assert_that { unit_class.new }.raises(ArgumentError)
     end
   end
 

--- a/test/unit/result_tests.rb
+++ b/test/unit/result_tests.rb
@@ -302,7 +302,7 @@ module Assert::Result
     end
 
     should "not allow creating for a test with non-TestFailure exceptions" do
-      assert_that(-> { Fail.for_test(test1, RuntimeError.new) }).raises(ArgumentError)
+      assert_that { Fail.for_test(test1, RuntimeError.new) }.raises(ArgumentError)
     end
   end
 
@@ -348,7 +348,7 @@ module Assert::Result
     end
 
     should "not allow creating for a test with non-TestSkipped exceptions" do
-      assert_that(-> { Skip.for_test(test1, RuntimeError.new) }).raises(ArgumentError)
+      assert_that { Skip.for_test(test1, RuntimeError.new) }.raises(ArgumentError)
     end
   end
 
@@ -375,7 +375,7 @@ module Assert::Result
     end
 
     should "not allow creating for a test without an exception" do
-      assert_that(-> { Error.for_test(test1, Factory.string) }).raises(ArgumentError)
+      assert_that { Error.for_test(test1, Factory.string) }.raises(ArgumentError)
     end
   end
 

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -15,11 +15,6 @@ class Assert::Suite
     should "include the config helpers" do
       assert_that(subject).includes(Assert::ConfigHelpers)
     end
-
-    should "know its test method regex" do
-      assert_that(subject::TEST_METHOD_REGEX).matches("test#{Factory.string}")
-      assert_that(subject::TEST_METHOD_REGEX).does_not_match("#{Factory.string}test")
-    end
   end
 
   class InitTests < UnitTests
@@ -28,7 +23,7 @@ class Assert::Suite
 
     let(:config1) { Factory.modes_off_config }
 
-    should have_readers :config, :test_methods, :setups, :teardowns
+    should have_readers :config, :setups, :teardowns
     should have_accessors :start_time, :end_time
     should have_imeths :suite, :setup, :startup, :teardown, :shutdown
     should have_imeths :tests_to_run?, :tests_to_run_count, :clear_tests_to_run
@@ -46,7 +41,6 @@ class Assert::Suite
     end
 
     should "default its attrs" do
-      assert_that(subject.test_methods).equals([])
       assert_that(subject.setups).equals([])
       assert_that(subject.teardowns).equals([])
 

--- a/test/unit/suite_tests.rb
+++ b/test/unit/suite_tests.rb
@@ -128,14 +128,14 @@ class Assert::Suite
 
     should "find a test to run given a file line" do
       test = tests1.sample
-      assert_that(subject.find_test_to_run(test.file_line)).is_the_same_as(test)
+      assert_that(subject.find_test_to_run(test.file_line)).is(test)
     end
 
     should "know its sorted tests to run" do
       sorted_tests = subject.sorted_tests_to_run{ 1 }
       assert_that(sorted_tests.size).equals(tests1.size)
       assert_that(sorted_tests.first).is_kind_of(Assert::Test)
-      assert_that(subject.sorted_tests_to_run{ 1 }.first).is_the_same_as(sorted_tests.first)
+      assert_that(subject.sorted_tests_to_run{ 1 }.first).is(sorted_tests.first)
     end
   end
 end

--- a/test/unit/test_tests.rb
+++ b/test/unit/test_tests.rb
@@ -293,21 +293,21 @@ class Assert::Test
         raise SignalException, "USR1"
       end
 
-      assert_that(-> { test.run }).raises(SignalException)
+      assert_that { test.run }.raises(SignalException)
     end
 
     should "raises signal exceptions in the context setup" do
       test = Factory.test("setup signal test", context_info1){ }
       test.context_class.setup{ raise SignalException, "INT" }
 
-      assert_that(-> { test.run }).raises(SignalException)
+      assert_that { test.run }.raises(SignalException)
     end
 
     should "raises signal exceptions in the context teardown" do
       test = Factory.test("teardown signal test", context_info1){ }
       test.context_class.teardown{ raise SignalException, "TERM" }
 
-      assert_that(-> { test.run }).raises(SignalException)
+      assert_that { test.run }.raises(SignalException)
     end
   end
 

--- a/test/unit/test_tests.rb
+++ b/test/unit/test_tests.rb
@@ -17,7 +17,7 @@ class Assert::Test
     let(:config1)        { Factory.modes_off_config }
     let(:test_code1)     { proc { assert(true) } }
 
-    should have_imeths :name_file_line_context_data, :for_block, :for_method
+    should have_imeths :name_file_line_context_data, :for_block
 
     should "know how to build the name and file line given context" do
       test_name = Factory.string
@@ -43,28 +43,6 @@ class Assert::Test
       assert_that(test.context_info).equals(context_info1)
       assert_that(test.config).equals(config1)
       assert_that(test.code).equals(test_code1)
-    end
-
-    should "build tests for a method" do
-      meth = "a_test_method"
-      test = subject.for_method(meth, context_info1, config1)
-
-      exp = Assert::FileLine.parse(context_info1.called_from)
-      assert_that(test.file_line).equals(exp)
-
-      exp = context_info1.test_name(meth)
-      assert_that(test.name).equals(exp)
-
-      assert_that(test.context_info).equals(context_info1)
-      assert_that(test.config).equals(config1)
-
-      assert_that(test.code).is_kind_of(Proc)
-      self.instance_eval(&test.code)
-      assert_that(@a_test_method_called).is_true
-    end
-
-    def a_test_method
-      @a_test_method_called = true
     end
   end
 


### PR DESCRIPTION
### remove support of Test::Unit style test methods, e.g. `def test_whatever`

This addresses Issue #244.

This was originally added, many years ago, to maintain backwards
compatibility with Test::Unit tests. This is no longer desired so
we are removing the legacy code.

### add `.is` and `.is_not` actual value assertion methods

This addresses Issue #302. These are just shorter aliases for
`.is{not_}_the_same_as` that are less to type.

### add `assert_changes`, `.changes` assertion helpers

This closes Issue #301.

This is an assertion helper to test before/after states of
a bit of code.

### allow passing a block to `assert_that`

This addresses Issue #300.

This is a more convenient/standard way to get actual values that
should be procs. You can still manually pass a proc in as a
proc actual value OR you can use the block slot to pass in a proc
actual value implicitly.

This also added `Assert::ActualValue.not_given` to use to know
whether a non-block-slot actual value was given or not. I can't do
`nil` or "truthy" checks as these actual values could be anything.
Using the "not given" pattern ensures this will work with any
value.
