### PR TITLE
bring in much-not-given; use to implement Assert::ActualValue.not_given

### DIFF
--- a/assert.gemspec
+++ b/assert.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = "~> 2.5"
 
-  gem.add_dependency("much-factory", ["~> 0.1.0"])
-  gem.add_dependency("much-stub",    ["~> 0.1.4"])
+  gem.add_dependency("much-factory",   ["~> 0.1.0"])
+  gem.add_dependency("much-not-given", ["~> 0.1.0"])
+  gem.add_dependency("much-stub",      ["~> 0.1.4"])
 end

--- a/lib/assert/actual_value.rb
+++ b/lib/assert/actual_value.rb
@@ -1,43 +1,9 @@
+require "much-not-given"
 require "much-stub"
 
 module Assert; end
 class Assert::ActualValue
-  def self.not_given
-    @not_given ||=
-      Class.new {
-        def to_s
-          "Assert::ActualValue.not_given"
-        end
-
-        def blank?
-          true
-        end
-
-        def present?
-          false
-        end
-
-        def ==(other)
-          if other.is_a?(self.class)
-            true
-          else
-            super
-          end
-        end
-
-        def inspect
-          to_s
-        end
-      }.new
-  end
-
-  def self.not_given?(value)
-    value == not_given
-  end
-
-  def self.given?(value)
-    value != not_given
-  end
+  include MuchNotGiven
 
   def initialize(value = self.class.not_given, context:, &value_block)
     @value = self.class.given?(value) ? value : value_block


### PR DESCRIPTION
The pattern was extracted into a special-purpose gem so it can be
used in other apps/gems. This switches to using the extraction.

See https://github.com/redding/much-not-given/pull/1 for reference.